### PR TITLE
[PW_SID:793760] [BlueZ] mesh: Fix check for active scan when using generic IO

### DIFF
--- a/mesh/mesh-io-generic.c
+++ b/mesh/mesh-io-generic.c
@@ -781,7 +781,7 @@ static bool recv_register(struct mesh_io *io, const uint8_t *filter,
 	bool already_scanning;
 	bool active = false;
 
-	already_scanning = !l_queue_isempty(io->rx_regs);
+	already_scanning = (l_queue_length(io->rx_regs) > 1);
 
 	/* Look for any AD types requiring Active Scanning */
 	if (l_queue_find(io->rx_regs, find_active, NULL))


### PR DESCRIPTION
This modifies the check for an active scan in generic IO:
the bug has been introduced during earlier code refactoring.

Fixes: https://github.com/bluez/bluez/issues/625
---
 mesh/mesh-io-generic.c | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)