### PR TITLE
[PW_SID:729593] [BlueZ,v2,1/2] mesh: Fix uninitialized memory usage

### DIFF
--- a/mesh/manager.c
+++ b/mesh/manager.c
@@ -709,7 +709,7 @@ static struct l_dbus_message *start_scan_call(struct l_dbus *dbus,
 	req = l_queue_remove_if(scans, by_node_svr, &new_req);
 
 	if (!req)
-		req = l_malloc(sizeof(new_req));
+		req = l_new(struct scan_req, 1);
 
 	if (req->timeout) {
 		l_timeout_remove(req->timeout);

--- a/mesh/mesh-io.c
+++ b/mesh/mesh-io.c
@@ -19,6 +19,7 @@
 #include "src/shared/mgmt.h"
 
 #include "mesh/mesh-defs.h"
+#include "mesh/util.h"
 #include "mesh/mesh-mgmt.h"
 #include "mesh/mesh-io.h"
 #include "mesh/mesh-io-api.h"
@@ -42,7 +43,10 @@ static const struct mesh_io_table table[] = {
 	{MESH_IO_TYPE_UNIT_TEST, &mesh_io_unit},
 };
 
+static uint8_t unprv_filter[] = { MESH_AD_TYPE_BEACON, 0 };
+
 static struct mesh_io *default_io;
+static struct l_timeout *loop_adv_to;
 
 static const struct mesh_io_api *io_api(enum mesh_io_type type)
 {
@@ -183,6 +187,9 @@ bool mesh_io_register_recv_cb(struct mesh_io *io, const uint8_t *filter,
 {
 	struct mesh_io_reg *rx_reg;
 
+	if (io == NULL)
+		io = default_io;
+
 	if (io != default_io)
 		return false;
 
@@ -224,6 +231,44 @@ bool mesh_io_deregister_recv_cb(struct mesh_io *io, const uint8_t *filter,
 	return false;
 }
 
+struct loop_data {
+	uint16_t len;
+	uint8_t data[];
+};
+
+static void loop_foreach(void *data, void *user_data)
+{
+	struct mesh_io_reg *rx_reg = data;
+	struct loop_data *rx = user_data;
+
+	if (!memcmp(rx_reg->filter, unprv_filter, sizeof(unprv_filter)))
+		rx_reg->cb(rx_reg->user_data, NULL, rx->data, rx->len);
+}
+
+static void loop_rx(struct l_timeout *timeout, void *user_data)
+{
+	struct loop_data *rx = user_data;
+
+	l_queue_foreach(default_io->rx_regs, loop_foreach, rx);
+	l_timeout_modify_ms(loop_adv_to, 500);
+}
+
+static void loop_destroy(void *user_data)
+{
+	l_debug("Free Looped Unprov Beacon");
+	l_free(user_data);
+}
+
+static void loop_unprv_beacon(const uint8_t *data, uint16_t len)
+{
+	struct loop_data *pkt = l_malloc(len + sizeof(struct loop_data));
+
+	memcpy(pkt->data, data, len);
+	pkt->len = len;
+	l_timeout_remove(loop_adv_to);
+	loop_adv_to = l_timeout_create_ms(500, loop_rx, pkt, loop_destroy);
+}
+
 bool mesh_io_send(struct mesh_io *io, struct mesh_io_send_info *info,
 					const uint8_t *data, uint16_t len)
 {
@@ -232,6 +277,9 @@ bool mesh_io_send(struct mesh_io *io, struct mesh_io_send_info *info,
 
 	if (!io)
 		io = default_io;
+
+	if (!memcmp(data, unprv_filter, 2))
+		loop_unprv_beacon(data, len);
 
 	if (io && io->api && io->api->send)
 		return io->api->send(io, info, data, len);
@@ -247,6 +295,12 @@ bool mesh_io_send_cancel(struct mesh_io *io, const uint8_t *pattern,
 
 	if (!io)
 		io = default_io;
+
+	if (loop_adv_to && len >= 2 && pattern[0] == MESH_AD_TYPE_BEACON &&
+							pattern[1] == 0) {
+		l_timeout_remove(loop_adv_to);
+		loop_adv_to = NULL;
+	}
 
 	if (io && io->api && io->api->cancel)
 		return io->api->cancel(io, pattern, len);


### PR DESCRIPTION
When attempting to cancel an unknown Scan request structure must be
NULL initialized.
---
 mesh/manager.c | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)