### PR TITLE
[PW_SID:729577] [BlueZ] device: Fix crash attempting to read Sets property

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/src/device.c
+++ b/src/device.c
@@ -1659,9 +1659,14 @@ static gboolean dev_property_wake_allowed_exist(
 static void append_set(void *data, void *user_data)
 {
 	struct sirk_info *info = data;
-	const char *path = btd_set_get_path(info->set);
+	const char *path;
 	DBusMessageIter *iter = user_data;
 	DBusMessageIter entry, dict;
+
+	if (!info->set)
+		return;
+
+	path = btd_set_get_path(info->set);
 
 	dbus_message_iter_open_container(iter, DBUS_TYPE_DICT_ENTRY, NULL,
 								&entry);


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

The following set can be observed when a sirk is exists but it is
encrypted leading to info->set to not be set:

Invalid read of size 8
   at 0x1ACDF0: append_set (device.c:1662)
   by 0x1FFEFFF7DF: ???
   by 0x1D4461: queue_foreach (queue.c:207)
   by 0x1AC8DE: dev_property_get_set (device.c:1700)
   by 0x1CF3E2: append_property (object.c:498)
   by 0x1CFA91: append_properties (object.c:527)
   by 0x1CFAFD: append_interface (object.c:542)
   by 0x48D7CEF: g_slist_foreach (gslist.c:887)
   by 0x1CF5A7: append_interfaces (object.c:1104)
   by 0x1CF5A7: append_object (object.c:1119)
   by 0x48D7CEF: g_slist_foreach (gslist.c:887)
   by 0x1CF5D0: append_object (object.c:1122)
   by 0x48D7CEF: g_slist_foreach (gslist.c:887)
 Address 0x8 is not stack'd, malloc'd or (recently) free'd
---
 src/device.c | 7 ++++++-
 1 file changed, 6 insertions(+), 1 deletion(-)