### PR TITLE
[PW_SID:808878] [BlueZ,v1] shared/vcp: Fix notification endianness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/src/shared/vcp.c
+++ b/src/shared/vcp.c
@@ -683,7 +683,7 @@ static uint8_t vocs_set_vol_offset(struct bt_vocs *vocs, struct bt_vcp *vcp,
 				struct iovec *iov)
 {
 	struct bt_vcp_db *vdb;
-	struct vol_offset_state *vstate;
+	struct vol_offset_state *vstate, state;
 	struct bt_vocs_set_vol_off *req;
 
 	DBG(vcp, "Set Volume Offset");
@@ -720,9 +720,13 @@ static uint8_t vocs_set_vol_offset(struct bt_vocs *vocs, struct bt_vcp *vcp,
 	/* Increment Change Counter */
 	vstate->counter = -~vstate->counter;
 
-	gatt_db_attribute_notify(vdb->vocs->vos, (void *)vstate,
-				 sizeof(struct vol_offset_state),
+	/* Notify change */
+	state.vol_offset = req->set_vol_offset;
+	state.counter = vstate->counter;
+
+	gatt_db_attribute_notify(vdb->vocs->vos, (void *)&state, sizeof(state),
 				 bt_vcp_get_att(vcp));
+
 	return 0;
 }
 


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

4db4d5fa1c4f ("shared/vcp: Fix endianness errors") does attempt to fix
the endianness of stored volume offset but in the process it broke the
notification since the value is no longer stored in the Bluetooth byte
order (Little Endian) but instead in the cpu byte order which is then
used in the notification as is, to fix this instead of notifying using
the stored value it now uses a dedicated variable which does use the
value from the request itself.
---
 src/shared/vcp.c | 10 +++++++---
 1 file changed, 7 insertions(+), 3 deletions(-)