### PR TITLE
[PW_SID:751640] [BlueZ] battery: Check interface before getting property

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/src/battery.c
+++ b/src/battery.c
@@ -288,16 +288,16 @@ static void provided_battery_added_cb(GDBusProxy *proxy, void *user_data)
 	uint8_t percentage;
 	DBusMessageIter iter;
 
+	if (strcmp(g_dbus_proxy_get_interface(proxy),
+		   BATTERY_PROVIDER_INTERFACE) != 0)
+		return;
+
 	if (g_dbus_proxy_get_property(proxy, "Device", &iter) == FALSE) {
 		warn("Battery object %s does not specify device path", path);
 		return;
 	}
 
 	dbus_message_iter_get_basic(&iter, &export_path);
-
-	if (strcmp(g_dbus_proxy_get_interface(proxy),
-		   BATTERY_PROVIDER_INTERFACE) != 0)
-		return;
 
 	device = btd_adapter_find_device_by_path(provider->manager->adapter,
 						 export_path);
@@ -341,14 +341,14 @@ static void provided_battery_removed_cb(GDBusProxy *proxy, void *user_data)
 	const char *export_path;
 	DBusMessageIter iter;
 
+	if (strcmp(g_dbus_proxy_get_interface(proxy),
+		   BATTERY_PROVIDER_INTERFACE) != 0)
+		return;
+
 	if (g_dbus_proxy_get_property(proxy, "Device", &iter) == FALSE)
 		return;
 
 	dbus_message_iter_get_basic(&iter, &export_path);
-
-	if (strcmp(g_dbus_proxy_get_interface(proxy),
-		   BATTERY_PROVIDER_INTERFACE) != 0)
-		return;
 
 	DBG("provided battery removed %s", g_dbus_proxy_get_path(proxy));
 


### PR DESCRIPTION
Client can export other interfaces than the BatteryProvide1 on the
registered object manager. So, before getting battery provider specific
property, validate that we are operating on the right interface.

This change will allow client to implement only one object manger for
media applications, players and battery providers without triggering
error message.
---
 src/battery.c | 16 ++++++++--------
 1 file changed, 8 insertions(+), 8 deletions(-)