### PR TITLE
[PW_SID:836647] [v1] tools/btattach: Add support for all QCA soc_types

### DIFF
--- a/tools/btattach.rst
+++ b/tools/btattach.rst
@@ -62,6 +62,8 @@ OPTIONS
 
 -S baudrate, --speed baudrate       Specify wich baudrate to use
 
+-T soc_type, --type soc_type        Specify soc_type for protocol qca
+
 -N, --noflowctl            Disable flow control
 
 -v, --version              Show version

--- a/tools/hciattach.h
+++ b/tools/hciattach.h
@@ -19,6 +19,8 @@
 #define HCIUARTGETDEVICE	_IOR('U', 202, int)
 #define HCIUARTSETFLAGS		_IOW('U', 203, int)
 #define HCIUARTGETFLAGS		_IOR('U', 204, int)
+#define HCIUARTSETPROTODATA    _IOW('U', 205, unsigned long)
+
 
 #define HCI_UART_H4	0
 #define HCI_UART_BCSP	1


### PR DESCRIPTION
Tool btattach currently only supports QCA default soc_type
QCA_ROME, this change adds support for all other QCA soc_types
by adding a option to specify soc_type.
---
 tools/btattach.c   | 29 ++++++++++++++++++++++++-----
 tools/btattach.rst |  2 ++
 tools/hciattach.h  |  2 ++
 3 files changed, 28 insertions(+), 5 deletions(-)