### PR TITLE
[PW_SID:774386] configure.ac: Install D-Bus policy in /usr/share, not /etc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -95,7 +95,7 @@ AC_ARG_WITH([dbusconfdir], AS_HELP_STRING([--with-dbusconfdir=DIR],
 					[path_dbusconfdir=${withval}])
 if (test -z "${path_dbusconfdir}"); then
 	AC_MSG_CHECKING([D-Bus configuration directory])
-	path_dbusconfdir="`$PKG_CONFIG --variable=sysconfdir dbus-1`"
+	path_dbusconfdir="`$PKG_CONFIG --variable=datadir dbus-1`"
 	if (test -z "${path_dbusconfdir}"); then
 		AC_MSG_ERROR([D-Bus configuration directory is required])
 	fi

--- a/configure.ac
+++ b/configure.ac
@@ -85,8 +85,8 @@ if (test "${enable_threads}" = "yes"); then
 	GLIB_LIBS="$GLIB_LIBS $GTHREAD_LIBS"
 fi
 
-PKG_CHECK_MODULES(DBUS, dbus-1 >= 1.6, dummy=yes,
-				AC_MSG_ERROR(D-Bus >= 1.6 is required))
+PKG_CHECK_MODULES(DBUS, dbus-1 >= 1.10, dummy=yes,
+				AC_MSG_ERROR(D-Bus >= 1.10 is required))
 AC_SUBST(DBUS_CFLAGS)
 AC_SUBST(DBUS_LIBS)
 


### PR DESCRIPTION
D-Bus 1.10, released in 2015, is the first version that supports reading
policy files from `/usr/share/dbus-1` in addition to `/etc/dbus-1`.

The previous minimum version, 1.6, was released in 2012.
---
 configure.ac | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)