### PR TITLE
[PW_SID:762216] plugins/admin: Fix heap-use-after-free when using 2 controllers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/plugins/admin.c
+++ b/plugins/admin.c
@@ -502,7 +502,6 @@ static int admin_policy_adapter_probe(struct btd_adapter *adapter)
 	if (policy_data) {
 		btd_warn(policy_data->adapter_id,
 						"Policy data already exists");
-		admin_policy_free(policy_data);
 		policy_data = NULL;
 	}
 


### PR DESCRIPTION
This commit fixes the heap-use-after-free error when connecting 2
controllers. When a controller is connected
admin_policy_adapter_probe is called. If policy_data was already
allocated it gets freed, if not, it only gets allocated. Eventually
add_interface is called. Here policy_data is put in the "data" variable
(specific for each controller) and the process_changes task is called
with idle priority. This function ultimately accesses policy_data from
the "data" variable.

When Bluez crashes the flow is:
1)first controller is attached
2)admin_policy_adapter_probe is called and policy_data is allocated
4)second controller is attached
5)admin_policy_adapter_probe is called and policy_data is freed, then
allocated again
6)process_changes runs and the policy_data for the first controller is
read, but it was already freed, thus the crash

---
 plugins/admin.c | 1 -
 1 file changed, 1 deletion(-)