### PR TITLE
[PW_SID:818707] Enhance GATT to pass PTS tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/src/shared/att.c
+++ b/src/shared/att.c
@@ -87,6 +87,8 @@ struct bt_att {
 
 	struct sign_info *local_sign;
 	struct sign_info *remote_sign;
+
+	bool retry_on_sec_error;
 };
 
 struct sign_info {
@@ -786,6 +788,9 @@ static bool handle_error_rsp(struct bt_att_chan *chan, uint8_t *pdu,
 
 	*opcode = rsp->opcode;
 
+	if (!att->retry_on_sec_error)
+		return false;
+
 	/* If operation has already been marked as retry don't attempt to change
 	 * the security again.
 	 */
@@ -1262,6 +1267,7 @@ struct bt_att *bt_att_new(int fd, bool ext_signed)
 	att = new0(struct bt_att, 1);
 	att->chans = queue_new();
 	att->mtu = chan->mtu;
+	att->retry_on_sec_error = true;
 
 	/* crypto is optional, if not available leave it NULL */
 	if (!ext_signed)
@@ -2041,4 +2047,12 @@ bool bt_att_has_crypto(struct bt_att *att)
 		return false;
 
 	return att->crypto ? true : false;
+}
+
+void bt_att_set_retry_on_sec_error(struct bt_att *att, bool retry_on_sec_error)
+{
+	if (!att)
+		return;
+
+	att->retry_on_sec_error = retry_on_sec_error;
 }

--- a/src/shared/att.h
+++ b/src/shared/att.h
@@ -110,3 +110,4 @@ bool bt_att_set_local_key(struct bt_att *att, uint8_t sign_key[16],
 bool bt_att_set_remote_key(struct bt_att *att, uint8_t sign_key[16],
 			bt_att_counter_func_t func, void *user_data);
 bool bt_att_has_crypto(struct bt_att *att);
+void bt_att_set_retry_on_sec_error(struct bt_att *att, bool retry_on_sec_error);

--- a/src/shared/gatt-client.c
+++ b/src/shared/gatt-client.c
@@ -3818,3 +3818,12 @@ bool bt_gatt_client_idle_unregister(struct bt_gatt_client *client,
 
 	return false;
 }
+
+void bt_gatt_client_set_retry_on_sec_error(struct bt_gatt_client *client,
+						bool retry_on_sec_error)
+{
+	if (!client)
+		return;
+
+	bt_att_set_retry_on_sec_error(client->att, retry_on_sec_error);
+}

--- a/src/shared/gatt-client.h
+++ b/src/shared/gatt-client.h
@@ -134,3 +134,5 @@ unsigned int bt_gatt_client_idle_register(struct bt_gatt_client *client,
 					bt_gatt_client_destroy_func_t destroy);
 bool bt_gatt_client_idle_unregister(struct bt_gatt_client *client,
 						unsigned int id);
+void bt_gatt_client_set_retry_on_sec_error(struct bt_gatt_client *client,
+						bool retry_on_sec_error);

--- a/tools/btgatt-client.c
+++ b/tools/btgatt-client.c
@@ -1404,6 +1404,92 @@ static void cmd_search_service(struct client *cli, char *cmd_str)
 						NULL);
 }
 
+static void search_characteristics_usage(void)
+{
+	printf("Usage: search-characteristics <start_hanlde> <end_handle> "
+		"<uuid>\n"
+		"e.g.:\n"
+		"\tsearch-characteristics 0x0001 0xFFFF 1800\n");
+}
+
+static void search_characteristics_cb(bool success, uint8_t att_ecode,
+					struct bt_gatt_result *result,
+					void *user_data)
+{
+	struct bt_gatt_iter iter;
+	uint16_t handle, length;
+	const uint8_t *value;
+	int i;
+
+	if (!success) {
+		PRLOG("\nCharacteristics discovery failed: %s (0x%02x)\n",
+				ecode_to_string(att_ecode), att_ecode);
+		return;
+	}
+
+	if (!result || !bt_gatt_iter_init(&iter, result))
+		return;
+
+	printf("\n");
+	while (bt_gatt_iter_next_read_by_type(&iter, &handle, &length,
+						&value)) {
+		printf("Found handle: 0x%04x value: ", handle);
+		for (i = 0; i < length; i++)
+			printf("%02x ", value[i]);
+		printf("\n");
+	}
+	PRLOG("\n");
+}
+
+static void cmd_search_characteristics(struct client *cli, char *cmd_str)
+{
+	char *argv[4];
+	int argc = 0;
+	uint16_t start_handle, end_handle;
+	char *endptr = NULL;
+	bt_uuid_t uuid;
+
+	if (!bt_gatt_client_is_ready(cli->gatt)) {
+		printf("GATT client not initialized\n");
+		return;
+	}
+
+	if (!parse_args(cmd_str, 3, argv, &argc)) {
+		printf("Too many arguments\n");
+		search_characteristics_usage();
+		return;
+	}
+
+	if (argc < 1) {
+		search_characteristics_usage();
+		return;
+	}
+
+	start_handle = strtol(argv[0], &endptr, 0);
+	if (!endptr || *endptr != '\0') {
+		printf("Invalid start handle: %s\n", argv[0]);
+		return;
+	}
+
+	end_handle = strtol(argv[1], &endptr, 0);
+	if (!endptr || *endptr != '\0') {
+		printf("Invalid end handle: %s\n", argv[1]);
+		return;
+	}
+
+	if (bt_string_to_uuid(&uuid, argv[2]) < 0) {
+		printf("Invalid UUID: %s\n", argv[2]);
+		return;
+	}
+
+	bt_gatt_read_by_type(bt_gatt_client_get_att(cli->gatt), start_handle,
+						end_handle,
+						&uuid,
+						search_characteristics_cb,
+						NULL,
+						NULL);
+}
+
 static void cmd_help(struct client *cli, char *cmd_str);
 
 typedef void (*command_func_t)(struct client *cli, char *cmd_str);
@@ -1442,6 +1528,8 @@ static struct {
 			"\tSet retry on security error by elevating security"},
 	{ "search-service", cmd_search_service,
 				"\tSearch service"},
+	{ "search-characteristics", cmd_search_characteristics,
+				"\tSearch characteristics"},
 	{ }
 };
 

--- a/tools/btgatt-client.c
+++ b/tools/btgatt-client.c
@@ -1332,13 +1332,6 @@ static void cmd_set_retry_on_sec_error(struct client *cli, char *cmd_str)
 		printf("Invalid argument: %s\n", argv[0]);
 }
 
-static void search_service_usage(void)
-{
-	printf("Usage: search-service <uuid>\n"
-		"e.g.:\n"
-		"\tsearch-service 1800\n");
-}
-
 static void search_service_cb(bool success, uint8_t att_ecode,
 					struct bt_gatt_result *result,
 					void *user_data)
@@ -1368,6 +1361,27 @@ static void search_service_cb(bool success, uint8_t att_ecode,
 			start_handle, end_handle, uuid_str);
 	}
 	PRLOG("\n");
+}
+
+static void cmd_search_all_primary_services(struct client *cli, char *cmd_str)
+{
+	if (!bt_gatt_client_is_ready(cli->gatt)) {
+		printf("GATT client not initialized\n");
+		return;
+	}
+
+	bt_gatt_discover_all_primary_services(bt_gatt_client_get_att(cli->gatt),
+						NULL,
+						search_service_cb,
+						NULL,
+						NULL);
+}
+
+static void search_service_usage(void)
+{
+	printf("Usage: search-service <uuid>\n"
+		"e.g.:\n"
+		"\tsearch-service 1800\n");
 }
 
 static void cmd_search_service(struct client *cli, char *cmd_str)
@@ -1603,6 +1617,8 @@ static struct {
 				"\tSet signing key for signed write command"},
 	{ "set-retry-on-sec-error", cmd_set_retry_on_sec_error,
 			"\tSet retry on security error by elevating security"},
+	{ "search-all-primary-services", cmd_search_all_primary_services,
+				"\tSearch all primary services"},
 	{ "search-service", cmd_search_service,
 				"\tSearch service"},
 	{ "search-characteristics", cmd_search_characteristics,

--- a/tools/btgatt-client.c
+++ b/tools/btgatt-client.c
@@ -1295,6 +1295,42 @@ static void cmd_set_sign_key(struct client *cli, char *cmd_str)
 		set_sign_key_usage();
 }
 
+static void set_retry_on_sec_error_usage(void)
+{
+	printf("Usage: set-retry-on-sec-error <y/n>\n"
+		"e.g.:\n"
+		"\tset-retry-on-sec-error n\n");
+}
+
+static void cmd_set_retry_on_sec_error(struct client *cli, char *cmd_str)
+{
+	char *argv[2];
+	int argc = 0;
+
+	if (!bt_gatt_client_is_ready(cli->gatt)) {
+		printf("GATT client not initialized\n");
+		return;
+	}
+
+	if (!parse_args(cmd_str, 1, argv, &argc)) {
+		printf("Too many arguments\n");
+		set_retry_on_sec_error_usage();
+		return;
+	}
+
+	if (argc < 1) {
+		set_retry_on_sec_error_usage();
+		return;
+	}
+
+	if (argv[0][0] == 'y')
+		bt_gatt_client_set_retry_on_sec_error(cli->gatt, true);
+	else if (argv[0][0] == 'n')
+		bt_gatt_client_set_retry_on_sec_error(cli->gatt, false);
+	else
+		printf("Invalid argument: %s\n", argv[0]);
+}
+
 static void cmd_help(struct client *cli, char *cmd_str);
 
 typedef void (*command_func_t)(struct client *cli, char *cmd_str);
@@ -1329,6 +1365,8 @@ static struct {
 				"\tGet security level on le connection"},
 	{ "set-sign-key", cmd_set_sign_key,
 				"\tSet signing key for signed write command"},
+	{ "set-retry-on-sec-error", cmd_set_retry_on_sec_error,
+			"\tSet retry on security error by elevating security"},
 	{ }
 };
 

--- a/tools/btgatt-client.c
+++ b/tools/btgatt-client.c
@@ -33,6 +33,7 @@
 #include "src/shared/queue.h"
 #include "src/shared/gatt-db.h"
 #include "src/shared/gatt-client.h"
+#include "src/shared/gatt-helpers.h"
 
 #define ATT_CID 4
 
@@ -1331,6 +1332,78 @@ static void cmd_set_retry_on_sec_error(struct client *cli, char *cmd_str)
 		printf("Invalid argument: %s\n", argv[0]);
 }
 
+static void search_service_usage(void)
+{
+	printf("Usage: search-service <uuid>\n"
+		"e.g.:\n"
+		"\tsearch-service 1800\n");
+}
+
+static void search_service_cb(bool success, uint8_t att_ecode,
+					struct bt_gatt_result *result,
+					void *user_data)
+{
+	struct bt_gatt_iter iter;
+	uint16_t start_handle, end_handle;
+	uint128_t u128;
+	bt_uuid_t uuid;
+	char uuid_str[MAX_LEN_UUID_STR];
+
+	if (!success) {
+		PRLOG("\nService discovery failed: %s (0x%02x)\n",
+				ecode_to_string(att_ecode), att_ecode);
+		return;
+	}
+
+	if (!result || !bt_gatt_iter_init(&iter, result))
+		return;
+
+	printf("\n");
+	while (bt_gatt_iter_next_service(&iter, &start_handle, &end_handle,
+						u128.data)) {
+		bt_uuid128_create(&uuid, u128);
+		bt_uuid_to_string(&uuid, uuid_str, sizeof(uuid_str));
+		printf("Found start handle: 0x%04x, end handle: 0x%04x, "
+			"UUID: %s\n",
+			start_handle, end_handle, uuid_str);
+	}
+	PRLOG("\n");
+}
+
+static void cmd_search_service(struct client *cli, char *cmd_str)
+{
+	char *argv[2];
+	int argc = 0;
+	bt_uuid_t uuid;
+
+	if (!bt_gatt_client_is_ready(cli->gatt)) {
+		printf("GATT client not initialized\n");
+		return;
+	}
+
+	if (!parse_args(cmd_str, 1, argv, &argc)) {
+		printf("Too many arguments\n");
+		search_service_usage();
+		return;
+	}
+
+	if (argc < 1) {
+		search_service_usage();
+		return;
+	}
+
+	if (bt_string_to_uuid(&uuid, argv[0]) < 0) {
+		printf("Invalid UUID: %s\n", argv[0]);
+		return;
+	}
+
+	bt_gatt_discover_primary_services(bt_gatt_client_get_att(cli->gatt),
+						&uuid, 0x0001, 0xFFFF,
+						search_service_cb,
+						NULL,
+						NULL);
+}
+
 static void cmd_help(struct client *cli, char *cmd_str);
 
 typedef void (*command_func_t)(struct client *cli, char *cmd_str);
@@ -1367,6 +1440,8 @@ static struct {
 				"\tSet signing key for signed write command"},
 	{ "set-retry-on-sec-error", cmd_set_retry_on_sec_error,
 			"\tSet retry on security error by elevating security"},
+	{ "search-service", cmd_search_service,
+				"\tSearch service"},
 	{ }
 };
 


### PR DESCRIPTION
Some PTS GATT tests like GATT/CL/GAR/BI-04-C request to be able to get the
security error and do not try to change the security level.

this commit adds a variable allowing to prevent to change the security
level.
---
 src/shared/att.c         | 14 ++++++++++++++
 src/shared/att.h         |  1 +
 src/shared/gatt-client.c |  9 +++++++++
 src/shared/gatt-client.h |  2 ++
 tools/btgatt-client.c    | 38 ++++++++++++++++++++++++++++++++++++++
 5 files changed, 64 insertions(+)