### PR TITLE
[PW_SID:745379] [BlueZ] mesh: Update the behavior of --io option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/mesh/bluetooth-meshd.rst.in
+++ b/mesh/bluetooth-meshd.rst.in
@@ -36,14 +36,17 @@ OPTIONS
 -i <type>, --io <type>
     Specifies I/O interface type:
 
-    *hci<index>* - Use generic HCI io on interface hci<index>,
-    or, if no idex is specified, the first available one.
+    *auto* - Use first available controller: via MGMT interface
+    if kernel supports it, otherwise, via raw HCI socket.
+
+    *generic:[hci]<index>* - Use generic HCI io on interface
+    hci<index>.
 
     *unit:<fd_path>*- Specifies open file descriptor for
     daemon testing.
 
-    By default, if no type is specified, uses generic I/O
-    on the first available HCI interface.
+    By default, if no type is specified, uses auto I/O
+    on the first available controller.
 
 -c <file>, --config <file>
     Specifies an explicit config file path instead of relying on the

--- a/mesh/mesh-io-generic.c
+++ b/mesh/mesh-io-generic.c
@@ -380,6 +380,9 @@ static void hci_init(void *user_data)
 	if (io->pvt->hci)
 		bt_hci_unref(io->pvt->hci);
 
+	/* Clear controller HCI list to suppress mgmt interface warnings */
+	mesh_mgmt_clear();
+
 	io->pvt->hci = bt_hci_new_user_channel(io->index);
 	if (!io->pvt->hci) {
 		l_error("Failed to start mesh io (hci %u): %s", io->index,

--- a/mesh/mesh-mgmt.c
+++ b/mesh/mesh-mgmt.c
@@ -271,3 +271,8 @@ bool mesh_mgmt_unregister(unsigned int id)
 {
 	return mgmt_unregister(mgmt_mesh, id);
 }
+
+void mesh_mgmt_clear(void)
+{
+	l_queue_clear(ctl_list, l_free);
+}

--- a/mesh/mesh-mgmt.h
+++ b/mesh/mesh-mgmt.h
@@ -22,3 +22,4 @@ unsigned int mesh_mgmt_register(uint16_t event, uint16_t index,
 				void *user_data, mgmt_destroy_func_t destroy);
 bool mesh_mgmt_unregister(unsigned int id);
 void mesh_mgmt_destroy(void);
+void mesh_mgmt_clear(void);


### PR DESCRIPTION
This aligns the behavior of command line option --io to
add new "auto" value and modify the behavior of "generic"
value:

*auto* - Use first available controller: via MGMT interface
if kernel supports it, otherwise, via raw HCI socket (i.e.,
default to *generic*).

*generic:[hci]<index>* - Use generic HCI io on interface hci<index>

The default value is now *auto*, whereas *generic* is used
only if the specific HCI controller is explicitly specified.
---
 mesh/bluetooth-meshd.rst.in | 11 ++++++----
 mesh/main.c                 | 40 +++++++++++--------------------------
 mesh/mesh-io-generic.c      |  3 +++
 mesh/mesh-io.c              | 17 +++++++++++-----
 mesh/mesh-mgmt.c            |  5 +++++
 mesh/mesh-mgmt.h            |  1 +
 6 files changed, 40 insertions(+), 37 deletions(-)