### PR TITLE
[PW_SID:696626] [BlueZ] tools: Use portable 64 bit data formats

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/tools/isotest.c
+++ b/tools/isotest.c
@@ -30,6 +30,7 @@
 #include <sys/uio.h>
 #include <linux/sockios.h>
 #include <time.h>
+#include <inttypes.h>
 
 #include "lib/bluetooth.h"
 #include "lib/hci.h"
@@ -589,12 +590,12 @@ static void send_wait(struct timespec *t_start, uint32_t us)
 	delta_us = us - TS_USEC(&t_diff);
 
 	if (delta_us < 0) {
-		syslog(LOG_INFO, "Send is behind: %zd us", delta_us);
+		syslog(LOG_INFO, "Send is behind: %" PRId64 " us", delta_us);
 		delta_us = 1000;
 	}
 
 	if (!quiet)
-		syslog(LOG_INFO, "Waiting (%zd us)...", delta_us);
+		syslog(LOG_INFO, "Waiting (%" PRId64 " us)...", delta_us);
 
 	usleep(delta_us);
 


### PR DESCRIPTION
The isotest executable was using the non-portable %zd string formatter
for loging 64 bit integers. This replaces them with PRId64.
---
 tools/isotest.c | 5 +++--
 1 file changed, 3 insertions(+), 2 deletions(-)