### PR TITLE
[PW_SID:732131] [BlueZ,1/2] shared/shell: Add support for -i/--init-script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/client/advertise-broadcast.bt
+++ b/client/advertise-broadcast.bt
@@ -1,0 +1,2 @@
+power on
+advertise broadcast

--- a/client/advertise-on.bt
+++ b/client/advertise-on.bt
@@ -1,0 +1,2 @@
+power on
+advertise on

--- a/client/advertise-peripheral.bt
+++ b/client/advertise-peripheral.bt
@@ -1,0 +1,2 @@
+power on
+advertise peripheral

--- a/client/power-on-off.bt
+++ b/client/power-on-off.bt
@@ -1,0 +1,3 @@
+power on
+power off
+quit

--- a/client/power-on.bt
+++ b/client/power-on.bt
@@ -1,0 +1,3 @@
+power on
+show
+quit

--- a/client/scan-bredr.bt
+++ b/client/scan-bredr.bt
@@ -1,0 +1,2 @@
+power on
+scan bredr

--- a/client/scan-le.bt
+++ b/client/scan-le.bt
@@ -1,0 +1,2 @@
+power on
+scan le

--- a/client/scan-on-off.bt
+++ b/client/scan-on-off.bt
@@ -1,0 +1,4 @@
+scan on
+show
+scan off
+quit

--- a/client/scan-on.bt
+++ b/client/scan-on.bt
@@ -1,0 +1,2 @@
+power on
+scan on


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

This adds support for -i/--init-script which can be used to provide a
file with commands to be initialized, the commands are then run in
sequence after completing:

client/bluetoothctl -i client/power-on-off.bt
Agent registered
Changing power on succeeded
[CHG] Controller A8:7E:EA:56:87:D5 Pairable: yes
[CHG] Controller 98:8D:46:EE:6D:16 Pairable: yes
[CHG] Controller 98:8D:46:EE:6D:16 PowerState: on-disabling
AdvertisementMonitor path registered
---
 src/shared/shell.c | 163 ++++++++++++++++++++++++++++++++++++++++-----
 1 file changed, 145 insertions(+), 18 deletions(-)