### PR TITLE
[PW_SID:783275] client/player: Add command for control of BIS encryption

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/client/player.c
+++ b/client/player.c
@@ -3196,6 +3196,28 @@ done:
 	return bt_shell_noninteractive_quit(EXIT_SUCCESS);
 }
 
+static void cmd_encryption_endpoint(int argc, char *argv[])
+{
+
+	uint8_t value;
+
+	if (argc < 2) {
+		bt_shell_printf("Encryption: %s\n",
+				bcast_qos.bcast.encryption ? "on" : "off");
+		return bt_shell_noninteractive_quit(EXIT_SUCCESS);
+	}
+
+	if (!strcmp(argv[1], "on") || !strcmp(argv[1], "yes"))
+		value = 1;
+	else if (!strcmp(argv[1], "off") || !strcmp(argv[1], "no"))
+		value = 0;
+	else
+		return bt_shell_noninteractive_quit(EXIT_FAILURE);
+
+	bcast_qos.bcast.encryption = value;
+	return bt_shell_noninteractive_quit(EXIT_SUCCESS);
+}
+
 static const struct bt_shell_menu endpoint_menu = {
 	.name = "endpoint",
 	.desc = "Media Endpoint Submenu",
@@ -3221,6 +3243,10 @@ static const struct bt_shell_menu endpoint_menu = {
 						cmd_presets_endpoint,
 						"List available presets",
 						uuid_generator },
+	{ "encryption",    "[on/off]",
+						cmd_encryption_endpoint,
+						"Enable/disable BIS encryption (mode 3 security)",
+						NULL },
 	{} },
 };
 


### PR DESCRIPTION
Currently there is no way to set the BIS encryption from
the bluetoothctl application. This commit adds support
for one.

Usage:
	encryption [on/off]
---
 client/player.c | 26 ++++++++++++++++++++++++++
 1 file changed, 26 insertions(+)