### PR TITLE
[PW_SID:718927] [BlueZ] shared/bap: fix crash unregistering media endpoint while streaming

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/src/shared/bap.c
+++ b/src/shared/bap.c
@@ -2479,8 +2479,11 @@ static void remove_streams(void *data, void *user_data)
 
 	stream = queue_remove_if(bap->streams, match_stream_lpac, pac);
 	if (stream) {
+		bool client = stream->client;
+
 		bt_bap_stream_release(stream, NULL, NULL);
-		stream_set_state(stream, BT_BAP_STREAM_STATE_IDLE);
+		if (client)
+			stream_set_state(stream, BT_BAP_STREAM_STATE_IDLE);
 	}
 }
 


### PR DESCRIPTION
The following ASAN crash is observed when media endpoint is unregistered
(stopping sound server) while streaming from remote BAP client:

ERROR: AddressSanitizer: heap-use-after-free on address 0x60b0000474d8
READ of size 8 at 0x60b0000474d8 thread T0
    #0 0x7a27c6 in stream_set_state src/shared/bap.c:1227
    #1 0x7aff61 in remove_streams src/shared/bap.c:2483
    #2 0x71d2d0 in queue_foreach src/shared/queue.c:207
    #3 0x7b0152 in bt_bap_remove_pac src/shared/bap.c:2501
    #4 0x463cda in media_endpoint_destroy profiles/audio/media.c:179
    ...
0x60b0000474d8 is located 8 bytes inside of 112-byte region
freed by thread T0 here:
    #0 0x7f93b12b9388 in __interceptor_free.part.0 (/lib64/libasan.so.8+0xb9388)
    #1 0x7a0504 in bap_stream_free src/shared/bap.c:972
    #2 0x7a0800 in bap_stream_detach src/shared/bap.c:989
    #3 0x7a26d1 in bap_stream_state_changed src/shared/bap.c:1208
    #4 0x7a2ab4 in stream_set_state src/shared/bap.c:1252
    #5 0x7ab18a in stream_release src/shared/bap.c:1985
    #6 0x7c6919 in bt_bap_stream_release src/shared/bap.c:4572
    #7 0x7aff50 in remove_streams src/shared/bap.c:2482
    ...
previously allocated by thread T0 here:
    #0 0x7f93b12ba6af in __interceptor_malloc (/lib64/libasan.so.8+0xba6af)
    #1 0x71e9ae in util_malloc src/shared/util.c:43
    #2 0x79c2f5 in bap_stream_new src/shared/bap.c:766
    #3 0x7a4863 in ep_config src/shared/bap.c:1446
    #4 0x7a4f22 in ascs_config src/shared/bap.c:1481
    ...

When stream->client is false, bt_bap_stream_release already sets the
stream to idle and frees it.

Fix the crash by not setting the state to idle for the second time,
in this case.
---

Notes:
    Crash seen when testing BlueZ at commit 67395a3b357d.

 src/shared/bap.c | 5 ++++-
 1 file changed, 4 insertions(+), 1 deletion(-)