### PR TITLE
[PW_SID:722269] [BlueZ,v2,1/3] audio/transport: add media_transport_get_stream method for transports

### DIFF
--- a/profiles/audio/media.c
+++ b/profiles/audio/media.c
@@ -1003,6 +1003,12 @@ static void pac_config_cb(struct media_endpoint *endpoint, void *ret, int size,
 {
 	struct pac_config_data *data = user_data;
 	gboolean *ret_value = ret;
+	struct media_transport *transport;
+
+	/* If transport was cleared, configuration was cancelled */
+	transport = find_transport(endpoint, data->stream);
+	if (!transport)
+		return;
 
 	data->cb(data->stream, ret_value ? 0 : -EINVAL);
 }

--- a/profiles/audio/transport.c
+++ b/profiles/audio/transport.c
@@ -116,6 +116,8 @@ struct media_transport {
 								guint id);
 	void			(*set_state) (struct media_transport *transport,
 						transport_state_t state);
+	void			*(*get_stream)
+					(struct media_transport *transport);
 	GDestroyNotify		destroy;
 	void			*data;
 };
@@ -1380,6 +1382,13 @@ static void bap_connecting(struct bt_bap_stream *stream, bool state, int fd,
 	bap_update_links(transport);
 }
 
+static void *get_stream_bap(struct media_transport *transport)
+{
+	struct bap_transport *bap = transport->data;
+
+	return bap->stream;
+}
+
 static void free_bap(void *data)
 {
 	struct bap_transport *bap = data;
@@ -1415,6 +1424,7 @@ static int media_transport_init_bap(struct media_transport *transport,
 	transport->suspend = suspend_bap;
 	transport->cancel = cancel_bap;
 	transport->set_state = set_state_bap;
+	transport->get_stream = get_stream_bap;
 	transport->destroy = free_bap;
 
 	return 0;
@@ -1481,6 +1491,14 @@ fail:
 const char *media_transport_get_path(struct media_transport *transport)
 {
 	return transport->path;
+}
+
+void *media_transport_get_stream(struct media_transport *transport)
+{
+	if (transport->get_stream)
+		return transport->get_stream(transport);
+
+	return NULL;
 }
 
 void media_transport_update_delay(struct media_transport *transport,

--- a/profiles/audio/transport.h
+++ b/profiles/audio/transport.h
@@ -19,6 +19,7 @@ struct media_transport *media_transport_create(struct btd_device *device,
 
 void media_transport_destroy(struct media_transport *transport);
 const char *media_transport_get_path(struct media_transport *transport);
+void *media_transport_get_stream(struct media_transport *transport);
 struct btd_device *media_transport_get_dev(struct media_transport *transport);
 int8_t media_transport_get_volume(struct media_transport *transport);
 void media_transport_update_delay(struct media_transport *transport,


### PR DESCRIPTION
Add a method for getting the audio stream associated with a media
transport.
---

Notes:
    v2: make generic and split out to separate patch

 profiles/audio/transport.c | 18 ++++++++++++++++++
 profiles/audio/transport.h |  1 +
 2 files changed, 19 insertions(+)