### PR TITLE
[PW_SID:814123] [BlueZ,v3,1/2] avdtp: fix incorrect transaction label in setconf phase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/profiles/audio/avdtp.c
+++ b/profiles/audio/avdtp.c
@@ -419,11 +419,11 @@ static int send_request(struct avdtp *session, gboolean priority,
 			void *buffer, size_t size);
 static gboolean avdtp_parse_resp(struct avdtp *session,
 					struct avdtp_stream *stream,
-					uint8_t transaction, uint8_t signal_id,
+					uint8_t signal_id,
 					void *buf, int size);
 static gboolean avdtp_parse_rej(struct avdtp *session,
 					struct avdtp_stream *stream,
-					uint8_t transaction, uint8_t signal_id,
+					uint8_t signal_id,
 					void *buf, int size);
 static int process_queue(struct avdtp *session);
 static void avdtp_sep_set_state(struct avdtp *session,
@@ -2293,7 +2293,6 @@ static gboolean session_cb(GIOChannel *chan, GIOCondition cond,
 	switch (header->message_type) {
 	case AVDTP_MSG_TYPE_ACCEPT:
 		if (!avdtp_parse_resp(session, session->req->stream,
-						session->in.transaction,
 						session->in.signal_id,
 						session->in.buf,
 						session->in.data_size)) {
@@ -2303,7 +2302,6 @@ static gboolean session_cb(GIOChannel *chan, GIOCondition cond,
 		break;
 	case AVDTP_MSG_TYPE_REJECT:
 		if (!avdtp_parse_rej(session, session->req->stream,
-						session->in.transaction,
 						session->in.signal_id,
 						session->in.buf,
 						session->in.data_size)) {
@@ -2941,7 +2939,7 @@ static gboolean avdtp_delay_report_resp(struct avdtp *session,
 
 static gboolean avdtp_parse_resp(struct avdtp *session,
 					struct avdtp_stream *stream,
-					uint8_t transaction, uint8_t signal_id,
+					uint8_t signal_id,
 					void *buf, int size)
 {
 	struct pending_req *next;
@@ -3055,7 +3053,7 @@ static gboolean stream_rej_to_err(struct stream_rej *rej, unsigned int size,
 
 static gboolean avdtp_parse_rej(struct avdtp *session,
 					struct avdtp_stream *stream,
-					uint8_t transaction, uint8_t signal_id,
+					uint8_t signal_id,
 					void *buf, int size)
 {
 	struct avdtp_error err;


### PR DESCRIPTION
From: Xiao Yao <xiaoyao@rock-chips.com>

BLUETOOTH SPECIFICATION Page 61 of 140
Audio/Video Distribution Transport Protocol Specification (V13)
8.4.6 Message integrity verification at receiver side

- The receiver of an AVDTP signaling message shall not interpret corrupted
messages. Those messages are discarded and no signaling message is returned
to the sender if no error code is applicable. Possible corrupted messages
are:

  * Response messages where the transaction label cannot match a previous
    command sent to the remote device

Consider the following scenario:
btmon log:
... ...
AVDTP: Discover (0x01) Command (0x00) type 0x00 label 5 nosp 0
AVDTP: Discover (0x01) Response Accept (0x02) type 0x00 label 5 nosp 0
AVDTP: Get All Capabilities (0x0c) Command (0x00) type 0x00 label 6 nosp 0
AVDTP: Get All Capabilities (0x0c) Resp Accept (0x02) type 0 label 6 nosp 0
AVDTP: Get All Capabilities (0x0c) Command (0x00) type 0x00 label 7 nosp 0
AVDTP: Get All Capabilities (0x0c) Resp Accept (0x02) type 0 label 7 nosp 0

< AVDTP: Set Configuration (0x03) Command (0x00) type 0x00 label 8 nosp 0
//Currently, a 'set configuration' message has been received from the
//sender, which contains a transaction label valued at 8. This message
//was then relayed to A2DP backend(PulseAudio/PipeWire) using the dbus
//interface.
  set_configuration()(media.c)
    dbus_message_new_method_call(..., "SetConfiguration", ...);
    g_dbus_send_message_with_reply(btd_get_dbus_connection(), ...);
    dbus_pending_call_set_notify(request->call, endpoint_reply, ...);
    ...

> AVDTP: Discover (0x01) Command (0x00) type 0x00 label 0 nosp 0
//At this time, the A2DP reverse discovery issued an A2DP discover command.
< AVDTP: Discover (0x01) Response Accept (0x02) type 0x00 label 0 nosp 0
//After receiving the discover reply, the session->in.transaction is
//changed to 0

> AVDTP: Set Configuration (0x03) Resp Accept (0x02) type 0 label 0 nosp 0
//The audio backend reply the dbus message
  endpoint_reply (media.c)
    setconf_cb (avdtp.c)
      //Here avdtp_send sends an incorrect transaction value, causing
      //the sender to discard the message. (The correct transaction
      //value is 8)
      avdtp_send(session, session->in.transaction, AVDTP_MSG_TYPE_ACCEPT,
                 AVDTP_SET_CONFIGURATION, NULL, 0)

AVDTP: Delay Report (0x0d) Command (0x00) type 0x00 label 1 nosp 0
AVDTP: Delay Report (0x0d) Response Accept (0x02) type 0x00 label 1 nosp 0
AVDTP: Get All Capabilities (0x0c) Command (0x00) type 0x00 label 2 nosp 0
AVDTP: Get All Capabilities (0x0c) Resp Accept (0x02) type 0 label 2 nosp 0
... ...

Therefore, a async_transaction that requires asynchronous return is
recorded to prevent it from being incorrectly modified.

Signed-off-by: Xiao Yao <xiaoyao@rock-chips.com>
---
v1 -> v2: Fixed "session->in.transaction" logic err.
v2 -> v3: Fixed some compile warnings
---
 profiles/audio/avdtp.c | 19 ++++++++++++++-----
 1 file changed, 14 insertions(+), 5 deletions(-)


base-commit: 7ad5669402c9acff8e4cc808edc12a41df36654e