### PR TITLE
[PW_SID:782332] [BlueZ,1/2] main.conf: Fix printing errors for valid options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/src/main.c
+++ b/src/main.c
@@ -85,6 +85,7 @@ static const char *supported_options[] = {
 	"Privacy",
 	"JustWorksRepairing",
 	"TemporaryTimeout",
+	"RefreshDiscovery",
 	"Experimental",
 	"KernelExperimental",
 	"RemoteNameRequestRetryDelay",
@@ -149,6 +150,7 @@ static const char *gatt_options[] = {
 
 static const char *csip_options[] = {
 	"SIRK",
+	"Encryption",
 	"Size",
 	"Rank",
 	NULL

--- a/src/main.conf
+++ b/src/main.conf
@@ -270,10 +270,10 @@
 
 # SIRK Encryption
 # Possible values:
-# yes: Encrypt SIRK when read
-# no: Do not encrypt SIRK when read. (plaintext)
-# Defaults to yes
-#Encryption = yes
+# true: Encrypt SIRK when read
+# false: Do not encrypt SIRK when read. (plaintext)
+# Defaults to true
+#Encryption = true
 
 # Total no of sets belongs to this Profile
 # Defaults to 0


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

This fixes the following errors:

Unknown key RefreshDiscovery for group General
Unknown key Encryption for group CSIS

Fixes: https://github.com/bluez/bluez/issues/583
---
 src/main.c | 2 ++
 1 file changed, 2 insertions(+)