### PR TITLE
[PW_SID:757099] bluez SEGV in current master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/profiles/audio/transport.c
+++ b/profiles/audio/transport.c
@@ -345,7 +345,7 @@ static void a2dp_resume_complete(struct avdtp *session, int err,
 	struct media_owner *owner = user_data;
 	struct media_request *req = owner->pending;
 	struct media_transport *transport = owner->transport;
-	struct a2dp_sep *sep = media_endpoint_get_sep(transport->endpoint);
+	struct a2dp_sep *sep;
 	struct avdtp_stream *stream;
 	int fd;
 	uint16_t imtu, omtu;
@@ -355,7 +355,10 @@ static void a2dp_resume_complete(struct avdtp *session, int err,
 
 	if (err)
 		goto fail;
+	if (!transport)
+		goto fail;
 
+	sep = media_endpoint_get_sep(transport->endpoint);
 	stream = a2dp_sep_get_stream(sep);
 	if (stream == NULL)
 		goto fail;


### PR DESCRIPTION
commit bap: Add broadcast source support, 3030883, in bluez.git

A co-worker see this SEGV when connecting a headset:

Jun 13 13:38:15 systemd-coredump[3941]: Process 1897 (bluetoothd) of user 0 dumped core.
                                        Module bluetoothd without build-id.
                                        #0  0x0000556bea93277a a2dp_resume_complete (bluetoothd + 0x3e77a)
                                        #1  0x0000556bea9210a2 finalize_resume (bluetoothd + 0x2d0a2)
                                        #2  0x0000556bea92afaf avdtp_start_resp (bluetoothd + 0x36faf)
                                        #6  0x0000556bea9dcc85 mainloop_run (bluetoothd + 0xe8c85)
                                        #7  0x0000556bea9dd0dc mainloop_run_with_signal (bluetoothd + 0xe90dc)
                                        #8  0x0000556bea91a4ef main (bluetoothd + 0x264ef)
                                        #11 0x0000556bea91ace1 _start (bluetoothd + 0x26ce1)
Jun 13 13:38:15 systemd[1]: bluetooth.service: Main process exited, code=dumped, status=11/SEGV


Crash seems to be at:

342	static void a2dp_resume_complete(struct avdtp *session, int err,
343								void *user_data)
344	{
345		struct media_owner *owner = user_data;
346		struct media_request *req = owner->pending;
347		struct media_transport *transport = owner->transport;
348		struct a2dp_sep *sep = media_endpoint_get_sep(transport->endpoint);

A good start(but does NOT fix the problem) might be:


bluez-5.66 Works fine though.

Headset: WH-1000XM3

  Jocke