### PR TITLE
[PW_SID:725708] obexd: launch obexd directly from dbus service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/obexd/src/org.bluez.obex.service
+++ b/obexd/src/org.bluez.obex.service
@@ -1,4 +1,3 @@
 [D-BUS Service]
 Name=org.bluez.obex
-Exec=/bin/false
-SystemdService=dbus-org.bluez.obex.service
+Exec=/usr/lib/bluetooth/obexd


### PR DESCRIPTION
Whenver obexd is summoned via dbus with the systemdservice file, the
daemon exits with the following error: Failed to start org.bluez.obex service: Process org.bluez.obex exite.
Irregardless of obex.service is enabled and running in the background,
whenver an app calls for obexd via dbus, it seems like it forces to use
the systemdservice, and that for whatever reason doesn't work.

Therefore, I propose instead of having systemd launch obexd, obexd
should be launched directly from the dbus service. Using this patch has
fixed all of my woes described in https://bugs.kde.org/show_bug.cgi?id=464929#c3
, and has worked both on KDE and GNOME. This is my first email patch, so
I look forward to you all's feedback and critical response!
---
 obexd/src/org.bluez.obex.service | 3 +--
 1 file changed, 1 insertion(+), 2 deletions(-)