### PR TITLE
[PW_SID:805627] [BlueZ,v1] shared/vcp: Fix build error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/src/shared/vcp.c
+++ b/src/shared/vcp.c
@@ -956,13 +956,12 @@ static void vocs_voal_read(struct gatt_db_attribute *attrib,
 				void *user_data)
 {
 	struct bt_vocs *vocs = user_data;
-	struct iovec iov;
+	uint32_t loc;
 
-	iov.iov_base = &cpu_to_le32(vocs->vocs_audio_loc);
-	iov.iov_len = sizeof(vocs->vocs_audio_loc);
+	loc = cpu_to_le32(vocs->vocs_audio_loc);
 
-	gatt_db_attribute_read_result(attrib, id, 0, iov.iov_base,
-							iov.iov_len);
+	gatt_db_attribute_read_result(attrib, id, 0, (void *)&loc,
+							sizeof(loc));
 }
 
 static void vocs_voaodec_read(struct gatt_db_attribute *attrib,


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

This fixes the following build error in some architectures:

src/shared/vcp.c:961:24: error: lvalue required as unary ‘&’ operand
 961 |     iov.iov_base = &cpu_to_le32(vocs->vocs_audio_loc);
   |            ^
---
 src/shared/vcp.c | 9 ++++-----
 1 file changed, 4 insertions(+), 5 deletions(-)