### PR TITLE
[PW_SID:723140] [BlueZ] configure: Check ell path

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -289,6 +289,10 @@ if (test "${enable_external_ell}" = "yes"); then
 	AC_SUBST(ELL_CFLAGS)
 	AC_SUBST(ELL_LIBS)
 fi
+if (test "${enable_external_ell}" != "yes"); then
+	AC_CHECK_FILE(../ell, dummy=yes,
+		AC_MSG_ERROR(ELL source is required at ../ell))
+fi
 AM_CONDITIONAL(EXTERNAL_ELL, test "${enable_external_ell}" = "yes" ||
 				(test "${enable_btpclient}" != "yes" &&
 						test "${enable_mesh}" != "yes"))


### PR DESCRIPTION
From: Tedd Ho-Jeong An <tedd.an@intel.com>

If the 'enable-external-ell' is not specified in the configure parameter,
the build system assumes that the ELL source is located same level where
the bluez source is cloned. But the configure doens't check the folder
and user will get the build error while building the source.

This patch checks if the ELL source path if the 'enable-external-ell'
flag is not set and throws an error if the ELL doesn't exist.
---
 configure.ac | 4 ++++
 1 file changed, 4 insertions(+)