### PR TITLE
[PW_SID:832119] [BlueZ] Don't install conf and state dir on systemd

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/Makefile.am
+++ b/Makefile.am
@@ -422,7 +422,12 @@ include Makefile.obexd
 include android/Makefile.am
 include Makefile.mesh
 
+if SYSTEMD
+install-data-hook: obexd-add-service-symlink
+else
 install-data-hook: bluetoothd-fix-permissions obexd-add-service-symlink
+endif
+
 uninstall-hook: obexd-remove-service-symlink
 
 if HID2HCI


### PR DESCRIPTION
The bluetooth.service file already specify the State and Configuration
directories with the correct modes, which guarantee they will be
available (with proper permissions) when bluetoohd starts.

Not installing those helps implementing the "Hermetic /usr" pattern
(TL;DR: '/usr' contains everything necessary to boostrap a working
system)

Handling this in upstream bluez (rather than in distribution packaging
scripts) avoid duplication of efforts between distros.

Links: https://0pointer.net/blog/fitting-everything-together.html
---
 Makefile.am | 5 +++++
 1 file changed, 5 insertions(+)