### PR TITLE
[PW_SID:735183] [v2,1/2] bap: Mark devices to auto-connect

### DIFF
--- a/profiles/audio/bap.c
+++ b/profiles/audio/bap.c
@@ -1352,6 +1352,7 @@ static struct btd_profile bap_profile = {
 	.device_remove	= bap_remove,
 	.accept		= bap_accept,
 	.disconnect	= bap_disconnect,
+	.auto_connect	= true,
 };
 
 static unsigned int bap_id = 0;

--- a/src/device.c
+++ b/src/device.c
@@ -312,9 +312,16 @@ static struct bearer_state *get_state(struct btd_device *dev,
 
 bool btd_device_is_initiator(struct btd_device *dev)
 {
-	if (dev->le_state.connected)
+	if (dev->le_state.connected) {
+		/* Mark as initiator if not set yet and auto-connect flag is
+		 * set and LTK key is for a peripheral.
+		 */
+		if (!dev->le_state.initiator && dev->auto_connect &&
+					dev->ltk && !dev->ltk->central)
+			dev->le_state.initiator = true;
+
 		return dev->le_state.initiator;
-	if (dev->bredr_state.connected)
+	} else if (dev->bredr_state.connected)
 		return dev->bredr_state.initiator;
 
 	return dev->att_io ? true : false;


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

This makes devices with BAP support to auto-connect once they start
advertising.
---
 profiles/audio/bap.c | 1 +
 1 file changed, 1 insertion(+)