### PR TITLE
[PW_SID:785362] [BlueZ] shared/log: Fix not checking vasprintf return

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/src/shared/log.c
+++ b/src/shared/log.c
@@ -135,7 +135,7 @@ int bt_log_vprintf(uint16_t index, const char *label, int level,
 	int len;
 
 	len = vasprintf(&str, format, ap);
-	if (len < 0)
+	if (len < 0 || !str)
 		return errno;
 
 	len = strlen(str);


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

It seems like some implementation of vasprintf set the content of the
str to NULL rather then returning -1 causing the following errors:

=================================================================
==216204==ERROR: AddressSanitizer: attempting free on address which
was not malloc()-ed: 0x55e787722cf0 in thread T0
      #0 0x55e784f75872 in __interceptor_free.part.0 asan_malloc_linux.cpp.o
      #1 0x55e7850e55f9 in bt_log_vprintf
/usr/src/debug/bluez-git/bluez-git/src/shared/log.c:154:2
      #2 0x55e78502db18 in monitor_log
/usr/src/debug/bluez-git/bluez-git/src/log.c:40:2
      #3 0x55e78502dab4 in info
/usr/src/debug/bluez-git/bluez-git/src/log.c:52:2
      #4 0x55e78502e314 in __btd_log_init
/usr/src/debug/bluez-git/bluez-git/src/log.c:179:2
      #5 0x55e78502aa63 in main
/usr/src/debug/bluez-git/bluez-git/src/main.c:1388:2
      #6 0x7f1d5fe27ccf  (/usr/lib/libc.so.6+0x27ccf) (BuildId:
316d0d3666387f0e8fb98773f51aa1801027c5ab)
      #7 0x7f1d5fe27d89 in __libc_start_main
(/usr/lib/libc.so.6+0x27d89) (BuildId:
316d0d3666387f0e8fb98773f51aa1801027c5ab)
      #8 0x55e784e88084 in _start
(/usr/lib/bluetooth/bluetoothd+0x36084) (BuildId:
19348ea642303b701c033d773055becb623fe79a)
  Address 0x55e787722cf0 is a wild pointer inside of access range of
size 0x000000000001.
  SUMMARY: AddressSanitizer: bad-free asan_malloc_linux.cpp.o in
__interceptor_free.part.0
  ==216204==ABORTING
сен 18 13:10:02 archlinux systemd[1]: bluetooth.service: Main process
exited, code=exited, status=1/FAILURE
---
 src/shared/log.c | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)