### PR TITLE
[PW_SID:729652] [BlueZ,1/4] shared/bap: Fix not unregistering idle callback on detach

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/src/shared/bap.c
+++ b/src/shared/bap.c
@@ -3818,6 +3818,8 @@ void bt_bap_detach(struct bt_bap *bap)
 		bap->req = NULL;
 	}
 
+	bt_gatt_client_idle_unregister(bap->client, bap->idle_id);
+
 	/* Cancel queued requests */
 	queue_remove_all(bap->reqs, NULL, NULL, bap_req_detach);
 

--- a/src/shared/csip.c
+++ b/src/shared/csip.c
@@ -810,6 +810,9 @@ bool bt_csip_get_sirk(struct bt_csip *csip, uint8_t *type,
 	if (!csis)
 		return false;
 
+	if (!csis->sirk_val)
+		return false;
+
 	if (type)
 		*type = csis->sirk_val->type;
 

--- a/src/shared/csip.c
+++ b/src/shared/csip.c
@@ -122,6 +122,8 @@ void bt_csip_detach(struct bt_csip *csip)
 	if (!queue_remove(sessions, csip))
 		return;
 
+	bt_gatt_client_idle_unregister(csip->client, csip->idle_id);
+
 	bt_gatt_client_unref(csip->client);
 	csip->client = NULL;
 

--- a/src/shared/gatt-client.c
+++ b/src/shared/gatt-client.c
@@ -173,9 +173,20 @@ static bool idle_notify(const void *data, const void *user_data)
 	return true;
 }
 
+static struct bt_gatt_client *
+bt_gatt_client_ref_safe(struct bt_gatt_client *client)
+{
+	if (!client && !client->ref_count)
+		return NULL;
+
+	return bt_gatt_client_ref(client);
+}
+
 static void notify_client_idle(struct bt_gatt_client *client)
 {
-	bt_gatt_client_ref(client);
+	client = bt_gatt_client_ref_safe(client);
+	if (!client)
+		return;
 
 	queue_remove_all(client->idle_cbs, idle_notify, NULL, idle_destroy);
 
@@ -1360,10 +1371,13 @@ static void notify_client_ready(struct bt_gatt_client *client, bool success,
 {
 	const struct queue_entry *entry;
 
-	if (client->ready)
+	client = bt_gatt_client_ref_safe(client);
+	if (!client)
 		return;
 
-	bt_gatt_client_ref(client);
+	if (client->ready)
+		goto done;
+
 	client->ready = success;
 
 	if (client->parent)
@@ -1386,6 +1400,7 @@ static void notify_client_ready(struct bt_gatt_client *client, bool success,
 		notify_client_ready(clone, success, att_ecode);
 	}
 
+done:
 	bt_gatt_client_unref(client);
 }
 


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

This make sure idle callback is unregistered before bt_gatt_client is
unref.
---
 src/shared/bap.c | 2 ++
 1 file changed, 2 insertions(+)