### PR TITLE
[PW_SID:780614] Set device non temp when synchronized with bcast source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/profiles/audio/bap.c
+++ b/profiles/audio/bap.c
@@ -658,6 +658,9 @@ static void bap_io_close(struct bap_ep *ep)
 	g_io_channel_unref(ep->io);
 	ep->io = NULL;
 	ep->cig_active = false;
+
+	if (bt_bap_pac_get_type(ep->lpac) == BT_BAP_BCAST_SINK)
+		btd_device_set_temporary(ep->data->device, true);
 }
 
 static DBusMessage *set_configuration(DBusConnection *conn, DBusMessage *msg,
@@ -796,6 +799,8 @@ static void iso_bcast_confirm_cb(GIOChannel *io, GError *err, void *user_data)
 		g_error_free(err);
 		goto drop;
 	}
+
+	btd_device_set_temporary(data->device, false);
 
 	g_io_channel_ref(io);
 	btd_service_connecting_complete(data->service, 0);

--- a/src/device.c
+++ b/src/device.c
@@ -5945,8 +5945,17 @@ void btd_device_set_temporary(struct btd_device *device, bool temporary)
 	if (device->temporary == temporary)
 		return;
 
-	if (device_address_is_private(device))
-		return;
+	if (device_address_is_private(device)) {
+		/* For audio LE broadcast, we need to set the device
+		 * temporary flag even if the address is private.
+		 * If the device that is temporarily set on
+		 * has BCAA_SERVICE_UUID (is a broadcast source)
+		 * will set the temporary flag even if the address
+		 * is private.
+		 */
+		if (!btd_device_has_uuid(device, BCAA_SERVICE_UUID))
+			return;
+	}
 
 	DBG("temporary %d", temporary);
 


### PR DESCRIPTION
For audio LE broadcast we need to set the device temporary flag eaven
if the address is private

---
 src/device.c | 13 +++++++++++--
 1 file changed, 11 insertions(+), 2 deletions(-)