### PR TITLE
[PW_SID:783189] [BlueZ] main.conf: Fix parsing of uint32_t values

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/src/main.c
+++ b/src/main.c
@@ -440,9 +440,9 @@ static bool parse_config_string(GKeyFile *config, const char *group,
 
 static bool parse_config_int(GKeyFile *config, const char *group,
 					const char *key, int *val,
-					int min, int max)
+					size_t min, size_t max)
 {
-	int tmp;
+	size_t tmp;
 	char *str = NULL;
 	char *endptr = NULL;
 
@@ -456,12 +456,14 @@ static bool parse_config_int(GKeyFile *config, const char *group,
 	}
 
 	if (tmp < min) {
-		warn("%s.%s = %d is out of range (< %d)", group, key, tmp, min);
+		warn("%s.%s = %zu is out of range (< %zu)", group, key, tmp,
+									min);
 		return false;
 	}
 
 	if (tmp > max) {
-		warn("%s.%s = %d is out of range (> %d)", group, key, tmp, max);
+		warn("%s.%s = %zu is out of range (> %zu)", group, key, tmp,
+									max);
 		return false;
 	}
 
@@ -774,7 +776,7 @@ static bool parse_config_u32(GKeyFile *config, const char *group,
 {
 	int tmp;
 
-	if (!parse_config_int(config, group, key, &tmp, 0, UINT32_MAX))
+	if (!parse_config_int(config, group, key, &tmp, min, max))
 		return false;
 
 	if (val)


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

Passing UINT32_MAX as int may overfollow causing errors such as:

bluetoothd[2688495]: src/main.c:parse_config_int()
General.TemporaryTimeout = 60 is out of range (> -1)

Fixes: https://github.com/bluez/bluez/issues/583#issuecomment-1713447461
---
 src/main.c | 12 +++++++-----
 1 file changed, 7 insertions(+), 5 deletions(-)