### PR TITLE
[PW_SID:811296] mgmt: Fix crash after pair command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/client/agent.c
+++ b/client/agent.c
@@ -77,14 +77,17 @@ static void confirm_response(const char *input, void *user_data)
 {
 	DBusConnection *conn = user_data;
 
-	if (!strcmp(input, "yes"))
-		g_dbus_send_reply(conn, pending_message, DBUS_TYPE_INVALID);
-	else if (!strcmp(input, "no"))
-		g_dbus_send_error(conn, pending_message,
+	if (pending_message != NULL) {
+		if (!strcmp(input, "yes"))
+			g_dbus_send_reply(conn, pending_message,
+					DBUS_TYPE_INVALID);
+		else if (!strcmp(input, "no"))
+			g_dbus_send_error(conn, pending_message,
 					"org.bluez.Error.Rejected", NULL);
-	else
-		g_dbus_send_error(conn, pending_message,
+		else
+			g_dbus_send_error(conn, pending_message,
 					"org.bluez.Error.Canceled", NULL);
+	}
 }
 
 static void agent_release(DBusConnection *conn)

--- a/client/mgmt.c
+++ b/client/mgmt.c
@@ -849,10 +849,16 @@ static void prompt_input(const char *input, void *user_data)
 								&prompt.addr);
 		break;
 	case MGMT_EV_USER_CONFIRM_REQUEST:
-		if (input[0] == 'y' || input[0] == 'Y')
-			mgmt_confirm_reply(prompt.index, &prompt.addr);
-		else
+		if (len) {
+			if (input[0] == 'y' || input[0] == 'Y')
+				mgmt_confirm_reply(prompt.index, &prompt.addr);
+			else
+				mgmt_confirm_neg_reply(prompt.index,
+						&prompt.addr);
+		} else {
 			mgmt_confirm_neg_reply(prompt.index, &prompt.addr);
+			bt_shell_set_prompt(PROMPT_ON);
+		}
 		break;
 	}
 }


### PR DESCRIPTION
After pair command, if the user doesn't provide any input on bluetoothctl
CLI interface after receiving the prompt(yes/no) below crash is observed:

dbus[782]: arguments to dbus_message_get_no_reply() were incorrect,
assertion "message != NULL" failed in file
/usr/src/debug/dbus/1.14.10-r0/dbus/dbus-message.c line 3250.
This is normally a bug in some application using the D-Bus library.
/usr/lib/libc.so.6(+0x27534) [0xffffa1b67534]
/usr/lib/libc.so.6(__libc_start_main+0x9c) [0xffffa1b6760c]
bluetoothctl(+0x188f0) [0xaaaac9c088f0]
Aborted (core dumped)
---
 client/agent.c | 15 +++++++++------
 client/mgmt.c  | 12 +++++++++---
 2 files changed, 18 insertions(+), 9 deletions(-)