### PR TITLE
[PW_SID:836816] [BlueZ,v1] shared/btsnoop: Add proper identifiers for ISO packets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/src/shared/btsnoop.c
+++ b/src/shared/btsnoop.c
@@ -305,6 +305,9 @@ static uint32_t get_flags_from_opcode(uint16_t opcode)
 	case BTSNOOP_OPCODE_SCO_TX_PKT:
 	case BTSNOOP_OPCODE_SCO_RX_PKT:
 		break;
+	case BTSNOOP_OPCODE_ISO_TX_PKT:
+	case BTSNOOP_OPCODE_ISO_RX_PKT:
+		break;
 	case BTSNOOP_OPCODE_OPEN_INDEX:
 	case BTSNOOP_OPCODE_CLOSE_INDEX:
 		break;
@@ -428,6 +431,14 @@ static bool pklg_read_hci(struct btsnoop *btsnoop, struct timeval *tv,
 		*index = 0x0000;
 		*opcode = BTSNOOP_OPCODE_SCO_RX_PKT;
 		break;
+	case 0x12:
+		*index = 0x0000;
+		*opcode = BTSNOOP_OPCODE_ISO_TX_PKT;
+		break;
+	case 0x13:
+		*index = 0x0000;
+		*opcode = BTSNOOP_OPCODE_ISO_RX_PKT;
+		break;
 	case 0x0b:
 		*index = 0x0000;
 		*opcode = BTSNOOP_OPCODE_VENDOR_DIAG;
@@ -470,6 +481,11 @@ static uint16_t get_opcode_from_flags(uint8_t type, uint32_t flags)
 			return BTSNOOP_OPCODE_SCO_TX_PKT;
 	case 0x04:
 		return BTSNOOP_OPCODE_EVENT_PKT;
+	case 0x05:
+		if (flags & 0x01)
+			return BTSNOOP_OPCODE_ISO_RX_PKT;
+		else
+			return BTSNOOP_OPCODE_ISO_TX_PKT;
 	case 0xff:
 		if (flags & 0x02) {
 			if (flags & 0x01)


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

This adds ISO packets identifiers so they are properly stored on files.
---
 src/shared/btsnoop.c | 16 ++++++++++++++++
 1 file changed, 16 insertions(+)