### PR TITLE
[PW_SID:778839] [BlueZ] transport: Fix crash with broadcast properties

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/profiles/audio/transport.c
+++ b/profiles/audio/transport.c
@@ -1199,7 +1199,7 @@ static gboolean get_timeout(const GDBusPropertyTable *property,
 	return TRUE;
 }
 
-static const GDBusPropertyTable bap_properties[] = {
+static const GDBusPropertyTable bap_ucast_properties[] = {
 	{ "Device", "o", get_device },
 	{ "UUID", "s", get_uuid },
 	{ "Codec", "y", get_codec },
@@ -1218,6 +1218,16 @@ static const GDBusPropertyTable bap_properties[] = {
 	{ "Location", "u", get_location },
 	{ "Metadata", "ay", get_metadata },
 	{ "Links", "ao", get_links, NULL, links_exists },
+	{ }
+};
+
+
+static const GDBusPropertyTable bap_bcast_properties[] = {
+	{ "Device", "o", get_device },
+	{ "UUID", "s", get_uuid },
+	{ "Codec", "y", get_codec },
+	{ "Configuration", "ay", get_configuration },
+	{ "State", "s", get_state },
 	{ "BIG", "y", get_big, NULL, qos_exists },
 	{ "BIS", "y", get_bis, NULL, qos_exists },
 	{ "SyncInterval", "y", get_sync_interval, NULL, qos_exists },
@@ -1229,6 +1239,9 @@ static const GDBusPropertyTable bap_properties[] = {
 	{ "SyncCteType", "y", get_sync_cte_type, NULL, qos_exists },
 	{ "MSE", "y", get_mse, NULL, qos_exists },
 	{ "Timeout", "q", get_timeout, NULL, qos_exists },
+	{ "Endpoint", "o", get_endpoint, NULL, endpoint_exists },
+	{ "Location", "u", get_location },
+	{ "Metadata", "ay", get_metadata },
 	{ }
 };
 
@@ -1876,12 +1889,15 @@ struct media_transport *media_transport_create(struct btd_device *device,
 			goto fail;
 		properties = a2dp_properties;
 	} else if (!strcasecmp(uuid, PAC_SINK_UUID) ||
-				!strcasecmp(uuid, PAC_SOURCE_UUID) ||
-				!strcasecmp(uuid, BCAA_SERVICE_UUID) ||
+				!strcasecmp(uuid, PAC_SOURCE_UUID)) {
+		if (media_transport_init_bap(transport, stream) < 0)
+			goto fail;
+		properties = bap_ucast_properties;
+	} else if (!strcasecmp(uuid, BCAA_SERVICE_UUID) ||
 				!strcasecmp(uuid, BAA_SERVICE_UUID)) {
 		if (media_transport_init_bap(transport, stream) < 0)
 			goto fail;
-		properties = bap_properties;
+		properties = bap_bcast_properties;
 	} else
 		goto fail;
 


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

When connecting a BAP unicast stream the followin crash can be observed:

Access not within mapped region at address 0x1D4C0000000A
  at 0x14F759: get_bcode (transport.c:1121)
  by 0x1E02E4: append_property.isra.0 (object.c:498)
  by 0x1E03B9: append_properties (object.c:527)
  by 0x1E2AAB: g_dbus_get_properties (object.c:1811)
  by 0x14B9B6: pac_config (media.c:1130)
---
 profiles/audio/transport.c | 24 ++++++++++++++++++++----
 1 file changed, 20 insertions(+), 4 deletions(-)