### PR TITLE
[PW_SID:802072] [BlueZ,v1] shared/shell: Remove readline color escapes

### DIFF
--- a/src/shared/shell.c
+++ b/src/shared/shell.c
@@ -1419,10 +1419,14 @@ bool bt_shell_add_submenu(const struct bt_shell_menu *menu)
 
 void bt_shell_set_prompt(const char *string)
 {
+	char *prompt;
+
 	if (!data.init || data.mode)
 		return;
 
-	rl_set_prompt(string);
+	asprintf(&prompt, "\001%s\002", string);
+
+	rl_set_prompt(prompt);
 	rl_redisplay();
 }
 

--- a/src/shared/shell.h
+++ b/src/shared/shell.h
@@ -10,14 +10,14 @@
 #include <getopt.h>
 #include <stdbool.h>
 
-#define COLOR_OFF	"\001\x1B[0m\002"
-#define COLOR_RED	"\001\x1B[0;91m\002"
-#define COLOR_GREEN	"\001\x1B[0;92m\002"
-#define COLOR_YELLOW	"\001\x1B[0;93m\002"
-#define COLOR_BLUE	"\001\x1B[0;94m\002"
-#define COLOR_BOLDGRAY	"\001\x1B[1;30m\002"
-#define COLOR_BOLDWHITE	"\001\x1B[1;37m\002"
-#define COLOR_HIGHLIGHT	"\001\x1B[1;39m\002"
+#define COLOR_OFF	"\x1B[0m"
+#define COLOR_RED	"\x1B[0;91m"
+#define COLOR_GREEN	"\x1B[0;92m"
+#define COLOR_YELLOW	"\x1B[0;93m"
+#define COLOR_BLUE	"\x1B[0;94m"
+#define COLOR_BOLDGRAY	"\x1B[1;30m"
+#define COLOR_BOLDWHITE	"\x1B[1;37m"
+#define COLOR_HIGHLIGHT	"\x1B[1;39m"
 
 struct bt_shell_menu;
 


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

This removes readline color escapes from color defines and instead only
used them with prompt since they are only really usefull when readline
is rendering the text, so it can calculate the prompt lenth properly.

Fixes: https://github.com/bluez/bluez/issues/10
---
 src/shared/shell.c |  6 +++++-
 src/shared/shell.h | 16 ++++++++--------
 2 files changed, 13 insertions(+), 9 deletions(-)