### PR TITLE
[PW_SID:747773] [BlueZ,1/7] profile: Add support for experimental flag

### DIFF
--- a/profiles/audio/bap.c
+++ b/profiles/audio/bap.c
@@ -1354,18 +1354,19 @@ static struct btd_profile bap_profile = {
 	.accept		= bap_accept,
 	.disconnect	= bap_disconnect,
 	.auto_connect	= true,
+	.experimental	= true,
 };
 
 static unsigned int bap_id = 0;
 
 static int bap_init(void)
 {
-	if (!(g_dbus_get_flags() & G_DBUS_FLAG_ENABLE_EXPERIMENTAL)) {
-		warn("D-Bus experimental not enabled");
-		return -ENOTSUP;
-	}
+	int err;
 
-	btd_profile_register(&bap_profile);
+	err = btd_profile_register(&bap_profile);
+	if (err)
+		return err;
+
 	bap_id = bt_bap_register(bap_attached, bap_detached, NULL);
 
 	return 0;
@@ -1373,10 +1374,8 @@ static int bap_init(void)
 
 static void bap_exit(void)
 {
-	if (g_dbus_get_flags() & G_DBUS_FLAG_ENABLE_EXPERIMENTAL) {
-		btd_profile_unregister(&bap_profile);
-		bt_bap_unregister(bap_id);
-	}
+	btd_profile_unregister(&bap_profile);
+	bt_bap_unregister(bap_id);
 }
 
 BLUETOOTH_PLUGIN_DEFINE(bap, VERSION, BLUETOOTH_PLUGIN_PRIORITY_DEFAULT,

--- a/profiles/audio/bass.c
+++ b/profiles/audio/bass.c
@@ -276,18 +276,19 @@ static struct btd_profile bass_service = {
 	.device_remove	= bass_remove,
 	.accept		= bass_accept,
 	.disconnect	= bass_disconnect,
+	.experimental	= true,
 };
 
 static unsigned int bass_id;
 
 static int bass_init(void)
 {
-	if (!(g_dbus_get_flags() & G_DBUS_FLAG_ENABLE_EXPERIMENTAL)) {
-		warn("D-Bus experimental not enabled");
-		return -ENOTSUP;
-	}
+	int err;
 
-	btd_profile_register(&bass_service);
+	err = btd_profile_register(&bass_service);
+	if (err)
+		return err;
+
 	bass_id = bt_bass_register(bass_attached, bass_detached, NULL);
 
 	return 0;
@@ -295,10 +296,8 @@ static int bass_init(void)
 
 static void bass_exit(void)
 {
-	if (g_dbus_get_flags() & G_DBUS_FLAG_ENABLE_EXPERIMENTAL) {
-		btd_profile_unregister(&bass_service);
-		bt_bass_unregister(bass_id);
-	}
+	btd_profile_unregister(&bass_service);
+	bt_bass_unregister(bass_id);
 }
 
 BLUETOOTH_PLUGIN_DEFINE(bass, VERSION, BLUETOOTH_PLUGIN_PRIORITY_DEFAULT,

--- a/profiles/audio/csip.c
+++ b/profiles/audio/csip.c
@@ -334,18 +334,20 @@ static struct btd_profile csip_profile = {
 
 	.adapter_probe	= csip_server_probe,
 	.adapter_remove	= csip_server_remove,
+
+	.experimental	= true,
 };
 
 static unsigned int csip_id;
 
 static int csip_init(void)
 {
-	if (!(g_dbus_get_flags() & G_DBUS_FLAG_ENABLE_EXPERIMENTAL)) {
-		warn("D-Bus experimental not enabled");
-		return -ENOTSUP;
-	}
+	int err;
 
-	btd_profile_register(&csip_profile);
+	err = btd_profile_register(&csip_profile);
+	if (err)
+		return err;
+
 	csip_id = bt_csip_register(csip_attached, csip_detached, NULL);
 
 	return 0;
@@ -353,10 +355,8 @@ static int csip_init(void)
 
 static void csip_exit(void)
 {
-	if (g_dbus_get_flags() & G_DBUS_FLAG_ENABLE_EXPERIMENTAL) {
-		btd_profile_unregister(&csip_profile);
-		bt_csip_unregister(csip_id);
-	}
+	btd_profile_unregister(&csip_profile);
+	bt_csip_unregister(csip_id);
 }
 
 BLUETOOTH_PLUGIN_DEFINE(csip, VERSION, BLUETOOTH_PLUGIN_PRIORITY_DEFAULT,

--- a/profiles/audio/mcp.c
+++ b/profiles/audio/mcp.c
@@ -403,27 +403,18 @@ static struct btd_profile mcp_profile = {
 
 	.adapter_probe	= media_control_server_probe,
 	.adapter_remove = media_control_server_remove,
+
+	.experimental	= true,
 };
 
 static int mcp_init(void)
 {
-	DBG("");
-
-	if (!(g_dbus_get_flags() & G_DBUS_FLAG_ENABLE_EXPERIMENTAL)) {
-		warn("D-Bus experimental not enabled");
-		return -ENOTSUP;
-	}
-
-	btd_profile_register(&mcp_profile);
-	return 0;
+	return btd_profile_register(&mcp_profile);
 }
 
 static void mcp_exit(void)
 {
-	DBG("");
-
-	if (g_dbus_get_flags() & G_DBUS_FLAG_ENABLE_EXPERIMENTAL)
-		btd_profile_unregister(&mcp_profile);
+	btd_profile_unregister(&mcp_profile);
 }
 
 BLUETOOTH_PLUGIN_DEFINE(mcp, VERSION, BLUETOOTH_PLUGIN_PRIORITY_DEFAULT,

--- a/profiles/audio/vcp.c
+++ b/profiles/audio/vcp.c
@@ -289,18 +289,20 @@ static struct btd_profile vcp_profile = {
 
 	.adapter_probe = vcp_server_probe,
 	.adapter_remove = vcp_server_remove,
+
+	.experimental	= true,
 };
 
 static unsigned int vcp_id = 0;
 
 static int vcp_init(void)
 {
-	if (!(g_dbus_get_flags() & G_DBUS_FLAG_ENABLE_EXPERIMENTAL)) {
-		warn("D-Bus experimental not enabled");
-		return -ENOTSUP;
-	}
+	int err;
 
-	btd_profile_register(&vcp_profile);
+	err = btd_profile_register(&vcp_profile);
+	if (err)
+		return err;
+
 	vcp_id = bt_vcp_register(vcp_attached, vcp_detached, NULL);
 
 	return 0;
@@ -308,10 +310,8 @@ static int vcp_init(void)
 
 static void vcp_exit(void)
 {
-	if (g_dbus_get_flags() & G_DBUS_FLAG_ENABLE_EXPERIMENTAL) {
-		btd_profile_unregister(&vcp_profile);
-		bt_vcp_unregister(vcp_id);
-	}
+	btd_profile_unregister(&vcp_profile);
+	bt_vcp_unregister(vcp_id);
 }
 
 BLUETOOTH_PLUGIN_DEFINE(vcp, VERSION, BLUETOOTH_PLUGIN_PRIORITY_DEFAULT,

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -186,7 +186,7 @@ start:
 
 		err = plugin->desc->init();
 		if (err < 0) {
-			if (err == -ENOSYS)
+			if (err == -ENOSYS || err == -ENOTSUP)
 				warn("System does not support %s plugin",
 							plugin->desc->name);
 			else

--- a/src/profile.c
+++ b/src/profile.c
@@ -775,6 +775,12 @@ static struct btd_profile *btd_profile_find_uuid(const char *uuid)
 
 int btd_profile_register(struct btd_profile *profile)
 {
+	if (profile->experimental && !(g_dbus_get_flags() &
+					G_DBUS_FLAG_ENABLE_EXPERIMENTAL)) {
+		DBG("D-Bus experimental not enabled");
+		return -ENOTSUP;
+	}
+
 	profiles = g_slist_append(profiles, profile);
 	return 0;
 }

--- a/src/profile.h
+++ b/src/profile.h
@@ -28,6 +28,11 @@ struct btd_profile {
 	 */
 	bool external;
 
+	/* Indicates the profile is experimental and shall only be registered
+	 * when experimental has been enabled (see: main.conf:Experimental).
+	 */
+	bool experimental;
+
 	int (*device_probe) (struct btd_service *service);
 	void (*device_remove) (struct btd_service *service);
 


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

This adds experimental field to btd_profile so the plugin can indicate
drivers that depends on experimental to be enabled.
---
 src/profile.c | 6 ++++++
 src/profile.h | 5 +++++
 2 files changed, 11 insertions(+)