### PR TITLE
[PW_SID:774181] Makefile.am: Install D-Bus policy in /usr/share, not /etc

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -32,7 +32,7 @@ confdir = $(sysconfdir)/bluetooth
 statedir = $(localstatedir)/lib/bluetooth
 
 if DATAFILES
-dbusdir = $(DBUS_CONFDIR)/dbus-1/system.d
+dbusdir = $(datadir)/dbus-1/system.d
 dbus_DATA = src/bluetooth.conf
 
 conf_DATA =


### PR DESCRIPTION
From https://bugs.debian.org/1006631:

> dbus supports policy files in both `/usr/share/dbus-1/system.d` and
> `/etc/dbus-1/systemd`. [The] recently released dbus 1.14.0, officially
> deprecates installing packages' default policies into `/etc/dbus-1/systemd`,
> instead reserving it for the sysadmin. This is the same idea as the
> difference between `/usr/lib/udev/rules.d` and `/etc/udev/rules.d`.
---
 Makefile.am | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)