### PR TITLE
[PW_SID:812362] [BlueZ] adapter: Fix airpod device pair fail

### DIFF
--- a/src/adapter.c
+++ b/src/adapter.c
@@ -7066,6 +7066,24 @@ static void adapter_msd_notify(struct btd_adapter *adapter,
 	}
 }
 
+#define APPLE_INC_VENDOR_ID 0x004c
+static bool eir_msd_is_apple_inc(GSList *msd_list)
+{
+	GSList *msd_l, *msd_next;
+
+	for (msd_l = msd_list; msd_l != NULL; msd_l = msd_next) 
+	{
+		const struct eir_msd *msd = msd_l->data;
+
+		msd_next = g_slist_next(msd_l);
+
+		if(msd->company == APPLE_INC_VENDOR_ID)
+			return true;
+	}
+
+	return false;
+}
+
 static bool is_filter_match(GSList *discovery_filter, struct eir_data *eir_data,
 								int8_t rssi)
 {
@@ -7279,6 +7297,12 @@ void btd_adapter_device_found(struct btd_adapter *adapter,
 		device_set_bredr_support(dev);
 		/* Update last seen for BR/EDR in case its flag is set */
 		device_update_last_seen(dev, BDADDR_BREDR, !not_connectable);
+	}
+
+	if(eir_msd_is_apple_inc(eir_data.msd_list) && 
+		(not_connectable == true) && (bdaddr_type == BDADDR_LE_PUBLIC)){
+		device_set_bredr_support(dev);
+		device_update_last_seen(dev, BDADDR_BREDR, true);
 	}
 
 	if (eir_data.name != NULL && eir_data.name_complete)


### PR DESCRIPTION
From: clancy shang <clancy.shang@quectel.com>

Airpod is performing inquiry scans in BR/EDR and advertising in a unconnectabl
mode whit the same public address at the same time. with this featrue, when
found airpod device, set the bredr support, fix it pair fail bug.

Signed-off-by: clancy shang <clancy.shang@quectel.com>
---
 src/adapter.c | 24 ++++++++++++++++++++++++
 1 file changed, 24 insertions(+)