### PR TITLE
[PW_SID:760764] [BlueZ] shared/bap: Fix handling of codec fields

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/src/shared/bap.c
+++ b/src/shared/bap.c
@@ -882,6 +882,12 @@ static void stream_notify_config(struct bt_bap_stream *stream)
 	put_le24(lpac->qos.ppd_min, config->ppd_min);
 	put_le24(lpac->qos.ppd_max, config->ppd_max);
 	config->codec = lpac->codec;
+
+	if (config->codec.id == 0x0ff) {
+		config->codec.vid = cpu_to_le16(config->codec.vid);
+		config->codec.cid = cpu_to_le16(config->codec.cid);
+	}
+
 	config->cc_len = stream->cc->iov_len;
 	memcpy(config->cc, stream->cc->iov_base, stream->cc->iov_len);
 
@@ -4346,6 +4352,11 @@ unsigned int bt_bap_stream_config(struct bt_bap_stream *stream,
 		config.latency = qos->ucast.target_latency;
 		config.phy = qos->ucast.io_qos.phy;
 		config.codec = stream->rpac->codec;
+
+		if (config.codec.id == 0xff) {
+			config.codec.cid = cpu_to_le16(config.codec.cid);
+			config.codec.vid = cpu_to_le16(config.codec.vid);
+		}
 
 		iov[0].iov_base = &config;
 		iov[0].iov_len = sizeof(config);


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

Codec fields needs to be converted when codec.id is 0xff as the host
endian may not always be little endian.
---
 src/shared/bap.c | 11 +++++++++++
 1 file changed, 11 insertions(+)