### PR TITLE
[PW_SID:764973] [BlueZ,1/2] test-runner: set non-quiet printk before running tests

### DIFF
--- a/tools/test-runner.c
+++ b/tools/test-runner.c
@@ -273,7 +273,8 @@ static void start_qemu(void)
 				initcmd, cwd, start_dbus, start_daemon,
 				start_dbus_session,
 				start_monitor, start_emulator, num_devs,
-				run_auto, audio_server, testargs);
+				run_auto, audio_server ? audio_server : "",
+				testargs);
 
 	argv = alloca(sizeof(qemu_argv) +
 				(sizeof(char *) * (4 + (num_devs * 4))));
@@ -1128,7 +1129,7 @@ static void run_tests(void)
 		const char *start = ptr + 11;
 		const char *end = strchr(start, '\'');
 
-		if (end) {
+		if (end && end != start) {
 			audio_server = strndup(start, end - start);
 			printf("Audio server %s requested\n", audio_server);
 		}

--- a/tools/test-runner.c
+++ b/tools/test-runner.c
@@ -136,6 +136,20 @@ static const char *config_table[] = {
 	NULL
 };
 
+static void enable_printk(void)
+{
+	FILE *f;
+
+	/* Set non-quiet printk level */
+	f = fopen("/proc/sys/kernel/printk", "w");
+	if (!f) {
+		perror("Failed to set printk");
+		return;
+	}
+	fprintf(f, "7 4 1 7");
+	fclose(f);
+}
+
 static void prepare_sandbox(void)
 {
 	int i;
@@ -181,6 +195,8 @@ static void prepare_sandbox(void)
 				"mode=0755") < 0)
 			perror("Failed to create filesystem");
 	}
+
+	enable_printk();
 }
 
 static char *const qemu_argv[] = {


### PR DESCRIPTION
It is useful to see WARN_ON/bt_dev_err messages when running the tests.
Enable non-quiet printk levels after boot, so that it is on by default
and doesn't need to be handled in local test scripts.
---

Notes:
    It could be useful to also check for BUG/WARNING in the bluez test bot.

 tools/test-runner.c | 16 ++++++++++++++++
 1 file changed, 16 insertions(+)