### PR TITLE
[PW_SID:797322] [BlueZ,1/4] doc: extend MediaEndpoint1 API with SelectQoS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/doc/org.bluez.MediaEndpoint.rst
+++ b/doc/org.bluez.MediaEndpoint.rst
@@ -66,6 +66,8 @@ array{byte} SelectConfiguration(array{byte} capabilities)
 	Note: There is no need to cache the selected configuration since on
 	success the configuration is send back as parameter of SetConfiguration.
 
+.. _SelectProperties:
+
 dict SelectProperties(dict capabilities)
 ````````````````````````````````````````
 
@@ -79,7 +81,57 @@ dict SelectProperties(dict capabilities)
 
 	:uint32 Locations:
 
+	See `MediaEndpoint Properties`_ for their possible values.
+
+	Returns a configuration which can be used to setup a transport:
+
+	:array{byte} Capabilities:
+
+		See **org.bluez.MediaTransport(5)**.
+
+	:array{byte} Metadata [optional]:
+
+		See **org.bluez.MediaTransport(5)**.
+
 	:dict QoS:
+
+		See **org.bluez.MediaTransport(5)**.
+
+		The following fields shall be provided:
+
+		:byte TargetLatency:
+		:byte PHY:
+
+		If `SelectQoS`_ is not implemented, then values for
+		all other ``QoS`` fields are also determined by the
+		value returned here.
+
+	Note: There is no need to cache the selected properties since
+	on success the configuration is sent back as parameter of
+	`SetConfiguration`_ and `SelectQoS`_.
+
+.. _SelectQoS:
+
+dict SelectQoS(dict configuration)
+``````````````````````````````````
+
+	Select BAP unicast QoS to be used for a transport, based on
+	server capabilities and selected configuration.
+
+	:object Endpoint:
+
+	:array{byte} Capabilities:
+
+		The configuration, as returned by `SelectProperties`_.
+
+	:array{byte} Metadata [optional]:
+
+		The metadata, as returned by `SelectProperties`_.
+
+	:dict QoS:
+
+		Server endpoint supported and preferred values.	 See
+		`MediaEndpoint Properties`_ for their possible values.
 
 		:byte Framing:
 		:byte PHY:
@@ -89,18 +141,16 @@ dict SelectProperties(dict capabilities)
 		:uint32 PreferredMinimumDelay:
 		:uint32 PreferredMaximumDelay:
 
-	See `MediaEndpoint Properties`_ for their possible values.
+	Returns a QoS configuration which can be used to setup a transport:
 
-	Returns a configuration which can be used to setup a transport:
-
-	:array{byte} Capabilities:
-	:array{byte} Metadata [optional]:
 	:dict QoS:
 
-	See `SetConfiguration`_ for their possible values.
+		See **org.bluez.MediaTransport(5)** QoS property for
+		possible values.
 
-	Note: There is no need to cache the selected properties since on
-	success the configuration is send back as parameter of SetConfiguration.
+	Note: There is no need to cache the selected properties since
+	on success the configuration is sent back as parameter of
+	`SetConfiguration`_.
 
 void ClearConfiguration(object transport)
 `````````````````````````````````````````

--- a/src/shared/bap.c
+++ b/src/shared/bap.c
@@ -4617,17 +4617,34 @@ static bool match_pac(struct bt_bap_pac *lpac, struct bt_bap_pac *rpac,
 	return false;
 }
 
-int bt_bap_select(struct bt_bap_pac *lpac, struct bt_bap_pac *rpac,
-			bt_bap_pac_select_t func, void *user_data)
+int bt_bap_select_codec(struct bt_bap_pac *lpac, struct bt_bap_pac *rpac,
+			bt_bap_pac_select_codec_t func, void *user_data)
 {
 	if (!lpac || !rpac || !func)
 		return -EINVAL;
 
-	if (!lpac->ops || !lpac->ops->select)
+	if (!lpac->ops || !lpac->ops->select_codec)
 		return -EOPNOTSUPP;
 
-	lpac->ops->select(lpac, rpac, &rpac->qos,
-					func, user_data, lpac->user_data);
+	lpac->ops->select_codec(lpac, rpac, func, user_data, lpac->user_data);
+
+	return 0;
+}
+
+int bt_bap_stream_select_qos(struct bt_bap_stream *stream,
+				bt_bap_pac_select_qos_t func, void *user_data)
+{
+	struct bt_bap_pac *lpac = stream->lpac;
+	struct bt_bap_pac *rpac = stream->rpac;
+
+	if (!lpac || !rpac || !func)
+		return -EINVAL;
+
+	if (!lpac->ops || !lpac->ops->select_qos)
+		return -EOPNOTSUPP;
+
+	lpac->ops->select_qos(stream, &rpac->qos, func, user_data,
+							lpac->user_data);
 
 	return 0;
 }
@@ -5122,6 +5139,16 @@ uint32_t bt_bap_stream_get_location(struct bt_bap_stream *stream)
 		 * for brodcast source and sink
 		 */
 		return stream->bap->ldb->pacs->source_loc_value;
+}
+
+struct bt_bap_pac *bt_bap_stream_get_lpac(struct bt_bap_stream *stream)
+{
+	return stream->lpac;
+}
+
+struct bt_bap_pac *bt_bap_stream_get_rpac(struct bt_bap_stream *stream)
+{
+	return stream->rpac;
 }
 
 struct iovec *bt_bap_stream_get_config(struct bt_bap_stream *stream)

--- a/src/shared/bap.h
+++ b/src/shared/bap.h
@@ -104,12 +104,15 @@ typedef void (*bt_bap_pac_func_t)(struct bt_bap_pac *pac, void *user_data);
 typedef bool (*bt_bap_pac_foreach_t)(struct bt_bap_pac *lpac,
 					struct bt_bap_pac *rpac,
 					void *user_data);
-typedef void (*bt_bap_pac_select_t)(struct bt_bap_pac *pac, int err,
+typedef void (*bt_bap_pac_select_codec_t)(struct bt_bap_pac *pac, int err,
 					struct iovec *caps,
 					struct iovec *metadata,
 					struct bt_bap_qos *qos,
 					void *user_data);
 typedef void (*bt_bap_pac_config_t)(struct bt_bap_stream *stream, int err);
+typedef void (*bt_bap_pac_select_qos_t)(struct bt_bap_stream *stream,
+					int err, struct bt_bap_qos *qos,
+					void *user_data);
 typedef void (*bt_bap_state_func_t)(struct bt_bap_stream *stream,
 					uint8_t old_state, uint8_t new_state,
 					void *user_data);
@@ -150,9 +153,12 @@ struct bt_bap_pac *bt_bap_add_pac(struct gatt_db *db, const char *name,
 					struct iovec *metadata);
 
 struct bt_bap_pac_ops {
-	int (*select)(struct bt_bap_pac *lpac, struct bt_bap_pac *rpac,
-			struct bt_bap_pac_qos *qos,
-			bt_bap_pac_select_t cb, void *cb_data, void *user_data);
+	int (*select_codec)(struct bt_bap_pac *lpac, struct bt_bap_pac *rpac,
+			bt_bap_pac_select_codec_t cb, void *cb_data,
+			void *user_data);
+	int (*select_qos)(struct bt_bap_stream *stream,
+			struct bt_bap_pac_qos *qos, bt_bap_pac_select_qos_t cb,
+			void *cb_data, void *user_data);
 	int (*config)(struct bt_bap_stream *stream, struct iovec *cfg,
 			struct bt_bap_qos *qos, bt_bap_pac_config_t cb,
 			void *user_data);
@@ -233,8 +239,8 @@ void bt_bap_pac_set_user_data(struct bt_bap_pac *pac, void *user_data);
 void *bt_bap_pac_get_user_data(struct bt_bap_pac *pac);
 
 /* Stream related functions */
-int bt_bap_select(struct bt_bap_pac *lpac, struct bt_bap_pac *rpac,
-			bt_bap_pac_select_t func, void *user_data);
+int bt_bap_select_codec(struct bt_bap_pac *lpac, struct bt_bap_pac *rpac,
+			bt_bap_pac_select_codec_t func, void *user_data);
 
 struct bt_bap_stream *bt_bap_stream_new(struct bt_bap *bap,
 					struct bt_bap_pac *lpac,
@@ -248,6 +254,9 @@ uint8_t bt_bap_stream_get_state(struct bt_bap_stream *stream);
 bool bt_bap_stream_set_user_data(struct bt_bap_stream *stream, void *user_data);
 
 void *bt_bap_stream_get_user_data(struct bt_bap_stream *stream);
+
+int bt_bap_stream_select_qos(struct bt_bap_stream *stream,
+				bt_bap_pac_select_qos_t func, void *user_data);
 
 unsigned int bt_bap_stream_config(struct bt_bap_stream *stream,
 					struct bt_bap_qos *pqos,
@@ -293,6 +302,8 @@ uint32_t bt_bap_stream_get_location(struct bt_bap_stream *stream);
 struct iovec *bt_bap_stream_get_config(struct bt_bap_stream *stream);
 struct bt_bap_qos *bt_bap_stream_get_qos(struct bt_bap_stream *stream);
 struct iovec *bt_bap_stream_get_metadata(struct bt_bap_stream *stream);
+struct bt_bap_pac *bt_bap_stream_get_lpac(struct bt_bap_stream *stream);
+struct bt_bap_pac *bt_bap_stream_get_rpac(struct bt_bap_stream *stream);
 
 struct io *bt_bap_stream_get_io(struct bt_bap_stream *stream);
 bool bt_bap_match_bcast_sink_stream(const void *data, const void *user_data);


### PR DESCRIPTION
Change unicast BAP configuration to proceed as:

0. SelectProperties(endpoint)
1. ASCS Config Codec
2. ASCS Server notifies ASE
3. SelectQoS(configuration)  [optional]
4. ASCS Config QoS
5. SetConfiguration(transport)

Previously, SelectProperties had to return also the QoS
configuration. However, it is impossible for it to provide it properly,
because the values supported by the server are known only after ASCS
Config Codec.

This resolves the issue by adding a new method call, which is supposed
to return suitable QoS values.

Remove the QoS input parameter from the SelectProperties() call, as the
server supported QoS settings may depend on the codec configuration, and
are not known yet at that point.

For convenience, e.g. when mandatory QoS presets are used, the endpoint
does not need to implement SelectQoS(). In this case the QoS values
returned by SelectProperties are used.
---

Notes:
    Alternative to this is calling SelectProperties() twice at the
    two different stages of the ASE setup steps.
    
    However, if the second SelectProperties() call returns a different
    Capabilities configuration, we'd need to either (i) do Config Codec again
    or (ii) fail the configuration.
    
    Doing Config Codec again introduces a chance of getting stuck looping,
    if client is not behaving correctly, which doesn't sound like good
    design. Failing the configuration raises question why have the
    Capabilities as return parameters at all. So instead, make it a separate
    method.
    
    ***
    
    If two methods is too much, we could in principle get rid of the
    SelectProperties() call and leave only SelectQoS.
    
    Instead, the sound server would call SetConfiguration() on a remote
    endpoint it chooses, and provide the configuration parameters there.
    IIUC, this is how it is supposed to work for BAP Broadcast currently.
    This might need some sort of "Ready" property on the Device1 DBus object
    or elsewhere (e.g. the endpoints), so that it's simple for the sound
    server to wait until all endpoints have been exposed in DBus.
    
    This might also be preferable way to do it, since only the component
    closer to the user i.e. the sound server knows which endpoint the user
    wanted to use, and when BlueZ guesses wrong it avoids needing to tear
    down the old configuration and reconfigure (which we have to do for
    A2DP).
    
    ***
    
    This series was tested also vs. this
    https://gitlab.freedesktop.org/pvir/pipewire/-/commits/bap-selectqos

 doc/org.bluez.MediaEndpoint.rst | 66 +++++++++++++++++++++++++++++----
 1 file changed, 58 insertions(+), 8 deletions(-)