### PR TITLE
[PW_SID:733736] [BlueZ,1/4] shared/gatt-db: Make gatt_db_attribute_get_value public

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/monitor/att.c
+++ b/monitor/att.c
@@ -42,6 +42,7 @@
 #include "display.h"
 #include "l2cap.h"
 #include "att.h"
+#include "keys.h"
 
 struct att_read {
 	struct gatt_db_attribute *attr;
@@ -2807,9 +2808,14 @@ static void load_gatt_db(struct packet_conn_data *conn)
 	char filename[PATH_MAX];
 	char local[18];
 	char peer[18];
+	uint8_t id[6], id_type;
 
 	ba2str((bdaddr_t *)conn->src, local);
-	ba2str((bdaddr_t *)conn->dst, peer);
+
+	if (keys_resolve_identity(conn->dst, id, &id_type))
+		ba2str((bdaddr_t *)id, peer);
+	else
+		ba2str((bdaddr_t *)conn->dst, peer);
 
 	create_filename(filename, PATH_MAX, "/%s/attributes", local);
 	gatt_load_db(data->ldb, filename, &data->ldb_mtim);

--- a/monitor/keys.c
+++ b/monitor/keys.c
@@ -112,3 +112,29 @@ bool keys_resolve_identity(const uint8_t addr[6], uint8_t ident[6],
 
 	return false;
 }
+
+static bool match_key(const void *data, const void *match_data)
+{
+	const struct irk_data *irk = data;
+	const uint8_t *key = match_data;
+
+	return !memcmp(irk->key, key, 16);
+}
+
+bool keys_add_identity(const uint8_t addr[6], uint8_t addr_type,
+					const uint8_t key[16])
+{
+	struct irk_data *irk;
+
+	irk = queue_find(irk_list, match_key, key);
+	if (!irk) {
+		irk = new0(struct irk_data, 1);
+		memcpy(irk->key, key, 16);
+		queue_push_tail(irk_list, irk);
+	}
+
+	memcpy(irk->addr, addr, 6);
+	irk->addr_type = addr_type;
+
+	return true;
+}

--- a/monitor/keys.h
+++ b/monitor/keys.h
@@ -20,3 +20,5 @@ void keys_update_identity_addr(const uint8_t addr[6], uint8_t addr_type);
 
 bool keys_resolve_identity(const uint8_t addr[6], uint8_t ident[6],
 							uint8_t *ident_type);
+bool keys_add_identity(const uint8_t addr[6], uint8_t addr_type,
+					const uint8_t key[16]);

--- a/monitor/packet.c
+++ b/monitor/packet.c
@@ -12870,6 +12870,7 @@ static void mgmt_print_identity_resolving_key(const void *data)
 
 	mgmt_print_address(data, address_type);
 	print_hex_field("Key", data + 7, 16);
+	keys_add_identity(data, address_type, data + 7);
 }
 
 static void mgmt_print_signature_resolving_key(const void *data)

--- a/src/shared/gatt-db.c
+++ b/src/shared/gatt-db.c
@@ -1549,7 +1549,7 @@ static int gatt_db_attribute_get_index(const struct gatt_db_attribute *attrib)
 	return -1;
 }
 
-static struct gatt_db_attribute *
+struct gatt_db_attribute *
 gatt_db_attribute_get_value(struct gatt_db_attribute *attrib)
 {
 	struct gatt_db_service *service;
@@ -1559,18 +1559,18 @@ gatt_db_attribute_get_value(struct gatt_db_attribute *attrib)
 		return NULL;
 
 	index = gatt_db_attribute_get_index(attrib);
-	if (index < 0)
+	if (index <= 0)
 		return NULL;
 
 	service = attrib->service;
 
 	if (!bt_uuid_cmp(&characteristic_uuid, &attrib->uuid))
-		index++;
-	else if (bt_uuid_cmp(&characteristic_uuid,
+		return service->attributes[index + 1];
+	else if (!bt_uuid_cmp(&characteristic_uuid,
 				&service->attributes[index - 1]->uuid))
-		return NULL;
+		return service->attributes[index];
 
-	return service->attributes[index];
+	return gatt_db_attribute_get_value(service->attributes[index - 1]);
 }
 
 void gatt_db_service_foreach_desc(struct gatt_db_attribute *attrib,

--- a/src/shared/gatt-db.h
+++ b/src/shared/gatt-db.h
@@ -285,6 +285,8 @@ bool gatt_db_attribute_write_result(struct gatt_db_attribute *attrib,
 						unsigned int id, int err);
 
 struct gatt_db_attribute *
+gatt_db_attribute_get_value(struct gatt_db_attribute *attrib);
+struct gatt_db_attribute *
 gatt_db_attribute_get_ccc(struct gatt_db_attribute *attrib);
 
 bool gatt_db_attribute_notify(struct gatt_db_attribute *attrib,


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

This makes gatt_db_attribute_get_value public so it can be used by the
likes of btmon.
---
 src/shared/gatt-db.c | 12 ++++++------
 src/shared/gatt-db.h |  2 ++
 2 files changed, 8 insertions(+), 6 deletions(-)