### PR TITLE
[PW_SID:737372] [BlueZ,1/5] main.conf: Fix parsing of CSIS group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/client/advertising.c
+++ b/client/advertising.c
@@ -67,9 +67,11 @@ static struct ad {
 	bool tx_power;
 	bool name;
 	bool appearance;
+	bool rsi;
 } ad = {
 	.local_appearance = UINT16_MAX,
 	.discoverable = true,
+	.rsi = true,
 };
 
 static void ad_release(DBusConnection *conn)
@@ -176,6 +178,7 @@ static void print_ad(void)
 					ad.appearance ? "on" : "off");
 
 	bt_shell_printf("Discoverable: %s\n", ad.discoverable ? "on": "off");
+	bt_shell_printf("RSI: %s\n", ad.rsi ? "on": "off");
 
 	if (ad.duration)
 		bt_shell_printf("Duration: %u sec\n", ad.duration);
@@ -295,7 +298,7 @@ static gboolean get_manufacturer_data(const GDBusPropertyTable *property,
 
 static gboolean includes_exists(const GDBusPropertyTable *property, void *data)
 {
-	return ad.tx_power || ad.name || ad.appearance;
+	return ad.tx_power || ad.name || ad.appearance || ad.rsi;
 }
 
 static gboolean get_includes(const GDBusPropertyTable *property,
@@ -319,6 +322,12 @@ static gboolean get_includes(const GDBusPropertyTable *property,
 
 	if (ad.appearance) {
 		const char *str = "appearance";
+
+		dbus_message_iter_append_basic(&array, DBUS_TYPE_STRING, &str);
+	}
+
+	if (ad.rsi) {
+		const char *str = "rsi";
 
 		dbus_message_iter_append_basic(&array, DBUS_TYPE_STRING, &str);
 	}
@@ -1020,6 +1029,23 @@ void ad_advertise_interval(DBusConnection *conn, uint32_t *min, uint32_t *max)
 		g_dbus_emit_property_changed(conn, AD_PATH, AD_IFACE,
 							"MaxInterval");
 	}
+
+	return bt_shell_noninteractive_quit(EXIT_SUCCESS);
+}
+
+void ad_advertise_rsi(DBusConnection *conn, dbus_bool_t *value)
+{
+	if (!value) {
+		bt_shell_printf("RSI: %s\n", ad.rsi ? "on" : "off");
+		return bt_shell_noninteractive_quit(EXIT_SUCCESS);
+	}
+
+	if (ad.rsi == *value)
+		return bt_shell_noninteractive_quit(EXIT_SUCCESS);
+
+	ad.rsi = *value;
+
+	g_dbus_emit_property_changed(conn, AD_PATH, AD_IFACE, "Includes");
 
 	return bt_shell_noninteractive_quit(EXIT_SUCCESS);
 }

--- a/client/advertising.h
+++ b/client/advertising.h
@@ -30,3 +30,4 @@ void ad_advertise_discoverable(DBusConnection *conn, dbus_bool_t *value);
 void ad_advertise_discoverable_timeout(DBusConnection *conn, long int *value);
 void ad_advertise_secondary(DBusConnection *conn, const char *value);
 void ad_advertise_interval(DBusConnection *conn, uint32_t *min, uint32_t *max);
+void ad_advertise_rsi(DBusConnection *conn, dbus_bool_t *value);

--- a/client/main.c
+++ b/client/main.c
@@ -2733,6 +2733,21 @@ static void cmd_advertise_interval(int argc, char *argv[])
 	ad_advertise_interval(dbus_conn, &min, &max);
 }
 
+static void cmd_advertise_rsi(int argc, char *argv[])
+{
+	dbus_bool_t value;
+
+	if (argc < 2) {
+		ad_advertise_rsi(dbus_conn, NULL);
+		return;
+	}
+
+	if (!parse_argument(argc, argv, NULL, NULL, &value, NULL))
+		return bt_shell_noninteractive_quit(EXIT_FAILURE);
+
+	ad_advertise_rsi(dbus_conn, &value);
+}
+
 static void ad_clear_uuids(void)
 {
 	ad_disable_uuids(dbus_conn);
@@ -2931,6 +2946,8 @@ static const struct bt_shell_menu advertise_menu = {
 			"Set/Get advertise secondary channel" },
 	{ "interval", "[min] [max] ", cmd_advertise_interval,
 			"Set/Get advertise interval range" },
+	{ "rsi", "[on/off]", cmd_advertise_rsi,
+			"Show/Enable/Disable RSI to be advertised", NULL },
 	{ "clear", "[uuids/service/manufacturer/config-name...]", cmd_ad_clear,
 			"Clear advertise config" },
 	{ } },

--- a/doc/advertising-api.txt
+++ b/doc/advertising-api.txt
@@ -224,6 +224,7 @@ Properties	byte ActiveInstances
 			Possible values: "tx-power"
 					 "appearance"
 					 "local-name"
+					 "rsi"
 
 		array{string} SupportedSecondaryChannels [Experimental]
 

--- a/src/main.c
+++ b/src/main.c
@@ -177,7 +177,7 @@ static const struct group_table {
 	{ "LE",		le_options },
 	{ "Policy",	policy_options },
 	{ "GATT",	gatt_options },
-	{ "CSIP",	csip_options },
+	{ "CSIS",	csip_options },
 	{ "AVDTP",	avdtp_options },
 	{ "AdvMon",	advmon_options },
 	{ }
@@ -1015,7 +1015,7 @@ static void parse_config(GKeyFile *config)
 		btd_opts.gatt_channels = val;
 	}
 
-	str = g_key_file_get_string(config, "CSIP", "SIRK", &err);
+	str = g_key_file_get_string(config, "CSIS", "SIRK", &err);
 	if (err) {
 		DBG("%s", err->message);
 		g_clear_error(&err);
@@ -1031,7 +1031,7 @@ static void parse_config(GKeyFile *config)
 		g_free(str);
 	}
 
-	boolean = g_key_file_get_boolean(config, "CSIP", "SIRK", &err);
+	boolean = g_key_file_get_boolean(config, "CSIS", "Encryption", &err);
 	if (err) {
 		DBG("%s", err->message);
 		g_clear_error(&err);
@@ -1041,7 +1041,7 @@ static void parse_config(GKeyFile *config)
 		btd_opts.csis.encrypt = boolean;
 	}
 
-	val = g_key_file_get_integer(config, "CSIP", "Size", &err);
+	val = g_key_file_get_integer(config, "CSIS", "Size", &err);
 	if (err) {
 		DBG("%s", err->message);
 		g_clear_error(&err);
@@ -1052,7 +1052,7 @@ static void parse_config(GKeyFile *config)
 		btd_opts.csis.size = val;
 	}
 
-	val = g_key_file_get_integer(config, "CSIP", "Rank", &err);
+	val = g_key_file_get_integer(config, "CSIS", "Rank", &err);
 	if (err) {
 		DBG("%s", err->message);
 		g_clear_error(&err);

--- a/src/shared/ad.c
+++ b/src/shared/ad.c
@@ -1028,6 +1028,9 @@ static bool data_match(const void *data, const void *user_data)
 	if (d1->type != d2->type)
 		return false;
 
+	if (!d2->len && !d2->data)
+		return true;
+
 	if (d1->len != d2->len)
 		return false;
 


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

There was a typo in the group name using CSIP instead of CSIS.
---
 src/main.c | 10 +++++-----
 1 file changed, 5 insertions(+), 5 deletions(-)