### PR TITLE
[PW_SID:748669] [BlueZ] monitor: Fix using PACKET_FILTER_SHOW_SCO_DATA for ISO packets

### DIFF
--- a/monitor/main.c
+++ b/monitor/main.c
@@ -62,6 +62,7 @@ static void usage(void)
 		"\t-T, --date             Show time and date information\n"
 		"\t-S, --sco              Dump SCO traffic\n"
 		"\t-A, --a2dp             Dump A2DP stream traffic\n"
+		"\t-I, --iso              Dump ISO traffic\n"
 		"\t-E, --ellisys [ip]     Send Ellisys HCI Injection\n"
 		"\t-P, --no-pager         Disable pager usage\n"
 		"\t-J  --jlink <device>,[<serialno>],[<interface>],[<speed>]\n"
@@ -89,6 +90,7 @@ static const struct option main_options[] = {
 	{ "date",      no_argument,       NULL, 'T' },
 	{ "sco",       no_argument,       NULL, 'S' },
 	{ "a2dp",      no_argument,       NULL, 'A' },
+	{ "iso",       no_argument,       NULL, 'I' },
 	{ "ellisys",   required_argument, NULL, 'E' },
 	{ "no-pager",  no_argument,       NULL, 'P' },
 	{ "jlink",     required_argument, NULL, 'J' },
@@ -126,8 +128,8 @@ int main(int argc, char *argv[])
 		struct sockaddr_un addr;
 
 		opt = getopt_long(argc, argv,
-					"r:w:a:s:p:i:d:B:V:MNtTSAE:PJ:R:C:c:vh",
-					main_options, NULL);
+				"r:w:a:s:p:i:d:B:V:MNtTSAIE:PJ:R:C:c:vh",
+				main_options, NULL);
 		if (opt < 0)
 			break;
 
@@ -196,6 +198,9 @@ int main(int argc, char *argv[])
 			break;
 		case 'A':
 			filter_mask |= PACKET_FILTER_SHOW_A2DP_STREAM;
+			break;
+		case 'I':
+			filter_mask |= PACKET_FILTER_SHOW_ISO_DATA;
 			break;
 		case 'E':
 			ellisys_server = optarg;

--- a/monitor/packet.c
+++ b/monitor/packet.c
@@ -66,6 +66,7 @@
 #define COLOR_HCI_EVENT_UNKNOWN		COLOR_WHITE_BG
 #define COLOR_HCI_ACLDATA		COLOR_CYAN
 #define COLOR_HCI_SCODATA		COLOR_YELLOW
+#define COLOR_HCI_ISODATA		COLOR_YELLOW
 
 #define COLOR_UNKNOWN_ERROR		COLOR_WHITE_BG
 #define COLOR_UNKNOWN_FEATURE_BIT	COLOR_WHITE_BG
@@ -12357,7 +12358,7 @@ void packet_hci_isodata(struct timeval *tv, struct ucred *cred, uint16_t index,
 	sprintf(handle_str, "Handle %d", acl_handle(handle));
 	sprintf(extra_str, "flags 0x%2.2x dlen %d", flags, hdr->dlen);
 
-	print_packet(tv, cred, in ? '>' : '<', index, NULL, COLOR_HCI_SCODATA,
+	print_packet(tv, cred, in ? '>' : '<', index, NULL, COLOR_HCI_ISODATA,
 				in ? "ISO Data RX" : "ISO Data TX",
 						handle_str, extra_str);
 
@@ -12368,7 +12369,7 @@ void packet_hci_isodata(struct timeval *tv, struct ucred *cred, uint16_t index,
 		return;
 	}
 
-	if (filter_mask & PACKET_FILTER_SHOW_SCO_DATA)
+	if (filter_mask & PACKET_FILTER_SHOW_ISO_DATA)
 		packet_hexdump(data, size);
 }
 

--- a/monitor/packet.h
+++ b/monitor/packet.h
@@ -22,6 +22,7 @@
 #define PACKET_FILTER_SHOW_SCO_DATA	(1 << 5)
 #define PACKET_FILTER_SHOW_A2DP_STREAM	(1 << 6)
 #define PACKET_FILTER_SHOW_MGMT_SOCKET	(1 << 7)
+#define PACKET_FILTER_SHOW_ISO_DATA	(1 << 8)
 
 struct packet_conn_data {
 	uint16_t index;


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

This fixes the uses of PACKET_FILTER_SHOW_SCO_DATA for ISO packets and
introduce a dedicated flag for it in the form of
PACKET_FILTER_SHOW_ISO_DATA which can be enabled with use of -I/--iso.
---
 monitor/main.c   | 9 +++++++--
 monitor/packet.c | 5 +++--
 monitor/packet.h | 1 +
 3 files changed, 11 insertions(+), 4 deletions(-)