### PR TITLE
[PW_SID:822251] [BlueZ,v2,1/8] client/mgmt: Add missing settings strings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/client/mgmt.c
+++ b/client/mgmt.c
@@ -359,6 +359,8 @@ static const char *settings_str[] = {
 				"wide-band-speech",
 				"cis-central",
 				"cis-peripheral",
+				"iso-broadcaster",
+				"sync-receiver"
 };
 
 static const char *settings2str(uint32_t settings)

--- a/profiles/audio/bap.c
+++ b/profiles/audio/bap.c
@@ -948,7 +948,7 @@ static DBusMessage *set_configuration(DBusConnection *conn, DBusMessage *msg,
 						&setup->qos, setup->caps);
 
 	setup->id = bt_bap_stream_config(setup->stream, &setup->qos,
-						setup->caps, config_cb, ep);
+						setup->caps, config_cb, setup);
 	if (!setup->id) {
 		DBG("Unable to config stream");
 		setup_free(setup);

--- a/profiles/audio/bap.c
+++ b/profiles/audio/bap.c
@@ -974,6 +974,9 @@ static DBusMessage *set_configuration(DBusConnection *conn, DBusMessage *msg,
 			setup->id = 0;
 		}
 
+		if (ep->data->service)
+			service_set_connecting(ep->data->service);
+
 		return g_dbus_create_reply(msg, DBUS_TYPE_INVALID);
 	}
 
@@ -2437,6 +2440,11 @@ static int bap_bcast_probe(struct btd_service *service)
 		return -EINVAL;
 	}
 
+	if (!bt_bap_attach(data->bap, NULL)) {
+		error("BAP unable to attach");
+		return -EINVAL;
+	}
+
 	bap_data_add(data);
 
 	data->ready_id = bt_bap_ready_register(data->bap, bap_ready, service,
@@ -2644,6 +2652,7 @@ static struct btd_profile bap_bcast_profile = {
 	.remote_uuid	= BCAAS_UUID_STR,
 	.device_probe	= bap_bcast_probe,
 	.device_remove	= bap_bcast_remove,
+	.disconnect	= bap_disconnect,
 	.auto_connect	= false,
 	.experimental	= true,
 };

--- a/profiles/audio/transport.c
+++ b/profiles/audio/transport.c
@@ -1539,7 +1539,8 @@ static guint transport_bap_suspend(struct media_transport *transport,
 	id = bt_bap_stream_disable(bap->stream, bap->linked, func, owner);
 
 	if (bt_bap_stream_get_type(bap->stream) == BT_BAP_STREAM_TYPE_BCAST) {
-		bap_disable_complete(bap->stream, 0x00, 0x00, owner);
+		if (transport->owner == owner)
+			bap_disable_complete(bap->stream, 0x00, 0x00, owner);
 		return 0;
 	}
 

--- a/src/device.c
+++ b/src/device.c
@@ -3276,6 +3276,13 @@ static bool device_disappeared(gpointer user_data)
 {
 	struct btd_device *dev = user_data;
 
+	/* If there are services connecting restart the timer to give more time
+	 * for the service to either complete the connection or disconnect.
+	 */
+	if (find_service_with_state(dev->services,
+					BTD_SERVICE_STATE_CONNECTING))
+		return TRUE;
+
 	dev->temporary_timer = 0;
 
 	btd_adapter_remove_device(dev->adapter, dev);

--- a/src/shared/bap.c
+++ b/src/shared/bap.c
@@ -1379,6 +1379,7 @@ static void stream_set_state_broadcast(struct bt_bap_stream *stream,
 		break;
 	case BT_ASCS_ASE_STATE_RELEASING:
 		bap_stream_io_detach(stream);
+		stream_set_state_broadcast(stream, BT_BAP_STREAM_STATE_QOS);
 		break;
 	}
 

--- a/src/shared/bap.c
+++ b/src/shared/bap.c
@@ -4156,7 +4156,8 @@ bool bt_bap_attach(struct bt_bap *bap, struct bt_gatt_client *client)
 	queue_foreach(bap_cbs, bap_attached, bap);
 
 	if (!client) {
-		bap_attach_att(bap, bap->att);
+		if (bap->att)
+			bap_attach_att(bap, bap->att);
 		return true;
 	}
 

--- a/src/shared/bap.c
+++ b/src/shared/bap.c
@@ -1377,9 +1377,13 @@ static void stream_set_state_broadcast(struct bt_bap_stream *stream,
 	case BT_ASCS_ASE_STATE_IDLE:
 		bap_stream_detach(stream);
 		break;
-	case BT_ASCS_ASE_STATE_RELEASING:
+	case BT_ASCS_ASE_STATE_DISABLING:
 		bap_stream_io_detach(stream);
 		stream_set_state_broadcast(stream, BT_BAP_STREAM_STATE_QOS);
+		break;
+	case BT_ASCS_ASE_STATE_RELEASING:
+		bap_stream_io_detach(stream);
+		stream_set_state_broadcast(stream, BT_BAP_STREAM_STATE_IDLE);
 		break;
 	}
 
@@ -5064,7 +5068,7 @@ unsigned int bt_bap_stream_disable(struct bt_bap_stream *stream,
 
 	case BT_BAP_STREAM_TYPE_BCAST:
 		stream_set_state_broadcast(stream,
-					BT_BAP_STREAM_STATE_RELEASING);
+					BT_BAP_STREAM_STATE_DISABLING);
 		return 1;
 	}
 
@@ -5161,11 +5165,8 @@ unsigned int bt_bap_stream_release(struct bt_bap_stream *stream,
 
 	/* If stream is broadcast, no BT_ASCS_RELEASE is required */
 	if (bt_bap_stream_get_type(stream) == BT_BAP_STREAM_TYPE_BCAST) {
-		if (!bap_stream_valid(stream)) {
-			stream_set_state_broadcast(stream,
-					BT_BAP_STREAM_STATE_IDLE);
-			stream = NULL;
-		}
+		stream_set_state_broadcast(stream,
+					BT_BAP_STREAM_STATE_RELEASING);
 		return 0;
 	}
 


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

This adds "iso-broadcaster" and "sync-receiver" which were missing.
---
 client/mgmt.c | 2 ++
 1 file changed, 2 insertions(+)