### PR TITLE
[PW_SID:834154] [BlueZ] shared/bap: fix setting io on linked stream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/src/shared/bap.c
+++ b/src/shared/bap.c
@@ -5603,7 +5603,7 @@ bool bt_bap_stream_set_io(struct bt_bap_stream *stream, int fd)
 	bap_stream_set_io(stream, INT_TO_PTR(fd));
 
 	if (stream->link)
-		bap_stream_set_io(stream, INT_TO_PTR(fd));
+		bap_stream_set_io(stream->link, INT_TO_PTR(fd));
 
 	return true;
 }


### PR DESCRIPTION
Fix the second bap_stream_set_io call to set the io on the linked
transport, as it's clearly meant to.

Fixes sending duplicate stream stop/start requests.

bluetoothd[588207]: < ACL Data TX: Handle 2048 flags 0x00 dlen 11   #492 [hci1]
      ATT: Write Command (0x52) len 6
        Handle: 0x0098 Type: ASE Control Point (0x2bc6)
          Data: 04020505
            Opcode: Receiver Start Ready (0x04)
            Number of ASE(s): 2
            ASE: #0
            ASE ID: 0x05
            ASE: #1
            ASE ID: 0x05
---
 src/shared/bap.c | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)