### PR TITLE
[PW_SID:817650] [BlueZ,v1,1/2] client/player: Add support for printing A2DP codec details

### DIFF
--- a/profiles/audio/transport.c
+++ b/profiles/audio/transport.c
@@ -531,6 +531,8 @@ static void media_owner_exit(DBusConnection *connection, void *user_data)
 {
 	struct media_owner *owner = user_data;
 
+	DBG("Owner %s", owner->name);
+
 	owner->watch = 0;
 
 	media_owner_remove(owner);
@@ -741,6 +743,8 @@ static DBusMessage *release(DBusConnection *conn, DBusMessage *msg,
 
 	if (owner == NULL || g_strcmp0(owner->name, sender) != 0)
 		return btd_error_not_authorized(msg);
+
+	DBG("Owner %s", owner->name);
 
 	if (owner->pending) {
 		const char *member;


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

This adds support for printing Capabilities and Configuration of A2DP
endpoints and transports:

bluetoothctl> endpoint.show /org/bluez/hci0/dev_94_DB_56_F7_F2_88/sep1
Endpoint /org/bluez/hci0/dev_94_DB_56_F7_F2_88/sep1
	UUID: 0000110b-0000-1000-8000-00805f9b34fb
	Codec: 0x00 (0)
	Media Codec: SBC
	Channel Modes: Mono DualChannel Stereo JointStereo
	Frequencies: 44.1Khz 48Khz
	Subbands: 4 8
	Blocks: 4 8 12 16
	Bitpool Range: 2-53
	...

bluetoothctl> transport.show /org/bluez/hci0/dev_94_DB_56_F7_F2_88/sep1/fd7
Transport /org/bluez/hci0/dev_94_DB_56_F7_F2_88/sep1/fd7
	UUID: 0000110a-0000-1000-8000-00805f9b34fb
	Codec: 0x00 (0)
	Media Codec: SBC
	Channel Modes: JointStereo
	Frequencies: 48Khz
	Subbands: 8
	Blocks: 16
	Bitpool Range: 2-53
---
 client/player.c | 548 +++++++++++++++++++++++++++++++++++++++++++++++-
 1 file changed, 538 insertions(+), 10 deletions(-)