### PR TITLE
[PW_SID:785020] [BlueZ,V2] configure.ac: Add enable_btpclient and enable_mesh for internal ELL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/configure.ac
+++ b/configure.ac
@@ -301,7 +301,8 @@ if (test "${enable_external_ell}" = "yes"); then
 	AC_SUBST(ELL_CFLAGS)
 	AC_SUBST(ELL_LIBS)
 fi
-if (test "${enable_external_ell}" != "yes"); then
+if (test "${enable_external_ell}" != "yes" &&
+		(test "${enable_btpclient}" = "yes" || test "${enable_mesh}" = "yes")); then
 	if (test ! -f ${srcdir}/ell/ell.h) &&
 			(test ! -f ${srcdir}/../ell/ell/ell.h); then
 				AC_MSG_ERROR(ELL source is required or use --enable-external-ell)


### PR DESCRIPTION
when checking enable_external_ell != 'yes',
even enable_btpclient and enable_mesh are not enabled.
configure still prompt the error.
Then ELL must be installed to pass the configure.

Signed-off-by: Koba Ko <koba.ko@canonical.com>
~~~
V2:
* correct the wrong-spelling
* add BlueZ tag
* rephrase the commit description
* change the '&&' to '||' condition.
---
 configure.ac | 3 ++-
 1 file changed, 2 insertions(+), 1 deletion(-)