### PR TITLE
[PW_SID:835259] [v2] main.conf: Introduce GATT.Client option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/src/btd.h
+++ b/src/btd.h
@@ -140,6 +140,7 @@ struct btd_opts {
 	bt_gatt_cache_t gatt_cache;
 	uint16_t	gatt_mtu;
 	uint8_t		gatt_channels;
+	bool		gatt_client;
 	enum mps_mode_t	mps;
 
 	struct btd_avdtp_opts avdtp;

--- a/src/device.c
+++ b/src/device.c
@@ -5511,6 +5511,10 @@ static void gatt_client_init(struct btd_device *device)
 		DBG("Reverse service discovery disabled: skipping GATT client");
 		return;
 	}
+	if (!device->connect && !btd_opts.gatt_client) {
+		DBG("GATT client disabled: skipping GATT client");
+		return;
+	}
 
 	device->client = bt_gatt_client_new(device->db, device->att,
 							device->att_mtu, 0);

--- a/src/main.c
+++ b/src/main.c
@@ -145,6 +145,7 @@ static const char *gatt_options[] = {
 	"KeySize",
 	"ExchangeMTU",
 	"Channels",
+	"Client",
 	NULL
 };
 
@@ -1058,6 +1059,7 @@ static void parse_gatt(GKeyFile *config)
 				BT_ATT_DEFAULT_LE_MTU, BT_ATT_MAX_LE_MTU);
 	parse_config_u8(config, "GATT", "Channels", &btd_opts.gatt_channels,
 				1, 5);
+	parse_config_bool(config, "GATT", "Client", &btd_opts.gatt_client);
 }
 
 static void parse_csis_sirk(GKeyFile *config)
@@ -1190,6 +1192,7 @@ static void init_defaults(void)
 	btd_opts.gatt_cache = BT_GATT_CACHE_ALWAYS;
 	btd_opts.gatt_mtu = BT_ATT_MAX_LE_MTU;
 	btd_opts.gatt_channels = 1;
+	btd_opts.gatt_client = true;
 
 	btd_opts.avdtp.session_mode = BT_IO_MODE_BASIC;
 	btd_opts.avdtp.stream_mode = BT_IO_MODE_BASIC;

--- a/src/main.conf
+++ b/src/main.conf
@@ -33,7 +33,7 @@
 # us. For BR/EDR this option is really only needed for qualification since the
 # BITE tester doesn't like us doing reverse SDP for some test cases, for LE
 # this disables the GATT client functionally so it can be used in system which
-# can only operate as peripheral.
+# can only operate as peripheral (see also GATT Client option).
 # Defaults to 'true'.
 #ReverseServiceDiscovery = true
 
@@ -282,6 +282,11 @@
 # Rank for the device
 # Defaults to 0
 #Rank = 0
+
+# This enables the GATT client functionally, so it can be disabled in system
+# which can only operate as a peripheral.
+# Defaults to 'true'.
+#Client = true
 
 [AVDTP]
 # AVDTP L2CAP Signalling Channel Mode.


### PR DESCRIPTION
General.ReverseServiceDiscovery option is responsible for two
different things:
 1. It disables SDP reverse discovering. As a side effect, some BR/EDR
 profiles cannot operate properly. E.g. AVRCP-target profile needs SDP
 results to determine the peer's AVRCP version.
 2. It disables GATT-client creation back to the GATT connection
 initiator. It may be useful for peripheral devices, especially if the
 peer doesn't expect them to connect back (and currently some IOS
 versions don't). This behavior was introduced in
 8de73cd12 ("main.conf: Make ReverseServiceDiscovery work with LE")

For peripheral devices implementing only A2DP-sink, AVRCP-target, and
GATT profiles (e.g. BT loudspeakers), it may be useful to disable
GATT-client functionality, but still have SDP reverse discovering.

Unfortunately, splitting the General.ReverseServiceDiscovery option
into two different options will break backward compatibility on the
configuration file level. So a new configuration option has been
introduced in addition to the old one.

Signed-off-by: Sergey Bobrenok <sibobrenok@salutedevices.com>
---
Changes v1 -> v2:
  - replace gboolean with bool
  - rename ReverseClient option to Client
---
 src/btd.h     | 1 +
 src/device.c  | 4 ++++
 src/main.c    | 3 +++
 src/main.conf | 7 ++++++-
 4 files changed, 14 insertions(+), 1 deletion(-)


base-commit: 3ad367874630bb62719ea02184a473cb1efeca34