### PR TITLE
[PW_SID:837373] [BlueZ,v1] bap: Fix not setting adapter address type

### DIFF
--- a/profiles/audio/bap.c
+++ b/profiles/audio/bap.c
@@ -2734,6 +2734,8 @@ static int short_lived_pa_sync(struct bap_bcast_pa_req *req)
 			NULL, &err,
 			BT_IO_OPT_SOURCE_BDADDR,
 			btd_adapter_get_address(data->adapter),
+			BT_IO_OPT_SOURCE_TYPE,
+			btd_adapter_get_address_type(data->adapter),
 			BT_IO_OPT_DEST_BDADDR,
 			device_get_address(data->device),
 			BT_IO_OPT_DEST_TYPE,


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

This fixes not setting adapter address type when listening for
broadcasters (aka Broadcast Sink).
---
 profiles/audio/bap.c | 2 ++
 1 file changed, 2 insertions(+)