### PR TITLE
[PW_SID:821056] Introduce option to limit A2DP channels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/profiles/audio/a2dp.c
+++ b/profiles/audio/a2dp.c
@@ -2549,6 +2549,14 @@ static void confirm_cb(GIOChannel *io, gpointer data)
 	if (!chan)
 		goto drop;
 
+	if (btd_opts.a2dp.channels &&
+				queue_length(server->channels) > btd_opts.a2dp.channels) {
+		device_request_disconnect(device, NULL);
+		DBG("Reject current connection, A2DP channel limit exceeded: %d",
+						btd_opts.a2dp.channels);
+		goto drop;
+	}
+
 	chan->auth_id = btd_request_authorization(&src, &dst,
 							ADVANCED_AUDIO_UUID,
 							auth_cb, chan);

--- a/src/btd.h
+++ b/src/btd.h
@@ -104,6 +104,10 @@ struct btd_avdtp_opts {
 	uint8_t  stream_mode;
 };
 
+struct btd_a2dp_opts {
+	uint8_t		channels;
+};
+
 struct btd_advmon_opts {
 	uint8_t		rssi_sampling_period;
 };
@@ -147,6 +151,8 @@ struct btd_opts {
 	uint8_t		key_size;
 
 	enum jw_repairing_t jw_repairing;
+
+	struct btd_a2dp_opts	a2dp;
 
 	struct btd_advmon_opts	advmon;
 

--- a/src/main.c
+++ b/src/main.c
@@ -162,6 +162,11 @@ static const char *avdtp_options[] = {
 	NULL
 };
 
+static const char *a2dp_options[] = {
+	"Channels",
+	NULL
+};
+
 static const char *advmon_options[] = {
 	"RSSISamplingPeriod",
 	NULL
@@ -178,6 +183,7 @@ static const struct group_table {
 	{ "GATT",	gatt_options },
 	{ "CSIS",	csip_options },
 	{ "AVDTP",	avdtp_options },
+	{ "A2DP",	a2dp_options },
 	{ "AdvMon",	advmon_options },
 	{ }
 };
@@ -1130,6 +1136,13 @@ static void parse_avdtp(GKeyFile *config)
 	parse_avdtp_stream_mode(config);
 }
 
+static void parse_a2dp(GKeyFile *config)
+{
+	parse_config_u8(config, "A2DP", "Channels",
+				&btd_opts.a2dp.channels,
+				0, UINT8_MAX);
+}
+
 static void parse_advmon(GKeyFile *config)
 {
 	parse_config_u8(config, "AdvMon", "RSSISamplingPeriod",
@@ -1153,6 +1166,7 @@ static void parse_config(GKeyFile *config)
 	parse_gatt(config);
 	parse_csis(config);
 	parse_avdtp(config);
+	parse_a2dp(config);
 	parse_advmon(config);
 }
 
@@ -1193,6 +1207,8 @@ static void init_defaults(void)
 
 	btd_opts.avdtp.session_mode = BT_IO_MODE_BASIC;
 	btd_opts.avdtp.stream_mode = BT_IO_MODE_BASIC;
+
+	btd_opts.a2dp.channels = 0;
 
 	btd_opts.advmon.rssi_sampling_period = 0xFF;
 	btd_opts.csis.encrypt = true;

--- a/src/main.conf
+++ b/src/main.conf
@@ -296,6 +296,11 @@
 # streaming: Use L2CAP Streaming Mode
 #StreamMode = basic
 
+[A2DP]
+# Maximum number of A2DP channels
+# Defaults to 0 (unlimited)
+#Channels = 0
+
 [Policy]
 #
 # The ReconnectUUIDs defines the set of remote services that should try


### PR DESCRIPTION
This introduces Channels which can be used to
limit the number of A2DP channels.

For new option this also adds a new group A2DP to config.

Signed-off-by: Victor Pushkarev <VAnPushkarev@salutedevices.com>
---
 src/btd.h     |  6 ++++++
 src/main.c    | 16 ++++++++++++++++
 src/main.conf |  5 +++++
 3 files changed, 27 insertions(+)