### PR TITLE
[PW_SID:777963] [Bluez,v1] adapter: check wake_override when setting device privacy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/src/adapter.c
+++ b/src/adapter.c
@@ -5520,6 +5520,8 @@ static void add_device_complete(uint8_t status, uint16_t length,
 	if (btd_opts.device_privacy) {
 		uint32_t flags = btd_device_get_current_flags(dev);
 
+		if (device_get_wake_override(dev))
+			flags |= DEVICE_FLAG_REMOTE_WAKEUP;
 		/* Set Device Privacy Mode has not set the flag yet. */
 		if (!(flags & DEVICE_FLAG_DEVICE_PRIVACY)) {
 			adapter_set_device_flags(adapter, dev, flags |

--- a/src/device.c
+++ b/src/device.c
@@ -1545,6 +1545,11 @@ void device_set_wake_override(struct btd_device *device, bool wake_override)
 	}
 }
 
+bool device_get_wake_override(struct btd_device *device)
+{
+	return device->wake_override;
+}
+
 static void device_set_wake_allowed_complete(struct btd_device *device)
 {
 	if (device->wake_id != -1U) {

--- a/src/device.h
+++ b/src/device.h
@@ -141,6 +141,7 @@ void device_set_wake_support(struct btd_device *device, bool wake_support);
 void device_set_wake_override(struct btd_device *device, bool wake_override);
 void device_set_wake_allowed(struct btd_device *device, bool wake_allowed,
 			     guint32 id);
+bool device_get_wake_override(struct btd_device *device);
 void device_set_refresh_discovery(struct btd_device *dev, bool refresh);
 
 typedef void (*disconnect_watch) (struct btd_device *device, gboolean removal,


### PR DESCRIPTION
For the device using a RPA, hog_probe sets wake_override to true, but
the command to set remote wakeup fails because the device has not been
added to the kernel and the connection with the public address cannot be
found.

When setting the device privacy flag, the wakeup flag should be set
according to the wake_override, instead of the current flags.

Signed-off-by: Zhengping Jiang <jiangzp@google.com>
---

Changes in v1:
- Add function to fetch wake_override value
- Set the remote wakeup bit if privacy mode is used when setting flags

 src/adapter.c | 2 ++
 src/device.c  | 5 +++++
 src/device.h  | 1 +
 3 files changed, 8 insertions(+)