### PR TITLE
[PW_SID:717858] [BlueZ] media: set default value for BAP endpoint Vendor field

### DIFF
--- a/profiles/audio/media.c
+++ b/profiles/audio/media.c
@@ -2546,7 +2546,7 @@ static void app_register_endpoint(void *data, void *user_data)
 	const char *uuid;
 	gboolean delay_reporting = FALSE;
 	uint8_t codec;
-	struct vendor vendor;
+	struct vendor vendor = { 0 };
 	struct bt_bap_pac_qos qos;
 	uint8_t *capabilities = NULL;
 	int size = 0;


### PR DESCRIPTION
The "Vendor" field is optional, and should have an initialized valid
default value.
---
 profiles/audio/media.c | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)