### PR TITLE
[PW_SID:731872] Split bt_iso_qos into dedicated structures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/btio/btio.c
+++ b/btio/btio.c
@@ -5,6 +5,7 @@
  *
  *  Copyright (C) 2009-2010  Marcel Holtmann <marcel@holtmann.org>
  *  Copyright (C) 2009-2010  Nokia Corporation
+ *  Copyright 2023 NXP
  *
  *
  */
@@ -68,7 +69,7 @@ struct set_opts {
 	int flushable;
 	uint32_t priority;
 	uint16_t voice;
-	struct bt_iso_qos qos;
+	struct bt_iso_unicast_qos qos;
 };
 
 struct connect {
@@ -857,11 +858,11 @@ voice:
 	return TRUE;
 }
 
-static gboolean iso_set(int sock, struct bt_iso_qos *qos, GError **err)
+static gboolean iso_set(int sock, struct bt_iso_unicast_qos *qos, GError **err)
 {
-	if (setsockopt(sock, SOL_BLUETOOTH, BT_ISO_QOS, qos,
+	if (setsockopt(sock, SOL_BLUETOOTH, BT_ISO_UNICAST_QOS, qos,
 				sizeof(*qos)) < 0) {
-		ERROR_FAILED(err, "setsockopt(BT_ISO_QOS)", errno);
+		ERROR_FAILED(err, "setsockopt(BT_ISO_UNICAST_QOS)", errno);
 		return FALSE;
 	}
 
@@ -963,7 +964,7 @@ static gboolean parse_set_opts(struct set_opts *opts, GError **err,
 			opts->voice = va_arg(args, int);
 			break;
 		case BT_IO_OPT_QOS:
-			opts->qos = *va_arg(args, struct bt_iso_qos *);
+			opts->qos = *va_arg(args, struct bt_iso_unicast_qos *);
 			break;
 		case BT_IO_OPT_INVALID:
 		case BT_IO_OPT_KEY_SIZE:
@@ -1570,14 +1571,15 @@ static gboolean iso_get(int sock, GError **err, BtIOOption opt1, va_list args)
 {
 	BtIOOption opt = opt1;
 	struct sockaddr_iso src, dst;
-	struct bt_iso_qos qos;
+	struct bt_iso_unicast_qos qos;
 	socklen_t len;
 	uint32_t phy;
 
 	len = sizeof(qos);
 	memset(&qos, 0, len);
-	if (getsockopt(sock, SOL_BLUETOOTH, BT_ISO_QOS, &qos, &len) < 0) {
-		ERROR_FAILED(err, "getsockopt(BT_ISO_QOS)", errno);
+	if (getsockopt(sock, SOL_BLUETOOTH, BT_ISO_UNICAST_QOS, &qos,
+							&len) < 0) {
+		ERROR_FAILED(err, "getsockopt(BT_ISO_UNICAST_QOS)", errno);
 		return FALSE;
 	}
 
@@ -1624,7 +1626,7 @@ static gboolean iso_get(int sock, GError **err, BtIOOption opt1, va_list args)
 			*(va_arg(args, uint32_t *)) = phy;
 			break;
 		case BT_IO_OPT_QOS:
-			*(va_arg(args, struct bt_iso_qos *)) = qos;
+			*(va_arg(args, struct bt_iso_unicast_qos *)) = qos;
 			break;
 		case BT_IO_OPT_HANDLE:
 		case BT_IO_OPT_CLASS:

--- a/client/player.c
+++ b/client/player.c
@@ -4,6 +4,7 @@
  *  BlueZ - Bluetooth protocol stack for Linux
  *
  *  Copyright (C) 2020  Intel Corporation. All rights reserved.
+ *  Copyright 2023 NXP
  *
  *
  */
@@ -3506,7 +3507,7 @@ static int transport_send_seq(struct transport *transport, int fd, uint32_t num)
 static bool transport_timer_read(struct io *io, void *user_data)
 {
 	struct transport *transport = user_data;
-	struct bt_iso_qos qos;
+	struct bt_iso_unicast_qos qos;
 	socklen_t len;
 	int ret, fd;
 	uint32_t num;
@@ -3526,9 +3527,10 @@ static bool transport_timer_read(struct io *io, void *user_data)
 	/* Read QoS if available */
 	memset(&qos, 0, sizeof(qos));
 	len = sizeof(qos);
-	if (getsockopt(transport->sk, SOL_BLUETOOTH, BT_ISO_QOS, &qos,
+	if (getsockopt(transport->sk, SOL_BLUETOOTH, BT_ISO_UNICAST_QOS, &qos,
 							&len) < 0) {
-		bt_shell_printf("Failed to getsockopt(BT_ISO_QOS): %s (%d)\n",
+		bt_shell_printf("Failed to getsockopt(BT_ISO_UNICAST_QOS):"
+					"%s (%d)\n",
 					strerror(errno), -errno);
 		return false;
 	}
@@ -3552,7 +3554,7 @@ static bool transport_timer_read(struct io *io, void *user_data)
 }
 
 static int transport_send(struct transport *transport, int fd,
-					struct bt_iso_qos *qos)
+					struct bt_iso_unicast_qos *qos)
 {
 	struct itimerspec ts;
 	int timer_fd;
@@ -3591,7 +3593,7 @@ static void cmd_send_transport(int argc, char *argv[])
 	GDBusProxy *proxy;
 	struct transport *transport;
 	int fd = -1, err;
-	struct bt_iso_qos qos;
+	struct bt_iso_unicast_qos qos;
 	socklen_t len;
 	int i;
 
@@ -3626,8 +3628,8 @@ static void cmd_send_transport(int argc, char *argv[])
 		/* Read QoS if available */
 		memset(&qos, 0, sizeof(qos));
 		len = sizeof(qos);
-		if (getsockopt(transport->sk, SOL_BLUETOOTH, BT_ISO_QOS, &qos,
-							&len) < 0)
+		if (getsockopt(transport->sk, SOL_BLUETOOTH,
+				BT_ISO_UNICAST_QOS, &qos, &len) < 0)
 			err = transport_send(transport, fd, NULL);
 		else
 			err = transport_send(transport, fd, &qos);


### PR DESCRIPTION
Convert the generic bt_iso_qos structure into the dedicated unicast
structure for ISO QoS options.

---
 btio/btio.c | 20 +++++++++++---------
 1 file changed, 11 insertions(+), 9 deletions(-)