### PR TITLE
[PW_SID:789421] [BlueZ,1/6] shared/csip: Fix returning invalid data to attribute Size reads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/src/device.c
+++ b/src/device.c
@@ -1938,6 +1938,23 @@ void device_set_ltk(struct btd_device *device, const uint8_t val[16],
 	queue_foreach(device->sirks, add_set, device);
 }
 
+bool btd_device_get_ltk(struct btd_device *device, uint8_t key[16],
+				bool *central, uint8_t *enc_size)
+{
+	if (!device || !device->ltk || !key)
+		return false;
+
+	memcpy(key, device->ltk->key, sizeof(device->ltk->key));
+
+	if (central)
+		*central = device->ltk->central;
+
+	if (enc_size)
+		*enc_size = device->ltk->enc_size;
+
+	return true;
+}
+
 static bool match_sirk(const void *data, const void *match_data)
 {
 	const struct sirk_info *sirk = data;

--- a/src/device.h
+++ b/src/device.h
@@ -132,6 +132,8 @@ void device_request_disconnect(struct btd_device *device, DBusMessage *msg);
 bool device_is_disconnecting(struct btd_device *device);
 void device_set_ltk(struct btd_device *device, const uint8_t val[16],
 				bool central, uint8_t enc_size);
+bool btd_device_get_ltk(struct btd_device *device, uint8_t val[16],
+				bool *central, uint8_t *enc_size);
 bool btd_device_add_set(struct btd_device *device, bool encrypted,
 				uint8_t sirk[16], uint8_t size, uint8_t rank);
 void device_store_svc_chng_ccc(struct btd_device *device, uint8_t bdaddr_type,

--- a/src/main.c
+++ b/src/main.c
@@ -1195,6 +1195,7 @@ static void init_defaults(void)
 	btd_opts.avdtp.stream_mode = BT_IO_MODE_BASIC;
 
 	btd_opts.advmon.rssi_sampling_period = 0xFF;
+	btd_opts.csis.encrypt = true;
 }
 
 static void log_handler(const gchar *log_domain, GLogLevelFlags log_level,

--- a/src/shared/csip.c
+++ b/src/shared/csip.c
@@ -721,7 +721,8 @@ static struct csis_sirk *sirk_new(struct bt_csis *csis, struct gatt_db *db,
 	bt_uuid16_create(&uuid, CS_SIRK);
 	csis->sirk = gatt_db_service_add_characteristic(csis->service,
 					&uuid,
-					BT_ATT_PERM_READ,
+					BT_ATT_PERM_READ |
+					BT_ATT_PERM_READ_ENCRYPT,
 					BT_GATT_CHRC_PROP_READ,
 					csis_sirk_read, NULL,
 					csis);
@@ -729,7 +730,8 @@ static struct csis_sirk *sirk_new(struct bt_csis *csis, struct gatt_db *db,
 	bt_uuid16_create(&uuid, CS_SIZE);
 	csis->size = gatt_db_service_add_characteristic(csis->service,
 					&uuid,
-					BT_ATT_PERM_READ,
+					BT_ATT_PERM_READ |
+					BT_ATT_PERM_READ_ENCRYPT,
 					BT_GATT_CHRC_PROP_READ,
 					csis_size_read, NULL,
 					csis);
@@ -737,7 +739,10 @@ static struct csis_sirk *sirk_new(struct bt_csis *csis, struct gatt_db *db,
 	/* Lock */
 	bt_uuid16_create(&uuid, CS_LOCK);
 	csis->lock = gatt_db_service_add_characteristic(csis->service, &uuid,
-					BT_ATT_PERM_READ,
+					BT_ATT_PERM_READ |
+					BT_ATT_PERM_READ_ENCRYPT |
+					BT_ATT_PERM_WRITE |
+					BT_ATT_PERM_WRITE_ENCRYPT,
 					BT_GATT_CHRC_PROP_READ |
 					BT_GATT_CHRC_PROP_WRITE |
 					BT_GATT_CHRC_PROP_NOTIFY,
@@ -751,7 +756,8 @@ static struct csis_sirk *sirk_new(struct bt_csis *csis, struct gatt_db *db,
 	/* Rank */
 	bt_uuid16_create(&uuid, CS_RANK);
 	csis->rank = gatt_db_service_add_characteristic(csis->service, &uuid,
-					BT_ATT_PERM_READ,
+					BT_ATT_PERM_READ |
+					BT_ATT_PERM_READ_ENCRYPT,
 					BT_GATT_CHRC_PROP_READ,
 					csis_rank_read_cb,
 					NULL, csis);

--- a/src/shared/csip.c
+++ b/src/shared/csip.c
@@ -597,7 +597,7 @@ static void foreach_csis_char(struct gatt_db_attribute *attr, void *user_data)
 		DBG(csip, "SIRK found: handle 0x%04x", value_handle);
 
 		csis = csip_get_csis(csip);
-		if (!csis || csis->sirk)
+		if (!csis)
 			return;
 
 		csis->sirk = attr;

--- a/src/shared/csip.c
+++ b/src/shared/csip.c
@@ -291,8 +291,8 @@ static void csis_size_read(struct gatt_db_attribute *attrib,
 	struct bt_csis *csis = user_data;
 	struct iovec iov;
 
-	iov.iov_base = &csis->size;
-	iov.iov_len = sizeof(csis->size);
+	iov.iov_base = &csis->size_val;
+	iov.iov_len = sizeof(csis->size_val);
 
 	gatt_db_attribute_read_result(attrib, id, 0, iov.iov_base,
 							iov.iov_len);

--- a/src/shared/csip.h
+++ b/src/shared/csip.h
@@ -27,8 +27,7 @@ typedef void (*bt_csip_ready_func_t)(struct bt_csip *csip, void *user_data);
 typedef void (*bt_csip_destroy_func_t)(void *user_data);
 typedef void (*bt_csip_debug_func_t)(const char *str, void *user_data);
 typedef void (*bt_csip_func_t)(struct bt_csip *csip, void *user_data);
-typedef bool (*bt_csip_ltk_func_t)(struct bt_csip *csip, uint8_t k[16],
-							void *user_data);
+typedef bool (*bt_csip_encrypt_func_t)(struct bt_att *att, uint8_t k[16]);
 typedef bool (*bt_csip_sirk_func_t)(struct bt_csip *csip, uint8_t type,
 				    uint8_t k[16], uint8_t size, uint8_t rank,
 				    void *user_data);
@@ -54,7 +53,7 @@ struct bt_csip *bt_csip_new(struct gatt_db *ldb, struct gatt_db *rdb);
 
 bool bt_csip_set_sirk(struct bt_csip *csip, bool encrypt,
 				uint8_t k[16], uint8_t size, uint8_t rank,
-				bt_csip_ltk_func_t func, void *user_data);
+				bt_csip_encrypt_func_t func);
 
 bool bt_csip_get_sirk(struct bt_csip *csip, uint8_t *type,
 				uint8_t k[16], uint8_t *size, uint8_t *rank);


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

The attribute Size value is stored in the size_val not on size member
which represents the attribute object.
---
 src/shared/csip.c | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)