### PR TITLE
[PW_SID:814435] [BlueZ,v4,1/2] a2dp: fix incorrect transaction label in setconf phase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+


### PR DESCRIPTION
From: Xiao Yao <xiaoyao@rock-chips.com>

BLUETOOTH SPECIFICATION Page 61 of 140
Audio/Video Distribution Transport Protocol Specification (V13)
8.4.6 Message integrity verification at receiver side

- The receiver of an AVDTP signaling message shall not interpret corrupted
messages. Those messages are discarded and no signaling message is returned
to the sender if no error code is applicable. Possible corrupted messages
are:

  * Response messages where the transaction label cannot match a previous
    command sent to the remote device

Consider the following scenario:
btmon log:
AVDTP: Discover (0x01) Command (0x00) type 0x00 label 5 nosp 0
... ...
< AVDTP: Set Configuration (0x03) Command (0x00) type 0x00 label 8 nosp 0
//Currently, a 'set configuration' message has been received from the
//sender, which contains a transaction label valued at 8. This message
//was then relayed to A2DP backend(PulseAudio/PipeWire) using the dbus
//interface.
  set_configuration()(media.c)
    dbus_message_new_method_call(..., "SetConfiguration", ...);
    g_dbus_send_message_with_reply(btd_get_dbus_connection(), ...);
    dbus_pending_call_set_notify(request->call, endpoint_reply, ...);
    ...

//The commit "02877c5e9" introduces a reverse discovery logic, resulting
//in a small probability that the discovery command is issued before the
//setconfig accept command.
//Tip: If an artificial delay is added to the audio backend, this issue
//will invariably occur."
> AVDTP: Discover (0x01) Command (0x00) type 0x00 label 0 nosp 0
//After receiving the discover reply, the session->in.transaction is
//changed to 0
< AVDTP: Discover (0x01) Response Accept (0x02) type 0x00 label 0 nosp 0

> AVDTP: Set Configuration (0x03) Resp Accept (0x02) type 0 label 0 nosp 0
//The audio backend reply the dbus message
  endpoint_reply (media.c)
    setconf_cb (avdtp.c)
      //Here avdtp_send sends an incorrect transaction value, causing
      //the sender to discard the message. (The correct transaction
      //value is 8)
      avdtp_send(session, session->in.transaction, AVDTP_MSG_TYPE_ACCEPT,
                 AVDTP_SET_CONFIGURATION, NULL, 0)

AVDTP: Delay Report (0x0d) Command (0x00) type 0x00 label 1 nosp 0
... ...

Therefore, the reverse discovery logic was adjusted to the back of
setconfig accept to avoid two transmission transactions at the same
time and fixed the problem.

Signed-off-by: Xiao Yao <xiaoyao@rock-chips.com>
---
v1 -> v2: Fixed "session->in.transaction" logic err.
v2 -> v3: Fixed some compile warnings
v3 -> v4: Adjust the timing of reverse discovery logic
---
 profiles/audio/a2dp.c | 27 ++++++++++++++-------------
 1 file changed, 14 insertions(+), 13 deletions(-)