### PR TITLE
[PW_SID:831169] Add command to create local endpoint in bluetoolct

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/client/player.c
+++ b/client/player.c
@@ -3582,6 +3582,26 @@ static void cmd_register_endpoint(int argc, char *argv[])
 	}
 }
 
+static void cmd_new_local_endpoint(int argc, char *argv[])
+{
+	struct endpoint *ep;
+	char *endptr = NULL;
+
+	ep = g_new0(struct endpoint, 1);
+	ep->uuid = g_strdup(argv[1]);
+	ep->codec = strtol(argv[2], &endptr, 0);
+	ep->cid = 0x0000;
+	ep->vid = 0x0000;
+	ep->path = g_strdup_printf("%s/ep%u", BLUEZ_MEDIA_ENDPOINT_PATH,
+					g_list_length(local_endpoints));
+	local_endpoints = g_list_append(local_endpoints, ep);
+
+	ep->broadcast = true;
+	ep->auto_accept = true;
+	ep->preset = find_presets_name(ep->uuid, argv[2]);
+	bt_shell_printf("Endpoint %s registered\n", ep->path);
+}
+
 static void unregister_endpoint_setup(DBusMessageIter *iter, void *user_data)
 {
 	struct endpoint *ep = user_data;
@@ -4286,6 +4306,10 @@ static const struct bt_shell_menu endpoint_menu = {
 	{ "presets",      "<UUID> <codec[:company]> [default]",
 						cmd_presets_endpoint,
 						"List available presets",
+						uuid_generator },
+	{ "new_local_ep",  "<UUID> <codec[:company]>",
+						cmd_new_local_endpoint,
+						"Create local endpoint",
 						uuid_generator },
 	{} },
 };


### PR DESCRIPTION
In the case of using BlueZ with Pipewire to start a BAP broadcast source,
Pipewire will do the register endpoint but bluetoothctl is still required
to configure the broadcast streams, but no local broadcast endpoint is defined
in bluetoothctl.
To resolve this problem I added the new_local_ep that will create a local
 endpoint that can be used to configure the Bap broadcast source\sink.
Example how to configure a BAP broadcast source:

endpoint.new_local_ep 00001852-0000-1000-8000-00805f9b34fb 0x06
endpoint.config /org/bluez/hci0/pac_bcast0 /local/endpoint/ep0 48_4_1
endpoint.config /org/bluez/hci0/pac_bcast0 /local/endpoint/ep0 48_4_1

---
 client/player.c | 24 ++++++++++++++++++++++++
 1 file changed, 24 insertions(+)