### PR TITLE
[PW_SID:772324] [BlueZ,RFC] profile: Add probe_on_discover flag

### DIFF
--- a/src/profile.h
+++ b/src/profile.h
@@ -33,6 +33,11 @@ struct btd_profile {
 	 */
 	bool experimental;
 
+	/* Indicates the profile needs to be probed when the remote_uuid is
+	 * discovered.
+	 */
+	bool probe_on_discover;
+
 	int (*device_probe) (struct btd_service *service);
 	void (*device_remove) (struct btd_service *service);
 


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

This adds probe_on_discover flag which indicates if profile needs to be
probed when the remote_uuid is discovered and changes device logic to
attempt to probe driver when a new UUID is discovered and
probe_on_discover is set.
---
 src/device.c  | 22 +++++++++++++++++-----
 src/profile.h |  5 +++++
 2 files changed, 22 insertions(+), 5 deletions(-)