### PR TITLE
[PW_SID:800330] [BlueZ,v2] bap: handle state transitions with old_state == new_state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/profiles/audio/bap.c
+++ b/profiles/audio/bap.c
@@ -1887,7 +1887,11 @@ static void bap_state(struct bt_bap_stream *stream, uint8_t old_state,
 			bt_bap_stream_statestr(old_state), old_state,
 			bt_bap_stream_statestr(new_state), new_state);
 
-	if (new_state == old_state)
+	/* Ignore transitions back to same state (ASCS allows some of these).
+	 * Of these we need to handle only the config->config case, which will
+	 * occur when reconfiguring the codec from initial config state.
+	 */
+	if (new_state == old_state && new_state != BT_BAP_STREAM_STATE_CONFIG)
 		return;
 
 	ep = bap_find_ep_by_stream(data, stream);


### PR DESCRIPTION
ASCS allows transitions from Codec/QoS Configured back to the same
state.

E.g. NRF5340_AUDIO devkit starts in the config(1) state, which is
allowed (only Config QoS, Release, Enable, Receiver Stop Ready
transition are client-only). In this case, as client, we do Config Codec
ourselves and end up with config(1)->config(1) transition.  We currently
ignore that event, so QoS won't be setup and transports won't be
created.

Handle the config(1)->config(1) transition by continuing to Config QoS
if it occurs.

Log:

src/gatt-client.c:btd_gatt_client_connected() Device connected.
src/shared/gatt-client.c:exchange_mtu_cb() MTU exchange complete, with MTU: 65
src/shared/bap.c:bap_ep_set_status() ASE status: ep 0x604000039a90 id 0x01 handle 0x000f state config len 42
src/shared/bap.c:ep_status_config() codec 0x06 framing 0x00 phy 0x02 rtn 2 latency 10 pd 4000 - 40000 ppd 4000 - 40000
src/shared/bap.c:ep_status_config() Codec Config #0: type 0x01 len 2
src/shared/bap.c:ep_status_config() Codec Config #1: type 0x02 len 2
src/shared/bap.c:ep_status_config() Codec Config #2: type 0x03 len 5
src/shared/bap.c:ep_status_config() Codec Config #3: type 0x04 len 3
src/shared/bap.c:ep_status_config() Codec Config #4: type 0x05 len 2
src/shared/bap.c:bap_stream_state_changed() stream 0x60c0000334c0 dir 0x01: idle -> config
src/shared/bap.c:bap_stream_update_io_links() stream 0x60c0000334c0
profiles/audio/bap.c:bap_state() stream 0x60c0000334c0: idle(0) -> config(1)
profiles/audio/bap.c:bap_ready() bap 0x60e000001d20
profiles/audio/bap.c:pac_found() lpac 0x608000017520 rpac 0x6080000183a0
profiles/audio/bap.c:ep_register() ep 0x60d000006910 lpac 0x608000017520 rpac 0x6080000183a0 path /org/bluez/hci0/dev_C9_C9_76_21_08_4F/pac_sink0
profiles/audio/media.c:media_endpoint_async_call() Calling SelectProperties: name = :1.604 path = /MediaEndpointLE/BAPSource/lc3
...
src/shared/bap.c:bap_stream_state_changed() stream 0x60c0000334c0 dir 0x01: config -> config
src/shared/bap.c:bap_stream_update_io_links() stream 0x60c0000334c0
profiles/audio/bap.c:bap_state() stream 0x60c0000334c0: config(1) -> config(1)
---

Notes:
    v2: add comment
    
    We can also avoid no-op reconfiguration by proceeding straight to QoS if
    the codec settings are already what we want.  We'll still need this
    patch, since we may need to reconfigure.
    
    I'll do that in separate series.

 profiles/audio/bap.c | 6 +++++-
 1 file changed, 5 insertions(+), 1 deletion(-)