### PR TITLE
[PW_SID:786290] client/player: Allow the user to control BIG encryption

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/client/player.c
+++ b/client/player.c
@@ -2750,10 +2750,10 @@ static void cmd_config_endpoint(int argc, char *argv[])
 	const struct capabilities *cap;
 	char *uuid;
 	uint8_t codec_id;
-	bool broadcast = false;
+	bool local_ep_not_provided = false;
+	uint8_t bcode_arg_position = 0;
 
 	cfg = new0(struct endpoint_config, 1);
-
 	/* Search for the remote endpoint name on DBUS */
 	cfg->proxy = g_dbus_proxy_lookup(endpoints, NULL, argv[1],
 						BLUEZ_MEDIA_ENDPOINT_INTERFACE);
@@ -2773,7 +2773,7 @@ static void cmd_config_endpoint(int argc, char *argv[])
 		codec_id = strtol(argv[3], NULL, 0);
 		cap = find_capabilities(uuid, codec_id);
 		if (cap) {
-			broadcast = true;
+			local_ep_not_provided = true;
 			cfg->ep = endpoint_new(cap);
 			cfg->ep->preset = find_presets_name(uuid, argv[3]);
 			if (!cfg->ep->preset)
@@ -2785,9 +2785,10 @@ static void cmd_config_endpoint(int argc, char *argv[])
 		}
 	}
 
-	if (((broadcast == false) && (argc > 3)) ||
-		((broadcast == true) && (argc > 4))) {
-		char *preset_name = (broadcast == false)?argv[3]:argv[4];
+	if (((local_ep_not_provided == false) && (argc > 3)) ||
+		((local_ep_not_provided == true) && (argc > 4))) {
+		uint8_t offset = (local_ep_not_provided == false)?0:1;
+		char *preset_name = argv[3 + offset];
 
 		preset = preset_find_name(cfg->ep->preset, preset_name);
 		if (!preset) {
@@ -2795,7 +2796,42 @@ static void cmd_config_endpoint(int argc, char *argv[])
 			goto fail;
 		}
 
+		/* If the endpoint is configured to be a source allow
+		 *the user to decide if encryption is enabled or not.
+		 */
+		if (!strcmp(cfg->ep->uuid, BCAA_SERVICE_UUID) &&
+			argc > 4 + offset) {
+			uint8_t value = strtol(argv[4 + offset],
+							NULL, 0);
+
+			if (value < 2)
+				bcast_qos.bcast.encryption = value;
+			else
+				goto fail;
+		}
+
+		/* If the endpoint is configured to be a source or a
+		 *sink allow the user to set a custom broadcast code.
+		 *If no broadcast code is set, the default will be used.
+		 */
+		if (!strcmp(cfg->ep->uuid, BCAA_SERVICE_UUID) &&
+			(argc > 5 + offset))
+			bcode_arg_position = 5 + offset;
+
+		/*The broadcast code is found at a smaller index due to the sink
+		 *config not using the encryption flag parameter.
+		 */
+		if (!strcmp(cfg->ep->uuid, BAA_SERVICE_UUID) &&
+			argc > 4 + offset)
+			bcode_arg_position = 4  + offset;
+
+		if (bcode_arg_position != 0)
+			for (uint8_t i = 0; i < 16; i++)
+				bcast_qos.bcast.bcode[i] =
+				strtol(argv[bcode_arg_position + i], NULL, 16);
+
 		if (cfg->ep->broadcast) {
+
 			iov_append(&cfg->ep->bcode, bcast_qos.bcast.bcode,
 				sizeof(bcast_qos.bcast.bcode));
 			/* Copy capabilities for broadcast*/
@@ -3213,7 +3249,7 @@ static const struct bt_shell_menu endpoint_menu = {
 						"Register Endpoint",
 						local_endpoint_generator },
 	{ "config",
-		"<endpoint> [local endpoint/UUID] [preset/codec id] [preset]",
+		"<endpoint> [local endpoint/UUID] [preset/codec id] [preset] [encryption] [broadcast code=xx xx ...]",
 						cmd_config_endpoint,
 						"Configure Endpoint",
 						endpoint_generator },


### PR DESCRIPTION
This commit adds support for controling the use of encryption and
setting the broadcast code. This is done as part of the endpoint.config
command. For source endpoints the encryption flag and broadcast code can
be set, while the sink supports only broadcast code setting. If no custom
broadcast code is provided, the default one will be used.
---
 client/player.c | 50 ++++++++++++++++++++++++++++++++++++++++++-------
 1 file changed, 43 insertions(+), 7 deletions(-)