### PR TITLE
[PW_SID:836840] Fix crash in iov_append_ltv function

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/client/player.c
+++ b/client/player.c
@@ -3553,22 +3553,6 @@ done:
 	endpoint_set_config(cfg);
 }
 
-static struct iovec *iov_append_ltv(struct iovec **iov, uint8_t l,
-					uint8_t t, void *v)
-{
-	if (!*iov)
-		*iov = new0(struct iovec, 1);
-
-	if (!((*iov)->iov_base))
-		(*iov)->iov_base = new0(uint8_t, l + 1);
-
-	util_iov_push_u8(*iov, l);
-	util_iov_push_u8(*iov, t);
-	util_iov_push_mem(*iov, l - 1, v);
-
-	return *iov;
-}
-
 static void config_endpoint_channel_location(const char *input, void *user_data)
 {
 	struct endpoint_config *cfg = user_data;
@@ -3587,7 +3571,7 @@ static void config_endpoint_channel_location(const char *input, void *user_data)
 
 	/* Add Channel Allocation LTV in capabilities */
 	location = cpu_to_le32(location);
-	iov_append_ltv(&cfg->caps, LC3_CONFIG_CHAN_ALLOC_LEN,
+	util_ltv_push(cfg->caps, LC3_CONFIG_CHAN_ALLOC_LEN - 1,
 			LC3_CONFIG_CHAN_ALLOC, &location);
 
 add_meta:


### PR DESCRIPTION
Fix function iov_append_ltv crashes because is not reallocating memory
Use util_ltv_push from util.c

[bluetooth]# [NEW] Endpoint /org/bluez/hci0/pac_bcast0
[bluetooth]# Endpoint /local/endpoint/ep0 registered
endpoint.config /org/bluez/hci0/pac_bcast0 /local/endpoint/ep0 48_4_1
[/local/endpoint/ep0] BIG (auto/value): 0
[/local/endpoint/ep0] Enter channel location (value/no): 3
=================================================================
==80806==ERROR: AddressSanitizer: heap-buffer-overflow on
 address 0x60200000a8ba at pc 0x561971611e0e bp 0x7ffd45ab1f00
 sp 0x7ffd45ab1ef0 WRITE of size 1 at 0x60200000a8ba thread T0
  0x561971611e0d in put_u8 src/shared/util.h:254
  0x561971611e0d in util_iov_push_u8 src/shared/util.c:534
  0x5619715c28f0 in iov_append_ltv client/player.c:3565
  0x5619715c28f0 in config_endpoint_channel_location client/player.c:3593
  0x5619716226ce in bt_shell_release_prompt src/shared/shell.c:744
  0x561971623087 in rl_handler src/shared/shell.c:769
---
 client/player.c | 18 +-----------------
 1 file changed, 1 insertion(+), 17 deletions(-)