### PR TITLE
[PW_SID:780014] [BlueZ] shared/gatt-client: Fix not sending confirmations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/src/shared/gatt-client.c
+++ b/src/shared/gatt-client.c
@@ -2232,10 +2232,10 @@ static void notify_cb(struct bt_att_chan *chan, uint8_t opcode,
 	struct bt_gatt_client *client = user_data;
 	struct value_data data;
 
-	if (queue_isempty(client->notify_list))
-		return;
-
 	bt_gatt_client_ref(client);
+
+	if (queue_isempty(client->notify_list))
+		goto done;
 
 	memset(&data, 0, sizeof(data));
 
@@ -2271,6 +2271,7 @@ static void notify_cb(struct bt_att_chan *chan, uint8_t opcode,
 		queue_foreach(client->notify_list, notify_handler, &data);
 	}
 
+done:
 	if (opcode == BT_ATT_OP_HANDLE_IND && !client->parent)
 		bt_att_chan_send(chan, BT_ATT_OP_HANDLE_CONF, NULL, 0,
 							NULL, NULL, NULL);


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

Commit fde32ff9c9c0 ("shared/gatt-client: Allow registering with NULL
callback") added an early return to the notify_cb function when the
current client's notify_list is empty which prevents sending
confirmations to indications.

Reported-by: Javier de San Pedro <dev.git@javispedro.com>
---
 src/shared/gatt-client.c | 7 ++++---
 1 file changed, 4 insertions(+), 3 deletions(-)