### PR TITLE
[PW_SID:831186] [BlueZ,1/1] avrcp: Add strict checks for supported events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/profiles/audio/avrcp.c
+++ b/profiles/audio/avrcp.c
@@ -4152,21 +4152,26 @@ static void target_init(struct avrcp *session)
 
 		init_volume = media_player_get_device_volume(session->dev);
 		media_transport_update_device_volume(session->dev, init_volume);
-	}
 
-	session->supported_events |= (1 << AVRCP_EVENT_STATUS_CHANGED) |
-				(1 << AVRCP_EVENT_TRACK_CHANGED) |
-				(1 << AVRCP_EVENT_TRACK_REACHED_START) |
-				(1 << AVRCP_EVENT_TRACK_REACHED_END) |
-				(1 << AVRCP_EVENT_SETTINGS_CHANGED);
+		/* These events below requires a player */
+		session->supported_events |= (1 << AVRCP_EVENT_STATUS_CHANGED) |
+					(1 << AVRCP_EVENT_TRACK_CHANGED) |
+					(1 << AVRCP_EVENT_TRACK_REACHED_START) |
+					(1 << AVRCP_EVENT_TRACK_REACHED_END) |
+					(1 << AVRCP_EVENT_SETTINGS_CHANGED);
 
-	if (target->version < 0x0104)
-		return;
+		if (target->version < 0x0104)
+			return;
 
-	session->supported_events |=
+		session->supported_events |=
 				(1 << AVRCP_EVENT_ADDRESSED_PLAYER_CHANGED) |
 				(1 << AVRCP_EVENT_AVAILABLE_PLAYERS_CHANGED) |
 				(1 << AVRCP_EVENT_VOLUME_CHANGED);
+	} else {
+		if (target->version > 0x0103)
+			session->supported_events =
+					(1 << AVRCP_EVENT_VOLUME_CHANGED);
+	}
 
 	/* Only check capabilities if controller is not supported */
 	if (session->controller == NULL)


### PR DESCRIPTION
From: Xiao Yao <xiaoyao@rock-chips.com>

In some resource-limited embedded systems, if the player is not
registered, but the supported event contains the status/track/
settings events that need player support, it will return some
unreasonable values to the peer, which will cause confusion on
the peer device and cause some unknown problems.

In my test scenario, bluez was the role of the source to connect
the bose speaker. bluez could send absolute volume to the bose
speaker, but it could not adjust the volume of bluez. By checking
the btsnoop, we could see that bluez had registered volume change
notification. When I removed the events above, everything worked
fine. I also tested on iPhone/Android and everything worked fine.
---
 profiles/audio/avrcp.c | 23 ++++++++++++++---------
 1 file changed, 14 insertions(+), 9 deletions(-)