### PR TITLE
[PW_SID:696767] [BlueZ] main.conf: Add SecureConnections option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/src/adapter.c
+++ b/src/adapter.c
@@ -10146,7 +10146,7 @@ static void read_info_complete(uint8_t status, uint16_t length,
 	}
 
 	if (missing_settings & MGMT_SETTING_SECURE_CONN)
-		set_mode(adapter, MGMT_OP_SET_SECURE_CONN, 0x01);
+		set_mode(adapter, MGMT_OP_SET_SECURE_CONN, btd_opts.secure_conn);
 
 	if (adapter->supported_settings & MGMT_SETTING_PRIVACY)
 		set_privacy(adapter, btd_opts.privacy);

--- a/src/btd.h
+++ b/src/btd.h
@@ -36,6 +36,12 @@ enum mps_mode_t {
 	MPS_MULTIPLE,
 };
 
+enum sc_mode_t {
+	SC_OFF,
+	SC_ON,
+	SC_ONLY,
+};
+
 struct btd_br_defaults {
 	uint16_t	page_scan_type;
 	uint16_t	page_scan_interval;
@@ -105,6 +111,7 @@ struct btd_opts {
 	uint8_t		privacy;
 	bool		device_privacy;
 	uint32_t	name_request_retry_delay;
+	uint8_t		secure_conn;
 
 	struct btd_defaults defaults;
 

--- a/src/main.c
+++ b/src/main.c
@@ -80,6 +80,7 @@ static const char *supported_options[] = {
 	"MaxControllers"
 	"MultiProfile",
 	"FastConnectable",
+	"SecureConnections",
 	"Privacy",
 	"JustWorksRepairing",
 	"TemporaryTimeout",
@@ -881,6 +882,19 @@ static void parse_config(GKeyFile *config)
 		btd_opts.name_request_retry_delay = val;
 	}
 
+	str = g_key_file_get_string(config, "General",
+						"SecureConnections", &err);
+	if (err)
+		g_clear_error(&err);
+	else {
+		if (!strcmp(str, "off"))
+			btd_opts.secure_conn = SC_OFF;
+		else if (!strcmp(str, "on"))
+			btd_opts.secure_conn = SC_ON;
+		else if (!strcmp(str, "only"))
+			btd_opts.secure_conn = SC_ONLY;
+	}
+
 	str = g_key_file_get_string(config, "GATT", "Cache", &err);
 	if (err) {
 		DBG("%s", err->message);
@@ -993,6 +1007,7 @@ static void init_defaults(void)
 	btd_opts.debug_keys = FALSE;
 	btd_opts.refresh_discovery = TRUE;
 	btd_opts.name_request_retry_delay = DEFAULT_NAME_REQUEST_RETRY_DELAY;
+	btd_opts.secure_conn = SC_ON;
 
 	btd_opts.defaults.num_entries = 0;
 	btd_opts.defaults.br.page_scan_type = 0xFFFF;

--- a/src/main.conf
+++ b/src/main.conf
@@ -111,6 +111,17 @@
 # profile is connected. Defaults to true.
 #RefreshDiscovery = true
 
+# Default Secure Connections setting.
+# Enables the Secure Connections setting for adapters that support it. It
+# provides better crypto algorithms for BT links and also enables CTKD (cross
+# transport key derivation) during pairing on any link.
+# Possible values: "off", "on", "only"
+# - "off": Secure Connections are disabled
+# - "on": Secure Connections are enabled when peer device supports them
+# - "only": we allow only Secure Connections
+# Defaults to "on"
+#SecureConnections = on
+
 # Enables D-Bus experimental interfaces
 # Possible values: true or false
 #Experimental = false


### PR DESCRIPTION
This introduces SecureConnections option to main.conf that can be used to
configure this on adapter initialization.

This is useful for:
- disable for adapters that have a problems with SecureConnections enabled
- if you want to disable CTKD (cross transport key derivation)
- add option to enable only SecureConnections
---
 src/adapter.c |  2 +-
 src/btd.h     |  7 +++++++
 src/main.c    | 15 +++++++++++++++
 src/main.conf | 11 +++++++++++
 4 files changed, 34 insertions(+), 1 deletion(-)