### PR TITLE
[PW_SID:724874] [BlueZ,1/2] bthost: Allow sending ISO packets with sequence number and timestamp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/emulator/bthost.c
+++ b/emulator/bthost.c
@@ -38,6 +38,8 @@
 #define acl_flags(h)		(h >> 12)
 
 #define iso_flags_pb(f)		(f & 0x0003)
+#define iso_flags_ts(f)		((f >> 2) & 0x0001)
+#define iso_flags_pack(pb, ts)	(((pb) & 0x03) | (((ts) & 0x01) << 2))
 #define iso_data_len_pack(h, f)	((uint16_t) ((h) | ((f) << 14)))
 
 #define L2CAP_FEAT_FIXED_CHAN	0x00000080
@@ -728,41 +730,58 @@ void bthost_send_cid_v(struct bthost *bthost, uint16_t handle, uint16_t cid,
 	send_iov(bthost, handle, cid, iov, iovcnt);
 }
 
-static void send_iso(struct bthost *bthost, uint16_t handle,
+static void send_iso(struct bthost *bthost, uint16_t handle, bool ts,
+					uint16_t sn, uint32_t timestamp,
 					const struct iovec *iov, int iovcnt)
 {
 	struct bt_hci_iso_hdr iso_hdr;
 	struct bt_hci_iso_data_start data_hdr;
 	uint8_t pkt = BT_H4_ISO_PKT;
-	struct iovec pdu[3 + iovcnt];
+	struct iovec pdu[4 + iovcnt];
+	uint16_t flags, dlen;
 	int i, len = 0;
-	static uint16_t sn;
 
 	for (i = 0; i < iovcnt; i++) {
-		pdu[3 + i].iov_base = iov[i].iov_base;
-		pdu[3 + i].iov_len = iov[i].iov_len;
+		pdu[4 + i].iov_base = iov[i].iov_base;
+		pdu[4 + i].iov_len = iov[i].iov_len;
 		len += iov[i].iov_len;
 	}
 
 	pdu[0].iov_base = &pkt;
 	pdu[0].iov_len = sizeof(pkt);
 
-	iso_hdr.handle = acl_handle_pack(handle, 0x02);
-	iso_hdr.dlen = cpu_to_le16(len + sizeof(data_hdr));
+	flags = iso_flags_pack(0x02, ts);
+	dlen = len + sizeof(data_hdr);
+	if (ts)
+		dlen += sizeof(timestamp);
+
+	iso_hdr.handle = acl_handle_pack(handle, flags);
+	iso_hdr.dlen = cpu_to_le16(dlen);
 
 	pdu[1].iov_base = &iso_hdr;
 	pdu[1].iov_len = sizeof(iso_hdr);
 
-	data_hdr.sn = cpu_to_le16(sn++);
+	if (ts) {
+		timestamp = cpu_to_le32(timestamp);
+
+		pdu[2].iov_base = &timestamp;
+		pdu[2].iov_len = sizeof(timestamp);
+	} else {
+		pdu[2].iov_base = NULL;
+		pdu[2].iov_len = 0;
+	}
+
+	data_hdr.sn = cpu_to_le16(sn);
 	data_hdr.slen = cpu_to_le16(iso_data_len_pack(len, 0));
 
-	pdu[2].iov_base = &data_hdr;
-	pdu[2].iov_len = sizeof(data_hdr);
+	pdu[3].iov_base = &data_hdr;
+	pdu[3].iov_len = sizeof(data_hdr);
 
-	send_packet(bthost, pdu, 3 + iovcnt);
+	send_packet(bthost, pdu, 4 + iovcnt);
 }
 
-void bthost_send_iso(struct bthost *bthost, uint16_t handle,
+void bthost_send_iso(struct bthost *bthost, uint16_t handle, bool ts,
+					uint16_t sn, uint32_t timestamp,
 					const struct iovec *iov, int iovcnt)
 {
 	struct btconn *conn;
@@ -771,7 +790,7 @@ void bthost_send_iso(struct bthost *bthost, uint16_t handle,
 	if (!conn)
 		return;
 
-	send_iso(bthost, handle, iov, iovcnt);
+	send_iso(bthost, handle, ts, sn, timestamp, iov, iovcnt);
 }
 
 bool bthost_l2cap_req(struct bthost *bthost, uint16_t handle, uint8_t code,

--- a/emulator/bthost.h
+++ b/emulator/bthost.h
@@ -79,7 +79,8 @@ void bthost_send_cid(struct bthost *bthost, uint16_t handle, uint16_t cid,
 					const void *data, uint16_t len);
 void bthost_send_cid_v(struct bthost *bthost, uint16_t handle, uint16_t cid,
 					const struct iovec *iov, int iovcnt);
-void bthost_send_iso(struct bthost *bthost, uint16_t handle,
+void bthost_send_iso(struct bthost *bthost, uint16_t handle, bool ts,
+					uint16_t sn, uint32_t timestamp,
 					const struct iovec *iov, int iovcnt);
 
 typedef void (*bthost_l2cap_rsp_cb) (uint8_t code, const void *data,

--- a/tools/iso-tester.c
+++ b/tools/iso-tester.c
@@ -149,6 +149,7 @@ struct iso_client_data {
 	bool bcast;
 	bool defer;
 	bool disconnect;
+	bool ts;
 };
 
 static void mgmt_debug(const char *str, void *user_data)
@@ -570,6 +571,14 @@ static const struct iso_client_data listen_16_2_1_recv = {
 	.expect_err = 0,
 	.recv = &send_16_2_1,
 	.server = true,
+};
+
+static const struct iso_client_data listen_16_2_1_recv_ts = {
+	.qos = QOS_16_2_1,
+	.expect_err = 0,
+	.recv = &send_16_2_1,
+	.server = true,
+	.ts = true,
 };
 
 static const struct iso_client_data defer_16_2_1 = {
@@ -1157,7 +1166,8 @@ static void iso_recv(struct test_data *data, GIOChannel *io)
 	}
 
 	host = hciemu_client_get_host(data->hciemu);
-	bthost_send_iso(host, data->handle, false, sn++, 0, isodata->recv, 1);
+	bthost_send_iso(host, data->handle, isodata->ts, sn++, 0,
+							isodata->recv, 1);
 
 	data->io_id[0] = g_io_add_watch(io, G_IO_IN, iso_recv_data, data);
 }
@@ -1807,6 +1817,10 @@ int main(int argc, char *argv[])
 							test_connect);
 
 	test_iso("ISO Receive - Success", &listen_16_2_1_recv, setup_powered,
+							test_listen);
+
+	test_iso("ISO Receive Timestamped - Success", &listen_16_2_1_recv_ts,
+							setup_powered,
 							test_listen);
 
 	test_iso("ISO Defer - Success", &defer_16_2_1, setup_powered,

--- a/tools/iso-tester.c
+++ b/tools/iso-tester.c
@@ -1146,6 +1146,7 @@ static void iso_recv(struct test_data *data, GIOChannel *io)
 {
 	const struct iso_client_data *isodata = data->test_data;
 	struct bthost *host;
+	static uint16_t sn;
 
 	tester_print("Receive %zu bytes of data", isodata->recv->iov_len);
 
@@ -1156,7 +1157,7 @@ static void iso_recv(struct test_data *data, GIOChannel *io)
 	}
 
 	host = hciemu_client_get_host(data->hciemu);
-	bthost_send_iso(host, data->handle, isodata->recv, 1);
+	bthost_send_iso(host, data->handle, false, sn++, 0, isodata->recv, 1);
 
 	data->io_id[0] = g_io_add_watch(io, G_IO_IN, iso_recv_data, data);
 }


### PR DESCRIPTION
Change bthost_send_iso to take packet sequence number and timestamp, and
allow it to send timestamped HCI ISO data packets.

Currently, btdev passes through ISO packets, so this can also be used to
test RX timestamping.
---

Notes:
    This series adds a test case for
    
    https://lore.kernel.org/linux-bluetooth/1fd2d4523c139deda93aab2c31f1508d79c32472.1676921889.git.pav@iki.fi/
    
    Here, it seems simplest if btdev simply passes through the timestamps
    and sequence numbers it receives, instead of modifying them.  One side
    of the "connection" generally is bthost, and it is easier for writing
    tests if nothing modifies the values in between.
    
    Also if dummy ISOAL like timestamping is added to the emulator later, we
    can still consider timestamped input packet as the trigger for enabling
    RX timestamping, or add something like
    hciemu_set_central_iso_timestamping(bool).

 emulator/bthost.c  | 45 ++++++++++++++++++++++++++++++++-------------
 emulator/bthost.h  |  3 ++-
 tools/iso-tester.c |  3 ++-
 3 files changed, 36 insertions(+), 15 deletions(-)