### PR TITLE
[PW_SID:836449] shared/util: Add util_iov_append function

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/src/shared/bap.c
+++ b/src/shared/bap.c
@@ -326,12 +326,6 @@ static bool bap_db_match(const void *data, const void *match_data)
 	return (bdb->db == db);
 }
 
-static void *iov_append(struct iovec *iov, size_t len, const void *d)
-{
-	iov->iov_base = realloc(iov->iov_base, iov->iov_len + len);
-	return util_iov_push_mem(iov, len, d);
-}
-
 unsigned int bt_bap_pac_register(struct bt_bap *bap, bt_bap_pac_func_t added,
 				bt_bap_pac_func_t removed, void *user_data,
 				bt_bap_destroy_func_t destroy)
@@ -3049,9 +3043,9 @@ static void *ltv_merge(struct iovec *data, struct iovec *cont)
 	if (!cont || !cont->iov_len || !cont->iov_base)
 		return data->iov_base;
 
-	iov_append(data, sizeof(delimiter), &delimiter);
+	util_iov_append(data, &delimiter, sizeof(delimiter));
 
-	return iov_append(data, cont->iov_len, cont->iov_base);
+	return util_iov_append(data, cont->iov_base, cont->iov_len);
 }
 
 static void bap_pac_foreach_channel(size_t i, uint8_t l, uint8_t t, uint8_t *v,
@@ -6081,9 +6075,9 @@ static void extract_ltv(size_t i, uint8_t l, uint8_t t, uint8_t *v,
 
 	if (!ltv_match.found) {
 		ltv_len = l + 1;
-		iov_append(ext_data->result, 1, &ltv_len);
-		iov_append(ext_data->result, 1, &t);
-		iov_append(ext_data->result, l, v);
+		util_iov_append(ext_data->result, &ltv_len, 1);
+		util_iov_append(ext_data->result, &t, 1);
+		util_iov_append(ext_data->result, v, l);
 	}
 }
 

--- a/src/shared/util.c
+++ b/src/shared/util.c
@@ -536,6 +536,12 @@ void *util_iov_push_u8(struct iovec *iov, uint8_t val)
 	return p;
 }
 
+void *util_iov_append(struct iovec *iov, const void *data, size_t len)
+{
+	iov->iov_base = realloc(iov->iov_base, iov->iov_len + len);
+	return util_iov_push_mem(iov, len, data);
+}
+
 void *util_iov_pull(struct iovec *iov, size_t len)
 {
 	if (!iov)

--- a/src/shared/util.h
+++ b/src/shared/util.h
@@ -175,6 +175,7 @@ void *util_iov_push_be24(struct iovec *iov, uint32_t val);
 void *util_iov_push_le16(struct iovec *iov, uint16_t val);
 void *util_iov_push_be16(struct iovec *iov, uint16_t val);
 void *util_iov_push_u8(struct iovec *iov, uint8_t val);
+void *util_iov_append(struct iovec *iov, const void *data, size_t len);
 void *util_iov_pull(struct iovec *iov, size_t len);
 void *util_iov_pull_mem(struct iovec *iov, size_t len);
 void *util_iov_pull_le64(struct iovec *iov, uint64_t *val);


### PR DESCRIPTION
Currently iov_append is defined in 2 places, client/player.c and
src/shared/bap.c. The player.c implementation is faulty as it
does not allocate additional memory for the data that it appends
to the original iovec. This can cause buffer overflows such as
the one attached at the end of this message, which was discovered
while running an Unicast setup. Therefore, the implementation from
src/shared/bap.c was used to create util_iov_append as it allocates
new memory appropriately.

==131878==ERROR: AddressSanitizer: heap-buffer-overflow on address
0x602000059dda at pc 0x7feee2e70ea3 bp 0x7ffd415773f0 sp 0x7ffd41576b98
WRITE of size 6 at 0x602000059dda thread T0
0 0x7feee2e70ea2 in __interceptor_memcpy ../../../../src/libsanitizer
/sanitizer_common/sanitizer_common_interceptors.inc:899
1 0x5579661314aa in memcpy /usr/include/x86_64-linux-gnu/bits/
string_fortified.h:29
2 0x5579661314aa in iov_append client/player.c:2120
3 0x557966132169 in endpoint_select_properties_reply client/player.c:2191
4 0x557966132a6f in endpoint_select_properties client/player.c:2268
5 0x55796616e0b4 in process_message gdbus/object.c:246
---
 src/shared/util.c | 6 ++++++
 src/shared/util.h | 1 +
 2 files changed, 7 insertions(+)