### PR TITLE
[PW_SID:832173] [BlueZ,v1] build: Fix distcheck

### DIFF
--- a/Makefile.tools
+++ b/Makefile.tools
@@ -539,7 +539,11 @@ endif
 
 if CUPS
 
-cupsdir = $(CUPSDIR)
+if CUPSDIR
+cupsdir = $(CUPSDIR)/backend
+else
+cupsdir = $(libdir)/cups/backend
+endif
 
 cups_PROGRAMS = profiles/cups/bluetooth
 

--- a/configure.ac
+++ b/configure.ac
@@ -247,7 +247,9 @@ AC_ARG_ENABLE(cups, AS_HELP_STRING([--disable-cups],
                 [disable CUPS printer support]), [enable_cups=${enableval}])
 AM_CONDITIONAL(CUPS, test "${enable_cups}" != "no")
 if (test "${enable_cups}" != "no"); then
-   AC_SUBST(CUPSDIR, `$PKG_CONFIG cups --variable=cups_serverbin`/backend)
+	AM_CONDITIONAL(CUPSDIR,
+		test `$PKG_CONFIG cups --variable=cups_serverbin` != "")
+	AC_SUBST(CUPSDIR, `$PKG_CONFIG cups --variable=cups_serverbin`)
 fi
 
 AC_ARG_ENABLE(mesh, AS_HELP_STRING([--enable-mesh],


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

This fixes the following errors:

/usr/bin/mkdir -p '/backend'
/usr/bin/mkdir: cannot create directory ‘/backend’: Permission denied
make[3]: *** [Makefile:4768: install-cupsPROGRAMS] Error 1
---
 Makefile.tools | 6 +++++-
 configure.ac   | 4 +++-
 2 files changed, 8 insertions(+), 2 deletions(-)