### PR TITLE
[PW_SID:745389] [BlueZ,1/2] monitor/att: Attempt to insert discovered attributes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/monitor/packet.c
+++ b/monitor/packet.c
@@ -11945,7 +11945,7 @@ void packet_system_note(struct timeval *tv, struct ucred *cred,
 struct monitor_l2cap_hdr {
 	uint16_t cid;
 	uint16_t psm;
-};
+} __attribute__((packed));
 
 static void packet_decode(struct timeval *tv, struct ucred *cred, char dir,
 				uint16_t index, const char *color,
@@ -11964,7 +11964,8 @@ static void packet_decode(struct timeval *tv, struct ucred *cred, char dir,
 				NULL);
 
 	/* Discard last byte since it just a filler */
-	l2cap_frame(index, dir == '>', 0, hdr->cid, hdr->psm,
+	l2cap_frame(index, dir == '>', 0,
+			le16_to_cpu(hdr->cid), le16_to_cpu(hdr->psm),
 			data + sizeof(*hdr), size - (sizeof(*hdr) + 1));
 }
 


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

This attempts to insert discovered attributes into monitor gatt_db
instance if their respective discover procedures are used which enables
decoding traces injected by user via unit testing:

> sudo unit/test-bap -m -s "34

= test-bap: BAP/UCL/SCC/BV-034-C [UCL SNK Config Codec, VS] - run
> test-bap: User Data RX
      ATT: Read Request (0x0a) len 2
        Handle: 0x0003 Type: Sink PAC (0x2bc9)
< test-bap: User Data TX
      ATT: Read Response (0x0b) len 8
        Handle: 0x0003 Type: Sink PAC (0x2bc9)
        Value: 01ff010001000000
          Number of PAC(s): 1
          PAC #0:
            Codec: Vendor specific (0xff)
            Codec Company ID: Nokia Mobile Phones (0x0001)
            Codec Vendor ID: 0x0001
> test-bap: User Data RX
      ATT: Read Request (0x0a) len 2
        Handle: 0x0006 Type: Sink Audio Locations (0x2bca)
< test-bap: User Data TX
      ATT: Read Response (0x0b) len 4
        Handle: 0x0006 Type: Sink Audio Locations (0x2bca)
        Value: 03000000
           Location: 0x00000003
              Front Left (0x00000001)
              Front Right (0x00000002)
> test-bap: User Data RX
      ATT: Read Request (0x0a) len 2
        Handle: 0x0009 Type: Source PAC (0x2bcb)
< test-bap: User Data TX
      ATT: Read Response (0x0b) len 8
        Handle: 0x0009 Type: Source PAC (0x2bcb)
        Value: 01ff010001000000
          Number of PAC(s): 1
          PAC #0:
            Codec: Vendor specific (0xff)
            Codec Company ID: Nokia Mobile Phones (0x0001)
            Codec Vendor ID: 0x0001
> test-bap: User Data RX
      ATT: Read Request (0x0a) len 2
        Handle: 0x000c Type: Source Audio Locations (0x2bcc)
< test-bap: User Data TX
      ATT: Read Response (0x0b) len 4
        Handle: 0x000c Type: Source Audio Locations (0x2bcc)
        Value: 03000000
           Location: 0x00000003
              Front Left (0x00000001)
              Front Right (0x00000002)
> test-bap: User Data RX
      ATT: Read Request (0x0a) len 2
        Handle: 0x000f Type: Available Audio Contexts (0x2bcd)
< test-bap: User Data TX
      ATT: Read Response (0x0b) len 4
        Handle: 0x000f Type: Available Audio Contexts (0x2bcd)
        Value: ff0f0e00
          Sink Context: 0x0fff
            Unspecified (0x0001)
            Conversational (0x0002)
            Media (0x0004)
            Game (0x0008)
            Instructional (0x0010)
            Voice Assistants (0x0020)
            Live (0x0040)
            Sound Effects (0x0080)
            Notifications (0x0100)
            Ringtone (0x0200)
            Alerts (0x0400)
            Emergency alarm (0x0800)
          Source Context: 0x000e
            Conversational (0x0002)
            Media (0x0004)
            Game (0x0008)
> test-bap: User Data RX
      ATT: Read Request (0x0a) len 2
        Handle: 0x0012 Type: Supported Audio Contexts (0x2bce)
< test-bap: User Data TX
      ATT: Read Response (0x0b) len 4
        Handle: 0x0012 Type: Supported Audio Contexts (0x2bce)
        Value: ff0f0e00
          Sink Context: 0x0fff
            Unspecified (0x0001)
            Conversational (0x0002)
            Media (0x0004)
            Game (0x0008)
            Instructional (0x0010)
            Voice Assistants (0x0020)
            Live (0x0040)
            Sound Effects (0x0080)
            Notifications (0x0100)
            Ringtone (0x0200)
            Alerts (0x0400)
            Emergency alarm (0x0800)
          Source Context: 0x000e
            Conversational (0x0002)
            Media (0x0004)
            Game (0x0008)
> test-bap: User Data RX
      ATT: Read Request (0x0a) len 2
        Handle: 0x0016 Type: Sink ASE (0x2bc4)
< test-bap: User Data TX
      ATT: Read Response (0x0b) len 2
        Handle: 0x0016 Type: Sink ASE (0x2bc4)
        Value: 0100
            ASE ID: 1
            State: Idle (0x00)
> test-bap: User Data RX
      ATT: Write Request (0x12) len 4
        Handle: 0x0017
          Data: 0100
< test-bap: User Data TX
      ATT: Write Response (0x13) len 0
> test-bap: User Data RX
      ATT: Read Request (0x0a) len 2
        Handle: 0x0019 Type: Sink ASE (0x2bc4)
< test-bap: User Data TX
      ATT: Read Response (0x0b) len 2
        Handle: 0x0019 Type: Sink ASE (0x2bc4)
        Value: 0200
            ASE ID: 2
            State: Idle (0x00)
> test-bap: User Data RX
      ATT: Write Request (0x12) len 4
        Handle: 0x001a
          Data: 0100
< test-bap: User Data TX
      ATT: Write Response (0x13) len 0
> test-bap: User Data RX
      ATT: Read Request (0x0a) len 2
        Handle: 0x001c Type: Source ASE (0x2bc5)
< test-bap: User Data TX
      ATT: Read Response (0x0b) len 2
        Handle: 0x001c Type: Source ASE (0x2bc5)
        Value: 0300
            ASE ID: 3
            State: Idle (0x00)
> test-bap: User Data RX
      ATT: Write Request (0x12) len 4
        Handle: 0x001d
          Data: 0100
< test-bap: User Data TX
      ATT: Write Response (0x13) len 0
> test-bap: User Data RX
      ATT: Read Request (0x0a) len 2
        Handle: 0x001f Type: Source ASE (0x2bc5)
< test-bap: User Data TX
      ATT: Read Response (0x0b) len 2
        Handle: 0x001f Type: Source ASE (0x2bc5)
        Value: 0400
            ASE ID: 4
            State: Idle (0x00)
> test-bap: User Data RX
      ATT: Write Request (0x12) len 4
        Handle: 0x0020
          Data: 0100
< test-bap: User Data TX
      ATT: Write Response (0x13) len 0
> test-bap: User Data RX
      ATT: Write Request (0x12) len 4
        Handle: 0x0023
          Data: 0100
< test-bap: User Data TX
      ATT: Write Response (0x13) len 0
> test-bap: User Data RX
      ATT: Write Command (0x52) len 13
        Handle: 0x0022 Type: ASE Control Point (0x2bc6)
          Data: 0101030202ff0100010000
            Opcode: Codec Configuration (0x01)
            Number of ASE(s): 1
            ASE: #0
            ASE ID: 0x03
            Target Latency: Balance Latency/Reliability (0x02)
            PHY: 0x02
            LE 2M PHY (0x02)
            Codec: Vendor specific (0xff)
            Codec Company ID: Nokia Mobile Phones (0x0001)
            Codec Vendor ID: 0x0001
< test-bap: User Data TX
      ATT: Handle Value Notification (0x1b) len 7
        Handle: 0x0022 Type: ASE Control Point (0x2bc6)
          Data: 0101030000
            Opcode: Codec Configuration (0x01)
            Number of ASE(s): 1
            ASE: #0
            ASE ID: 0x03
            ASE Response Code: Success (0x00)
            ASE Response Reason: None (0x00)
< test-bap: User Data TX
      ATT: Handle Value Notification (0x1b) len 27
        Handle: 0x001c Type: Source ASE (0x2bc5)
          Data: 03010102010a00204e00409c00204e00409c00ff0100010000
            ASE ID: 3
            State: Codec Configured (0x01)
            Framing: Unframed PDUs not supported (0x01)
            PHY: 0x02
            LE 2M PHY preffered (0x02)
            RTN: 1
            Max Transport Latency: 10
            Presentation Delay Min: 20000 us
            Presentation Delay Max: 40000 us
            Preferred Presentation Delay Min: 20000 us
            Preferred Presentation Delay Max: 40000 us
            Codec: Vendor specific (0xff)
            Codec Company ID: Nokia Mobile Phones (0x0001)
            Codec Vendor ID: 0x0001
---
 monitor/att.c | 538 ++++++++++++++++++++++++++++++++------------------
 1 file changed, 345 insertions(+), 193 deletions(-)