### PR TITLE
[PW_SID:777635] [BlueZ,1/4] vhci: Add function to pause processing input from vhci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/emulator/hciemu.c
+++ b/emulator/hciemu.c
@@ -21,6 +21,7 @@
 #include <stdbool.h>
 #include <errno.h>
 #include <sys/socket.h>
+#include <sys/ioctl.h>
 
 #include <glib.h>
 
@@ -41,6 +42,7 @@ struct hciemu_client {
 	guint start_source;
 	guint host_source;
 	guint source;
+	int sock[2];
 };
 
 struct hciemu {
@@ -54,6 +56,8 @@ struct hciemu {
 	hciemu_debug_func_t debug_callback;
 	hciemu_destroy_func_t debug_destroy;
 	void *debug_data;
+
+	unsigned int flush_id;
 };
 
 struct hciemu_command_hook {
@@ -338,6 +342,9 @@ static struct hciemu_client *hciemu_client_new(struct hciemu *hciemu,
 		return NULL;
 	}
 
+	client->sock[0] = sv[0];
+	client->sock[1] = sv[1];
+
 	client->source = create_source_btdev(sv[0], client->dev);
 	client->host_source = create_source_bthost(sv[1], client->host);
 	client->start_source = g_idle_add(start_host, client);
@@ -434,6 +441,9 @@ void hciemu_unref(struct hciemu *hciemu)
 
 	queue_destroy(hciemu->post_command_hooks, destroy_command_hook);
 	queue_destroy(hciemu->clients, hciemu_client_destroy);
+
+	if (hciemu->flush_id)
+		g_source_remove(hciemu->flush_id);
 
 	vhci_close(hciemu->vhci);
 
@@ -743,4 +753,48 @@ bool hciemu_del_hook(struct hciemu *hciemu, enum hciemu_hook_type type,
 	}
 
 	return btdev_del_hook(dev, hook_type, opcode);
+}
+
+static bool client_is_pending(const void *data, const void *match_data)
+{
+	struct hciemu_client *client = (struct hciemu_client *)data;
+	int used, i;
+
+	if (!client->source || !client->host_source)
+		return false;
+
+	for (i = 0; i < 2; ++i) {
+		if (!ioctl(client->sock[i], TIOCOUTQ, &used) && used > 0)
+			return true;
+		if (!ioctl(client->sock[i], TIOCINQ, &used) && used > 0)
+			return true;
+	}
+
+	return false;
+}
+
+static gboolean flush_client_events(gpointer user_data)
+{
+	struct hciemu *hciemu = user_data;
+
+	if (queue_find(hciemu->clients, client_is_pending, NULL))
+		return TRUE;
+
+	hciemu->flush_id = 0;
+
+	util_debug(hciemu->debug_callback, hciemu->debug_data, "vhci: resume");
+	if (hciemu->vhci)
+		vhci_pause_input(hciemu->vhci, false);
+
+	return FALSE;
+}
+
+void hciemu_flush_client_events(struct hciemu *hciemu)
+{
+	if (hciemu->flush_id || !hciemu->vhci)
+		return;
+
+	util_debug(hciemu->debug_callback, hciemu->debug_data, "vhci: pause");
+	vhci_pause_input(hciemu->vhci, true);
+	hciemu->flush_id = g_idle_add(flush_client_events, hciemu);
 }

--- a/emulator/hciemu.h
+++ b/emulator/hciemu.h
@@ -48,6 +48,9 @@ bool hciemu_set_debug(struct hciemu *hciemu, hciemu_debug_func_t callback,
 struct vhci *hciemu_get_vhci(struct hciemu *hciemu);
 struct bthost *hciemu_client_get_host(struct hciemu *hciemu);
 
+/* Process pending client events before new VHCI events */
+void hciemu_flush_client_events(struct hciemu *hciemu);
+
 const char *hciemu_get_address(struct hciemu *hciemu);
 uint8_t *hciemu_get_features(struct hciemu *hciemu);
 

--- a/emulator/vhci.c
+++ b/emulator/vhci.c
@@ -178,6 +178,15 @@ void vhci_close(struct vhci *vhci)
 	vhci_destroy(vhci);
 }
 
+bool vhci_pause_input(struct vhci *vhci, bool paused)
+{
+	if (paused)
+		return io_set_read_handler(vhci->io, NULL, NULL, NULL);
+	else
+		return io_set_read_handler(vhci->io, vhci_read_callback, vhci,
+									NULL);
+}
+
 struct btdev *vhci_get_btdev(struct vhci *vhci)
 {
 	if (!vhci)

--- a/emulator/vhci.h
+++ b/emulator/vhci.h
@@ -31,3 +31,4 @@ int vhci_set_emu_opcode(struct vhci *vhci, uint16_t opcode);
 int vhci_set_force_static_address(struct vhci *vhci, bool enable);
 int vhci_force_devcd(struct vhci *vhci, const void *data, size_t len);
 int vhci_read_devcd(struct vhci *vhci, void *buf, size_t size);
+bool vhci_pause_input(struct vhci *vhci, bool paused);


### PR DESCRIPTION
Add function to pause (temporarily) reading data from vhci.  This can be
used to synchronously pause handling of btdev commands from the kernel.
---
 emulator/vhci.c | 9 +++++++++
 emulator/vhci.h | 1 +
 2 files changed, 10 insertions(+)