### PR TITLE
[PW_SID:831152] [BlueZ,v1] shared/bap: Remove bt_bap_stream_bcast_new

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/profiles/audio/bap.c
+++ b/profiles/audio/bap.c
@@ -68,11 +68,6 @@ struct bap_setup {
 	struct bt_bap_qos qos;
 	int (*qos_parser)(struct bap_setup *setup, const char *key, int var,
 							DBusMessageIter *iter);
-	struct bt_bap_stream* (*stream_new)(struct bt_bap *bap,
-					struct bt_bap_pac *lpac,
-					struct bt_bap_pac *rpac,
-					struct bt_bap_qos *pqos,
-					struct iovec *data);
 	GIOChannel *io;
 	unsigned int io_id;
 	bool recreate;
@@ -893,13 +888,11 @@ static struct bap_setup *setup_new(struct bap_ep *ep)
 		setup->qos.bcast.bis = BT_ISO_QOS_BIS_UNSET;
 		setup->qos_parser = setup_parse_bcast_qos;
 		setup->destroy = setup_bcast_destroy;
-		setup->stream_new = bt_bap_stream_bcast_new;
 	} else {
 		/* Mark CIG and CIS to be auto assigned */
 		setup->qos.ucast.cig_id = BT_ISO_QOS_CIG_UNSET;
 		setup->qos.ucast.cis_id = BT_ISO_QOS_CIS_UNSET;
 		setup->qos_parser = setup_parse_ucast_qos;
-		setup->stream_new = bt_bap_stream_new;
 	}
 
 	if (!ep->setups)
@@ -965,7 +958,7 @@ static DBusMessage *set_configuration(DBusConnection *conn, DBusMessage *msg,
 		return btd_error_invalid_args(msg);
 	}
 
-	setup->stream = setup->stream_new(ep->data->bap, ep->lpac, ep->rpac,
+	setup->stream = bt_bap_stream_new(ep->data->bap, ep->lpac, ep->rpac,
 						&setup->qos, setup->caps);
 
 	setup->id = bt_bap_stream_config(setup->stream, &setup->qos,
@@ -1300,7 +1293,7 @@ static void setup_config(void *data, void *user_data)
 	 * and PHY.
 	 */
 	if (!setup->stream)
-		setup->stream = setup->stream_new(ep->data->bap, ep->lpac,
+		setup->stream = bt_bap_stream_new(ep->data->bap, ep->lpac,
 						ep->rpac, &setup->qos,
 						setup->caps);
 

--- a/src/shared/bap.c
+++ b/src/shared/bap.c
@@ -5163,7 +5163,7 @@ int bt_bap_select(struct bt_bap_pac *lpac, struct bt_bap_pac *rpac,
 	return 0;
 }
 
-struct bt_bap_stream *bt_bap_stream_bcast_new(struct bt_bap *bap,
+static struct bt_bap_stream *bap_bcast_stream_new(struct bt_bap *bap,
 					struct bt_bap_pac *lpac,
 					struct bt_bap_pac *rpac,
 					struct bt_bap_qos *pqos,
@@ -5245,66 +5245,20 @@ struct bt_bap_stream *bt_bap_stream_bcast_new(struct bt_bap *bap,
 	return stream;
 }
 
-struct bt_bap_stream *bt_bap_stream_new(struct bt_bap *bap,
+static struct bt_bap_stream *bap_ucast_stream_new(struct bt_bap *bap,
 					struct bt_bap_pac *lpac,
 					struct bt_bap_pac *rpac,
 					struct bt_bap_qos *pqos,
 					struct iovec *data)
 {
-	struct bt_bap_stream *stream;
-	struct bt_bap_endpoint *ep;
+	struct bt_bap_stream *stream = NULL;
+	struct bt_bap_endpoint *ep = NULL;
 	struct match_pac match;
 
-	if (!bap)
+	if (!lpac || !rpac || !bap_codec_equal(&lpac->codec, &rpac->codec))
 		return NULL;
 
-	if (!rpac && (lpac->type != BT_BAP_BCAST_SOURCE)
-		&& queue_isempty(bap->remote_eps))
-		return NULL;
-
-	if (lpac && rpac) {
-		if ((rpac->type != BT_BAP_BCAST_SOURCE)
-			&& (!bap_codec_equal(&lpac->codec, &rpac->codec)))
-			return NULL;
-	} else {
-		uint8_t type;
-
-		match.lpac = lpac;
-		match.rpac = rpac;
-		memset(&match.codec, 0, sizeof(match.codec));
-
-		if (rpac)
-			type = rpac->type;
-		else if (lpac) {
-			switch (lpac->type) {
-			case BT_BAP_SINK:
-				type = BT_BAP_SOURCE;
-				break;
-			case BT_BAP_SOURCE:
-				type = BT_BAP_SINK;
-				break;
-			case BT_BAP_BCAST_SOURCE:
-				type = BT_BAP_BCAST_SINK;
-				break;
-			case BT_BAP_BCAST_SINK:
-				type = BT_BAP_BCAST_SOURCE;
-				break;
-			default:
-				return NULL;
-			}
-		} else
-			return NULL;
-
-		bt_bap_foreach_pac(bap, type, match_pac, &match);
-		if ((!match.lpac) || (!lpac))
-			return NULL;
-		if (!match.rpac && (lpac->type != BT_BAP_BCAST_SOURCE))
-			return NULL;
-
-		lpac = match.lpac;
-		rpac = match.rpac;
-	}
-
+	memset(&match, 0, sizeof(match));
 	match.lpac = lpac;
 	match.rpac = rpac;
 
@@ -5324,6 +5278,22 @@ struct bt_bap_stream *bt_bap_stream_new(struct bt_bap *bap,
 		stream = bap_stream_new(bap, ep, lpac, rpac, data, true);
 
 	return stream;
+}
+
+struct bt_bap_stream *bt_bap_stream_new(struct bt_bap *bap,
+					struct bt_bap_pac *lpac,
+					struct bt_bap_pac *rpac,
+					struct bt_bap_qos *pqos,
+					struct iovec *data)
+{
+	if (!bap)
+		return NULL;
+
+	/* Check if ATT is attached then it must be a unicast stream */
+	if (bt_bap_get_att(bap))
+		return bap_ucast_stream_new(bap, lpac, rpac, pqos, data);
+
+	return bap_bcast_stream_new(bap, lpac, rpac, pqos, data);
 }
 
 struct bt_bap *bt_bap_stream_get_session(struct bt_bap_stream *stream)

--- a/src/shared/bap.h
+++ b/src/shared/bap.h
@@ -244,12 +244,6 @@ struct bt_bap_stream *bt_bap_stream_new(struct bt_bap *bap,
 					struct bt_bap_qos *pqos,
 					struct iovec *data);
 
-struct bt_bap_stream *bt_bap_stream_bcast_new(struct bt_bap *bap,
-					struct bt_bap_pac *lpac,
-					struct bt_bap_pac *rpac,
-					struct bt_bap_qos *pqos,
-					struct iovec *data);
-
 struct bt_bap *bt_bap_stream_get_session(struct bt_bap_stream *stream);
 uint8_t bt_bap_stream_get_state(struct bt_bap_stream *stream);
 


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

This is now handled internally by bt_bap_stream_new by detecting if an
ATT session has been attached.
---
 profiles/audio/bap.c | 11 ++-----
 src/shared/bap.c     | 74 +++++++++++++-------------------------------
 src/shared/bap.h     |  6 ----
 3 files changed, 24 insertions(+), 67 deletions(-)