### PR TITLE
[PW_SID:780953] [BlueZ] monitor: Fix runtime error

### DIFF
--- a/monitor/packet.c
+++ b/monitor/packet.c
@@ -10473,11 +10473,14 @@ static void packet_dequeue_tx(struct timeval *tv, uint16_t handle)
 
 	packet_latency_add(&conn->tx_l, &delta);
 
-	print_field("#%zu: len %zu (%lld Kb/s)", frame->num, frame->len,
-					frame->len * 8 / TV_MSEC(delta));
-	print_field("Latency: %lld msec (%lld-%lld msec ~%lld msec)",
-			TV_MSEC(delta), TV_MSEC(conn->tx_l.min),
-			TV_MSEC(conn->tx_l.max), TV_MSEC(conn->tx_l.med));
+	if (TV_MSEC(delta)) {
+		print_field("#%zu: len %zu (%lld Kb/s)", frame->num, frame->len,
+				frame->len * 8 / TV_MSEC(delta));
+		print_field("Latency: %lld msec (%lld-%lld msec ~%lld msec)",
+				TV_MSEC(delta), TV_MSEC(conn->tx_l.min),
+				TV_MSEC(conn->tx_l.max),
+				TV_MSEC(conn->tx_l.med));
+	}
 
 	l2cap_dequeue_frame(&delta, conn);
 


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

This fixes the following runtime error:

monitor/packet.c:10476:2: runtime error: division by zero
Floating point exception
---
 monitor/packet.c | 13 ++++++++-----
 1 file changed, 8 insertions(+), 5 deletions(-)