### PR TITLE
[PW_SID:777134] [BlueZ] profile: Remove probe_on_discover

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -3930,17 +3930,13 @@ static bool device_match_profile(struct btd_device *device,
 					struct btd_profile *profile,
 					GSList *uuids)
 {
+	GSList *l;
+
 	if (profile->remote_uuid == NULL)
 		return false;
 
-	/* Don't match if device was just discovered, is temporary, and the
-	 * profile don't have probe_on_discover flag set.
-	 */
-	if (device->temporary && !profile->probe_on_discover)
-		return false;
-
-	if (g_slist_find_custom(uuids, profile->remote_uuid,
-							bt_uuid_strcmp) == NULL)
+	l = g_slist_find_custom(uuids, profile->remote_uuid, bt_uuid_strcmp);
+	if (!l)
 		return false;
 
 	return true;
@@ -4902,8 +4898,6 @@ void device_probe_profiles(struct btd_device *device, GSList *uuids)
 		DBG("Skipping profiles for blocked device %s", addr);
 		goto add_uuids;
 	}
-
-	DBG("Probing profiles for device %s", addr);
 
 	btd_profile_foreach(dev_probe, &d);
 
@@ -6932,9 +6926,6 @@ void btd_device_add_uuid(struct btd_device *device, const char *uuid)
 	GSList *uuid_list;
 	char *new_uuid;
 
-	if (g_slist_find_custom(device->uuids, uuid, bt_uuid_strcmp))
-		return;
-
 	new_uuid = g_strdup(uuid);
 	uuid_list = g_slist_append(NULL, new_uuid);
 
@@ -6942,11 +6933,6 @@ void btd_device_add_uuid(struct btd_device *device, const char *uuid)
 
 	g_free(new_uuid);
 	g_slist_free(uuid_list);
-
-	store_device_info(device);
-
-	g_dbus_emit_property_changed(dbus_conn, device->path,
-						DEVICE_INTERFACE, "UUIDs");
 }
 
 static sdp_list_t *read_device_records(struct btd_device *device)

--- a/src/profile.h
+++ b/src/profile.h
@@ -33,11 +33,6 @@ struct btd_profile {
 	 */
 	bool experimental;
 
-	/* Indicates the profile needs to be probed when the remote_uuid is
-	 * discovered.
-	 */
-	bool probe_on_discover;
-
 	int (*device_probe) (struct btd_service *service);
 	void (*device_remove) (struct btd_service *service);
 


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

The concept of probing not connected devices is already supported when
loading devices from storage, so drivers shall already be capabable of
handling such a thing as there are dedicated callbacks to indicate when
there is a new connection in the form of .accept callback.
---
 src/device.c  | 22 ++++------------------
 src/profile.h |  5 -----
 2 files changed, 4 insertions(+), 23 deletions(-)