### PR TITLE
[PW_SID:822175] [BlueZ,v1,1/5] client/mgmt: Add missing settings strings

### DIFF
--- a/client/mgmt.c
+++ b/client/mgmt.c
@@ -359,6 +359,8 @@ static const char *settings_str[] = {
 				"wide-band-speech",
 				"cis-central",
 				"cis-peripheral",
+				"iso-broadcaster",
+				"sync-receiver"
 };
 
 static const char *settings2str(uint32_t settings)

--- a/profiles/audio/bap.c
+++ b/profiles/audio/bap.c
@@ -948,7 +948,7 @@ static DBusMessage *set_configuration(DBusConnection *conn, DBusMessage *msg,
 						&setup->qos, setup->caps);
 
 	setup->id = bt_bap_stream_config(setup->stream, &setup->qos,
-						setup->caps, config_cb, ep);
+						setup->caps, config_cb, setup);
 	if (!setup->id) {
 		DBG("Unable to config stream");
 		setup_free(setup);

--- a/profiles/audio/bap.c
+++ b/profiles/audio/bap.c
@@ -974,6 +974,9 @@ static DBusMessage *set_configuration(DBusConnection *conn, DBusMessage *msg,
 			setup->id = 0;
 		}
 
+		if (ep->data->service)
+			service_set_connecting(ep->data->service);
+
 		return g_dbus_create_reply(msg, DBUS_TYPE_INVALID);
 	}
 
@@ -2437,6 +2440,11 @@ static int bap_bcast_probe(struct btd_service *service)
 		return -EINVAL;
 	}
 
+	if (!bt_bap_attach(data->bap, NULL)) {
+		error("BAP unable to attach");
+		return -EINVAL;
+	}
+
 	bap_data_add(data);
 
 	data->ready_id = bt_bap_ready_register(data->bap, bap_ready, service,
@@ -2644,6 +2652,7 @@ static struct btd_profile bap_bcast_profile = {
 	.remote_uuid	= BCAAS_UUID_STR,
 	.device_probe	= bap_bcast_probe,
 	.device_remove	= bap_bcast_remove,
+	.disconnect	= bap_disconnect,
 	.auto_connect	= false,
 	.experimental	= true,
 };

--- a/src/device.c
+++ b/src/device.c
@@ -3276,6 +3276,13 @@ static bool device_disappeared(gpointer user_data)
 {
 	struct btd_device *dev = user_data;
 
+	/* If there are services connecting restart the timer to give more time
+	 * for the service to either complete the connection or disconnect.
+	 */
+	if (find_service_with_state(dev->services,
+					BTD_SERVICE_STATE_CONNECTING))
+		return TRUE;
+
 	dev->temporary_timer = 0;
 
 	btd_adapter_remove_device(dev->adapter, dev);

--- a/src/shared/bap.c
+++ b/src/shared/bap.c
@@ -4156,7 +4156,8 @@ bool bt_bap_attach(struct bt_bap *bap, struct bt_gatt_client *client)
 	queue_foreach(bap_cbs, bap_attached, bap);
 
 	if (!client) {
-		bap_attach_att(bap, bap->att);
+		if (bap->att)
+			bap_attach_att(bap, bap->att);
 		return true;
 	}
 


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

This adds "iso-broadcaster" and "sync-receiver" which were missing.
---
 client/mgmt.c | 2 ++
 1 file changed, 2 insertions(+)