### PR TITLE
[PW_SID:724435] [BlueZ] device: wait GATT client ready before service accept() if no cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/src/device.c
+++ b/src/device.c
@@ -5155,10 +5155,11 @@ static void gatt_client_init(struct btd_device *device)
 	g_attrib_attach_client(device->attrib, device->client);
 
 	/*
-	 * Notify notify existing service about the new connection so they can
-	 * react to notifications while discovering services
+	 * If we have cache, notify existing service about the new connection
+	 * so they can react to notifications while discovering services
 	 */
-	device_accept_gatt_profiles(device);
+	if (!gatt_db_isempty(device->db))
+		device_accept_gatt_profiles(device);
 
 	device->gatt_ready_id = bt_gatt_client_ready_register(device->client,
 							gatt_client_ready_cb,


### PR DESCRIPTION
On device ATT attach, do not immediately call accept() for profiles, if
there is no cached data in GATT database. Instead, wait for service
resolution to complete, as likely accept() cannot succeed before that.

Several profiles (bap, vcp, midi, deviceinfo) assume that GATT
attributes are available when their accept() is called, returning
success even if not.  In this case, the services never find the remote
attributes and are not operable.  Other profiles (hog, batt, ...) fail
their accept which prompts core to retry after discovery, and work
correctly also in this case.

Fix the failing services by waiting for service resolution as necessary,
so profiles can assume the GATT DB has some content.
---

Notes:
    This fixes the issue with BAP client being broken when there is no GATT
    cache.
    
    On my setup, btd_settings_gatt_db_load often fails with EIO, even though
    the files are there. Apparently, in some cases the saved cache data is
    not loadable, need to figure out later why it happens.

 src/device.c | 7 ++++---
 1 file changed, 4 insertions(+), 3 deletions(-)