### PR TITLE
[PW_SID:788549] iso-tester: Test bcast receiver with PA sync, no BIS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/tools/iso-tester.c
+++ b/tools/iso-tester.c
@@ -411,6 +411,7 @@ struct iso_client_data {
 	uint8_t pkt_status;
 	const uint8_t *base;
 	size_t base_len;
+	bool bcast_defer_accept;
 };
 
 static void mgmt_debug(const char *str, void *user_data)
@@ -1141,6 +1142,16 @@ static const struct iso_client_data bcast_16_2_1_recv_defer = {
 	.recv = &send_16_2_1,
 	.bcast = true,
 	.server = true,
+	.bcast_defer_accept = true,
+};
+
+static const struct iso_client_data bcast_16_2_1_recv_defer_no_bis = {
+	.qos = QOS_IN_16_2_1,
+	.expect_err = 0,
+	.defer = true,
+	.bcast = true,
+	.server = true,
+	.bcast_defer_accept = false,
 };
 
 static const struct iso_client_data bcast_ac_12 = {
@@ -2257,8 +2268,11 @@ static int listen_iso_sock(struct test_data *data)
 
 		bacpy(&addr->iso_bc->bc_bdaddr, (void *) dst);
 		addr->iso_bc->bc_bdaddr_type = BDADDR_LE_PUBLIC;
-		addr->iso_bc->bc_num_bis = 1;
-		addr->iso_bc->bc_bis[0] = 1;
+
+		if (!isodata->defer || isodata->bcast_defer_accept) {
+			addr->iso_bc->bc_num_bis = 1;
+			addr->iso_bc->bc_bis[0] = 1;
+		}
 
 		err = bind(sk, (struct sockaddr *) addr, sizeof(*addr) +
 						   sizeof(*addr->iso_bc));
@@ -2420,9 +2434,21 @@ static gboolean iso_accept_cb(GIOChannel *io, GIOCondition cond,
 			return false;
 		}
 
-		if (isodata->bcast && data->step > 1) {
-			data->step--;
-			goto connect;
+		if (isodata->bcast) {
+			if (data->step > 1)
+				data->step--;
+			else
+				data->step++;
+
+			iso_connect(io, cond, user_data);
+
+			if (!data->step)
+				return false;
+
+			if (!isodata->bcast_defer_accept) {
+				tester_test_passed();
+				return false;
+			}
 		}
 
 		if (!iso_defer_accept(data, io)) {
@@ -2444,7 +2470,6 @@ static gboolean iso_accept_cb(GIOChannel *io, GIOCondition cond,
 		}
 	}
 
-connect:
 	return iso_connect(io, cond, user_data);
 }
 
@@ -3029,6 +3054,10 @@ int main(int argc, char *argv[])
 							test_bcast_recv);
 	test_iso("ISO Broadcaster Receiver Defer - Success",
 						&bcast_16_2_1_recv_defer,
+						setup_powered,
+						test_bcast_recv);
+	test_iso("ISO Broadcaster Receiver Defer No BIS - Success",
+						&bcast_16_2_1_recv_defer_no_bis,
 						setup_powered,
 						test_bcast_recv);
 


### PR DESCRIPTION
This tests that a broadcast receiver is able to successfully sync to the
PA transmitted by a source, without performing BIS sync also:

ISO Broadcaster Receiver Defer No BIS - Success

---
 tools/iso-tester.c | 41 +++++++++++++++++++++++++++++++++++------
 1 file changed, 35 insertions(+), 6 deletions(-)