### PR TITLE
[PW_SID:807630] [BlueZ,v1] test-vcp: Fix CCC value endianness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/unit/test-vcp.c
+++ b/unit/test-vcp.c
@@ -130,18 +130,10 @@ static void gatt_notify_cb(struct gatt_db_attribute *attrib,
 					struct bt_att *att, void *user_data)
 {
 	struct test_data *data = user_data;
-	struct notify notify;
-
-	memset(&notify, 0, sizeof(notify));
-
-	notify.handle = gatt_db_attribute_get_handle(attrib);
-	notify.ccc_handle = gatt_db_attribute_get_handle(ccc);
-	notify.value = (void *) value;
-	notify.len = len;
+	uint16_t handle = gatt_db_attribute_get_handle(attrib);
 
 	if (!bt_gatt_server_send_notification(data->server,
-			notify.handle, notify.value,
-			notify.len, false))
+			handle, value, len, false))
 		printf("%s: Failed to send notification\n", __func__);
 }
 
@@ -154,8 +146,7 @@ static void gatt_ccc_read_cb(struct gatt_db_attribute *attrib,
 	struct ccc_state *ccc;
 	uint16_t handle;
 	uint8_t ecode = 0;
-	const uint8_t *value = NULL;
-	size_t len = 0;
+	uint16_t value = 0;
 
 	handle = gatt_db_attribute_get_handle(attrib);
 
@@ -165,11 +156,11 @@ static void gatt_ccc_read_cb(struct gatt_db_attribute *attrib,
 		goto done;
 	}
 
-	len = sizeof(ccc->value);
-	value = (void *) &ccc->value;
+	value = cpu_to_le16(ccc->value);
 
 done:
-	gatt_db_attribute_read_result(attrib, id, ecode, value, len);
+	gatt_db_attribute_read_result(attrib, id, ecode, (void *)&value,
+							sizeof(value));
 }
 
 static void test_server(const void *user_data)


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

CCC value is 2 octects long so it needs to be converted using
cpu_to_le16 in order to not fail in Big Endian architectures.
---
 unit/test-vcp.c | 21 ++++++---------------
 1 file changed, 6 insertions(+), 15 deletions(-)