### PR TITLE
[PW_SID:785720] [BlueZ] pbap: Fix not checking Primary/Secundary Counter length

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/obexd/client/pbap.c
+++ b/obexd/client/pbap.c
@@ -285,7 +285,7 @@ static void read_version(struct pbap_data *pbap, GObexApparam *apparam)
 		data = value;
 	}
 
-	if (memcmp(pbap->primary, data, len)) {
+	if (len == sizeof(pbap->primary) && memcmp(pbap->primary, data, len)) {
 		memcpy(pbap->primary, data, len);
 		g_dbus_emit_property_changed(conn,
 					obc_session_get_path(pbap->session),
@@ -299,7 +299,8 @@ static void read_version(struct pbap_data *pbap, GObexApparam *apparam)
 		data = value;
 	}
 
-	if (memcmp(pbap->secondary, data, len)) {
+	if (len == sizeof(pbap->secondary) &&
+			memcmp(pbap->secondary, data, len)) {
 		memcpy(pbap->secondary, data, len);
 		g_dbus_emit_property_changed(conn,
 					obc_session_get_path(pbap->session),


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

Primary/Secundary Counters are supposed to be 16 bytes values, if the
server has implemented them incorrectly it may lead to the following
crash:

=================================================================
==31860==ERROR: AddressSanitizer: heap-buffer-overflow on address
0x607000001878 at pc 0x7f95a1575638 bp 0x7fff58c6bb80 sp 0x7fff58c6b328

 READ of size 48 at 0x607000001878 thread T0
     #0 0x7f95a1575637 in MemcmpInterceptorCommon(void*, int (*)(void const*, void const*, unsigned long), void const*, void const*, unsigned long) ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:860
     #1 0x7f95a1575ba6 in __interceptor_memcmp ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:892
     #2 0x7f95a1575ba6 in __interceptor_memcmp ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:887
     #3 0x564df69c77a0 in read_version obexd/client/pbap.c:288
     #4 0x564df69c77a0 in read_return_apparam obexd/client/pbap.c:352
     #5 0x564df69c77a0 in phonebook_size_callback obexd/client/pbap.c:374
     #6 0x564df69bea3c in session_terminate_transfer obexd/client/session.c:921
     #7 0x564df69d56b0 in get_xfer_progress_first obexd/client/transfer.c:729
     #8 0x564df698b9ee in handle_response gobex/gobex.c:1140
     #9 0x564df698cdea in incoming_data gobex/gobex.c:1385
     #10 0x7f95a12fdc43 in g_main_context_dispatch (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x55c43)
     #11 0x7f95a13526c7  (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0xaa6c7)
     #12 0x7f95a12fd2b2 in g_main_loop_run (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x552b2)
     #13 0x564df6977d41 in main obexd/src/main.c:307
     #14 0x7f95a10a7d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
     #15 0x7f95a10a7e3f in __libc_start_main_impl ../csu/libc-start.c:392
     #16 0x564df6978704 in _start (/usr/local/libexec/bluetooth/obexd+0x8b704)
 0x607000001878 is located 0 bytes to the right of 72-byte region [0x607000001830,0x607000001878)

 allocated by thread T0 here:
     #0 0x7f95a1595a37 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
     #1 0x564df69c8b6a in pbap_probe obexd/client/pbap.c:1259
---
 obexd/client/pbap.c | 5 +++--
 1 file changed, 3 insertions(+), 2 deletions(-)