### PR TITLE
[PW_SID:762038] monitor: Add decoding support for Sync Receiver events

### DIFF
--- a/lib/mgmt.h
+++ b/lib/mgmt.h
@@ -1238,6 +1238,9 @@ static const char *mgmt_ev[] = {
 	"Advertisement Monitor Device Lost",
 	"Mesh Packet Found",
 	"Mesh Packet Complete",
+	"PA Sync Established",
+	"BIG Sync Established",
+	"BIG Sync Lost",
 };
 
 static const char *mgmt_status[] = {

--- a/monitor/packet.c
+++ b/monitor/packet.c
@@ -3093,6 +3093,11 @@ static const struct bitfield_data events_le_table[] = {
 	{ 27, "LE Terminate BIG Complete"		},
 	{ 28, "LE BIG Sync Estabilished Complete"	},
 	{ 29, "LE BIG Sync Lost"			},
+	{ 30, "LE Request Peer SCA Complete"},
+	{ 31, "LE Path Loss Threshold"		},
+	{ 32, "LE Transmit Power Reporting"	},
+	{ 33, "LE BIG Info Advertising Report"	},
+	{ 34, "LE Subrate Change"			},
 	{ }
 };
 


### PR DESCRIPTION
This commit adds decoding support for PA Sync Established, 
BIG Sync Established and BIG Sync Lost events.

---
 lib/mgmt.h       | 3 +++
 monitor/packet.c | 5 +++++
 2 files changed, 8 insertions(+)