### PR TITLE
[PW_SID:721100] [BlueZ] shared/bap: wait for GATT client ready before ASCS/PACS discovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+


### PR DESCRIPTION
BAP client fails to find endpoints if GATT services are not resolved
when the GATT client is attached to the session.  This condition
almost always occurs on the first BAP connection to a device between
bluetoothd restarts, and may occur also otherwise.

The BAP client code discovers ASCS/PACS services and characteristics at
client attach time.

Fix the connection issue by postponing PAC/ASE discovery until the
GATT client is ready, if it was not ready at attach time.
---

Notes:
    Typical bluetoothctl output in the failing case, without this patch:
    
    $ sudo systemctl restart bluetooth
    $ bluetoothctl
    ...
    [bluetooth]# connect XX:XX:XX:XX:XX:XX
    Attempting to connect to XX:XX:XX:XX:XX:XX
    [CHG] Device XX:XX:XX:XX:XX:XX Connected: yes
    [CHG] Device XX:XX:XX:XX:XX:XX UUIDs: 0000184e-0000-1000-8000-00805f9b34fb
    [CHG] Device XX:XX:XX:XX:XX:XX UUIDs: 00001850-0000-1000-8000-00805f9b34fb
    [CHG] Device XX:XX:XX:XX:XX:XX UUIDs: 03b80e5a-ede8-4b33-a751-6ce34ec4c700
    Connection successful
    [NEW] Primary Service (Handle 0x0000)
            /org/bluez/hci0/dev_XX_XX_XX_XX_XX_XX/service0008
            00001801-0000-1000-8000-00805f9b34fb
            Generic Attribute Profile
    ...
    [NEW] Descriptor (Handle 0x0000)
            /org/bluez/hci0/dev_XX_XX_XX_XX_XX_XX/service0065/char0066/desc0069
            00002901-0000-1000-8000-00805f9b34fb
            Characteristic User Description
    [CHG] Device XX:XX:XX:XX:XX:XX UUIDs: 00001800-0000-1000-8000-00805f9b34fb
    [CHG] Device XX:XX:XX:XX:XX:XX UUIDs: 00001801-0000-1000-8000-00805f9b34fb
    [CHG] Device XX:XX:XX:XX:XX:XX UUIDs: 0000180a-0000-1000-8000-00805f9b34fb
    [CHG] Device XX:XX:XX:XX:XX:XX UUIDs: 00001844-0000-1000-8000-00805f9b34fb
    [CHG] Device XX:XX:XX:XX:XX:XX UUIDs: 0000184e-0000-1000-8000-00805f9b34fb
    [CHG] Device XX:XX:XX:XX:XX:XX UUIDs: 00001850-0000-1000-8000-00805f9b34fb
    [CHG] Device XX:XX:XX:XX:XX:XX UUIDs: 03b80e5a-ede8-4b33-a751-6ce34ec4c700
    [CHG] Device XX:XX:XX:XX:XX:XX ServicesResolved: yes
    [CHG] Device XX:XX:XX:XX:XX:XX Paired: yes
    [xxx]# endpoint.list
    [xxx]# disconnect
    Attempting to disconnect from XX:XX:XX:XX:XX:XX
    [CHG] Device XX:XX:XX:XX:XX:XX ServicesResolved: no
    Successful disconnected
    [CHG] Device XX:XX:XX:XX:XX:XX Connected: no
    [bluetooth]# connect XX:XX:XX:XX:XX:XX
    Attempting to connect to XX:XX:XX:XX:XX:XX
    [CHG] Device XX:XX:XX:XX:XX:XX Connected: yes
    Connection successful
    [NEW] Endpoint /org/bluez/hci0/dev_XX_XX_XX_XX_XX_XX/pac_source0
    [NEW] Endpoint /org/bluez/hci0/dev_XX_XX_XX_XX_XX_XX/pac_sink0
    [NEW] Transport /org/bluez/hci0/dev_XX_XX_XX_XX_XX_XX/pac_source0/fd0
    [NEW] Transport /org/bluez/hci0/dev_XX_XX_XX_XX_XX_XX/pac_sink0/fd1
    [CHG] Transport /org/bluez/hci0/dev_XX_XX_XX_XX_XX_XX/pac_source0/fd0 Links: /org/bluez/hci0/dev_XX_XX_XX_XX_XX_XX/pac_sink0/fd1
    [CHG] Transport /org/bluez/hci0/dev_XX_XX_XX_XX_XX_XX/pac_sink0/fd1 Links: /org/bluez/hci0/dev_XX_XX_XX_XX_XX_XX/pac_source0/fd0
    [CHG] Device XX:XX:XX:XX:XX:XX ServicesResolved: yes
    [xxx]# endpoint.list
    Endpoint /org/bluez/hci0/dev_XX_XX_XX_XX_XX_XX/pac_source0
    Endpoint /org/bluez/hci0/dev_XX_XX_XX_XX_XX_XX/pac_sink0
    [xxx]#
    
    Endpoints and transports failed to appear on the first connect to the
    BAP server, since GATT discovery was not yet completed when the BAP code
    tried to discover the endpoints. Second connection succeeded.
    Occasionally, it also happens that endpoints appear but transports do
    not, but this is hard to reproduce.
    
    With this patch:
    
    $ sudo systemctl restart bluetooth
    $ bluetoothctl
    ...
    [bluetooth]# connect XX:XX:XX:XX:XX:XX
    Attempting to connect to XX:XX:XX:XX:XX:XX
    [CHG] Device XX:XX:XX:XX:XX:XX Connected: yes
    [CHG] Device XX:XX:XX:XX:XX:XX UUIDs: 0000184e-0000-1000-8000-00805f9b34fb
    [CHG] Device XX:XX:XX:XX:XX:XX UUIDs: 00001850-0000-1000-8000-00805f9b34fb
    [CHG] Device XX:XX:XX:XX:XX:XX UUIDs: 03b80e5a-ede8-4b33-a751-6ce34ec4c700
    Connection successful
    [NEW] Primary Service (Handle 0x0000)
            /org/bluez/hci0/dev_XX_XX_XX_XX_XX_XX/service0008
            00001801-0000-1000-8000-00805f9b34fb
            Generic Attribute Profile
    ...
    [NEW] Descriptor (Handle 0x0000)
            /org/bluez/hci0/dev_XX_XX_XX_XX_XX_XX/service0065/char0066/desc0069
            00002901-0000-1000-8000-00805f9b34fb
            Characteristic User Description
    [CHG] Device XX:XX:XX:XX:XX:XX ServicesResolved: yes
    [CHG] Device XX:XX:XX:XX:XX:XX Paired: yes
    [NEW] Endpoint /org/bluez/hci0/dev_XX_XX_XX_XX_XX_XX/pac_source0
    [NEW] Endpoint /org/bluez/hci0/dev_XX_XX_XX_XX_XX_XX/pac_sink0
    [NEW] Transport /org/bluez/hci0/dev_XX_XX_XX_XX_XX_XX/pac_source0/fd0
    [NEW] Transport /org/bluez/hci0/dev_XX_XX_XX_XX_XX_XX/pac_sink0/fd1
    [CHG] Transport /org/bluez/hci0/dev_XX_XX_XX_XX_XX_XX/pac_source0/fd0 Links: /org/bluez/hci0/dev_XX_XX_XX_XX_XX_XX/pac_sink0/fd1
    [CHG] Transport /org/bluez/hci0/dev_XX_XX_XX_XX_XX_XX/pac_sink0/fd1 Links: /org/bluez/hci0/dev_XX_XX_XX_XX_XX_XX/pac_source0/fd0
    [xxx]#
    
    Now the first connection works properly.
    
    On first reading, the spec does not seem to clearly comment if ASEs and
    PACs could be removed/added by the server while client is connected. If
    that's allowed, then we'd need some bigger changes here. Regardless,
    waiting for GATT client ready before first scan seems good also in this
    case.

 src/shared/bap.c | 93 +++++++++++++++++++++++++++++++-----------------
 1 file changed, 60 insertions(+), 33 deletions(-)