### PR TITLE
[PW_SID:730060] [BlueZ] shared/gatt-client: Fix crash on bt_gatt_client_idle_unregister

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/src/shared/gatt-client.c
+++ b/src/shared/gatt-client.c
@@ -3794,6 +3794,9 @@ bool bt_gatt_client_idle_unregister(struct bt_gatt_client *client,
 {
 	struct idle_cb *idle = UINT_TO_PTR(id);
 
+	if (!client || !id)
+		return false;
+
 	if (queue_remove(client->idle_cbs, idle)) {
 		idle_destroy(idle);
 		return true;


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

This fixes the following crash:

Invalid read of size 8
   at 0x1E1E0B: bt_gatt_client_idle_unregister (gatt-client.c:3812)
   by 0x1EB6BD: bt_bap_detach (bap.c:3821)
   by 0x1EB6BD: bt_bap_detach (bap.c:3808)
   by 0x1D5631: queue_foreach (queue.c:207)
   by 0x1DCAA3: disconnect_cb (att.c:713)
   by 0x1F4404: watch_callback (io-glib.c:157)
   by 0x48BBC7E: g_main_context_dispatch (in /usr/lib64/libglib-2.0.so.0.7400.6)
   by 0x4912117: ??? (in /usr/lib64/libglib-2.0.so.0.7400.6)
   by 0x48BB24E: g_main_loop_run (in /usr/lib64/libglib-2.0.so.0.7400.6)
   by 0x1F4A54: mainloop_run (mainloop-glib.c:66)
   by 0x1F4E21: mainloop_run_with_signal (mainloop-notify.c:188)
   by 0x1304B4: main (main.c:1428)
 Address 0x28 is not stack'd, malloc'd or (recently) free'd
---
 src/shared/gatt-client.c | 3 +++
 1 file changed, 3 insertions(+)