### PR TITLE
[PW_SID:806818] [BlueZ,v1] shared/vcp: Fix comparison of values in different endianess

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/src/shared/vcp.c
+++ b/src/shared/vcp.c
@@ -709,13 +709,16 @@ static uint8_t vocs_set_vol_offset(struct bt_vocs *vocs, struct bt_vcp *vcp,
 		return BT_ATT_ERROR_INVALID_CHANGE_COUNTER;
 	}
 
-	if (req->set_vol_offset > VOCS_VOL_OFFSET_UPPER_LIMIT ||
-		req->set_vol_offset < VOCS_VOL_OFFSET_LOWER_LIMIT) {
+	vstate->vol_offset = le16_to_cpu(req->set_vol_offset);
+
+	if (vstate->vol_offset > VOCS_VOL_OFFSET_UPPER_LIMIT ||
+		vstate->vol_offset < VOCS_VOL_OFFSET_LOWER_LIMIT) {
 		DBG(vcp, "error: Value Out of Range");
 		return BT_ATT_ERROR_VALUE_OUT_OF_RANGE;
 	}
-	vstate->vol_offset = le16_to_cpu(req->set_vol_offset);
-	vstate->counter = -~vstate->counter; /*Increment Change Counter*/
+
+	/* Increment Change Counter */
+	vstate->counter = -~vstate->counter;
 
 	gatt_db_attribute_notify(vdb->vocs->vos, (void *)vstate,
 				 sizeof(struct vol_offset_state),


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

Values received over the air are in Little Endian format so they first
need to be converted to host endianess before comparing with other
values.
---
 src/shared/vcp.c | 11 +++++++----
 1 file changed, 7 insertions(+), 4 deletions(-)