### PR TITLE
[PW_SID:805347] [BlueZ,v1,1/2] test-micp: Fix endianess error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/src/shared/vcp.c
+++ b/src/shared/vcp.c
@@ -714,7 +714,7 @@ static uint8_t vocs_set_vol_offset(struct bt_vocs *vocs, struct bt_vcp *vcp,
 		DBG(vcp, "error: Value Out of Range");
 		return BT_ATT_ERROR_VALUE_OUT_OF_RANGE;
 	}
-	vstate->vol_offset = req->set_vol_offset;
+	vstate->vol_offset = le16_to_cpu(req->set_vol_offset);
 	vstate->counter = -~vstate->counter; /*Increment Change Counter*/
 
 	gatt_db_attribute_notify(vdb->vocs->vos, (void *)vstate,
@@ -926,13 +926,13 @@ static void vocs_state_read(struct gatt_db_attribute *attrib,
 				void *user_data)
 {
 	struct bt_vocs *vocs = user_data;
-	struct iovec iov;
+	struct vol_offset_state state;
 
-	iov.iov_base = vocs->vostate;
-	iov.iov_len = sizeof(*vocs->vostate);
+	state.vol_offset = cpu_to_le16(vocs->vostate->vol_offset);
+	state.counter = vocs->vostate->counter;
 
-	gatt_db_attribute_read_result(attrib, id, 0, iov.iov_base,
-							iov.iov_len);
+	gatt_db_attribute_read_result(attrib, id, 0, (void *)&state,
+					sizeof(state));
 }
 
 static void vcs_flag_read(struct gatt_db_attribute *attrib,
@@ -958,7 +958,7 @@ static void vocs_voal_read(struct gatt_db_attribute *attrib,
 	struct bt_vocs *vocs = user_data;
 	struct iovec iov;
 
-	iov.iov_base = &vocs->vocs_audio_loc;
+	iov.iov_base = &cpu_to_le32(vocs->vocs_audio_loc);
 	iov.iov_len = sizeof(vocs->vocs_audio_loc);
 
 	gatt_db_attribute_read_result(attrib, id, 0, iov.iov_base,
@@ -1376,8 +1376,8 @@ static void read_vol_offset_state(struct bt_vcp *vcp, bool success,
 		return;
 	}
 
-	DBG(vcp, "Vol Set:%x", vos->vol_offset);
-	DBG(vcp, "Vol Counter:%x", vos->counter);
+	DBG(vcp, "Vol Offset: 0x%04x", le16_to_cpu(vos->vol_offset));
+	DBG(vcp, "Vol Counter: 0x%02x", vos->counter);
 }
 
 static void read_vocs_audio_location(struct bt_vcp *vcp, bool success,
@@ -1386,6 +1386,7 @@ static void read_vocs_audio_location(struct bt_vcp *vcp, bool success,
 				     void *user_data)
 {
 	uint32_t vocs_audio_loc;
+	struct iovec iov;
 
 	if (!value) {
 		DBG(vcp, "Unable to get VOCS Audio Location");
@@ -1398,9 +1399,15 @@ static void read_vocs_audio_location(struct bt_vcp *vcp, bool success,
 		return;
 	}
 
-	memcpy(&vocs_audio_loc, value, length);
+	iov.iov_base = (void *)value;
+	iov.iov_len = length;
 
-	DBG(vcp, "VOCS Audio Loc: %x", vocs_audio_loc);
+	if (!util_iov_pull_le32(&iov, &vocs_audio_loc)) {
+		DBG(vcp, "Invalid size for VOCS Audio Location");
+		return;
+	}
+
+	DBG(vcp, "VOCS Audio Loc: 0x%8x", vocs_audio_loc);
 }
 
 

--- a/unit/test-micp.c
+++ b/unit/test-micp.c
@@ -147,7 +147,7 @@ static void micp_write_value(struct bt_micp *micp, void *user_data)
 	struct bt_mics *mics = micp_get_mics(micp);
 	uint16_t	value_handle;
 	int ret;
-	const uint16_t value = 0x0001;
+	uint16_t value = cpu_to_le16(0x0001);
 
 	gatt_db_attribute_get_char_data(mics->ms, NULL, &value_handle,
 							NULL, NULL, NULL);


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

On big endian the followin error can be observed:

MICP/CL/CGGIT/SER/BV-01-C - init
MICP/CL/CGGIT/SER/BV-01-C - setup
MICP/CL/CGGIT/SER/BV-01-C - setup complete
MICP/CL/CGGIT/SER/BV-01-C - run
micp_write_value handle: 3
**
ERROR:src/shared/tester.c:954:test_io_recv: assertion failed:
(memcmp(buf, iov->iov_base, len) == 0)
Bail out! ERROR:src/shared/tester.c:954:test_io_recv: assertion failed:
(memcmp(buf, iov->iov_base, len) == 0)
Aborted
---
 unit/test-micp.c | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)