### PR TITLE
[PW_SID:728452] [BlueZ] mesh: Fix node when loading from storage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/mesh/node.c
+++ b/mesh/node.c
@@ -347,6 +347,7 @@ static bool add_elements_from_storage(struct mesh_node *node,
 					struct mesh_config_node *db_node)
 {
 	const struct l_queue_entry *entry;
+	struct node_element *ele;
 
 	entry = l_queue_get_entries(db_node->elements);
 
@@ -354,14 +355,19 @@ static bool add_elements_from_storage(struct mesh_node *node,
 		if (!add_element_from_storage(node, entry->data))
 			return false;
 
+	ele = l_queue_find(node->elements, match_element_idx,
+						L_UINT_TO_PTR(PRIMARY_ELE_IDX));
+	if (!ele)
+		return false;
+
 	/* Add configuration server model on the primary element */
-	mesh_model_add(node, PRIMARY_ELE_IDX, CONFIG_SRV_MODEL, NULL);
+	mesh_model_add(node, ele->models, CONFIG_SRV_MODEL, NULL);
 
 	/* Add remote provisioning models on the primary element */
-	mesh_model_add(node, PRIMARY_ELE_IDX, REM_PROV_SRV_MODEL, NULL);
+	mesh_model_add(node, ele->models, REM_PROV_SRV_MODEL, NULL);
 
 	if (node->provisioner)
-		mesh_model_add(node, PRIMARY_ELE_IDX, REM_PROV_CLI_MODEL, NULL);
+		mesh_model_add(node, ele->models, REM_PROV_CLI_MODEL, NULL);
 
 	return true;
 }


### PR DESCRIPTION
From: Inga Stotland <inga.stotland@gmail.com>

This fixes adding mandatory models (config server, remote provisioner)
to a node whose configuration is being loaded from storage:
mesh_model_add() was called with a wrong argument.

Was:     mesh_model_add(..., PRIMARY_ELE_IDX, ...);
Correct: mesh_model_add(..., ele->models, ...);
---
 mesh/node.c | 12 +++++++++---
 1 file changed, 9 insertions(+), 3 deletions(-)