### PR TITLE
[PW_SID:837824] [Bluez] Advertising: Emit features property update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/src/advertising.c
+++ b/src/advertising.c
@@ -1890,6 +1890,19 @@ static void read_adv_features_callback(uint8_t status, uint16_t length,
 	/* Reset existing instances */
 	if (feat->num_instances)
 		remove_advertising(manager, 0);
+
+	/* Emit property update */
+	g_dbus_emit_property_changed(btd_get_dbus_connection(),
+		adapter_get_path(manager->adapter),
+		LE_ADVERTISING_MGR_IFACE, "SupportedFeatures");
+
+	g_dbus_emit_property_changed(btd_get_dbus_connection(),
+		adapter_get_path(manager->adapter),
+		LE_ADVERTISING_MGR_IFACE, "SupportedIncludes");
+
+	g_dbus_emit_property_changed(btd_get_dbus_connection(),
+		adapter_get_path(manager->adapter),
+		LE_ADVERTISING_MGR_IFACE, "SupportedSecondaryChannels");
 }
 
 static void read_controller_cap_complete(uint8_t status, uint16_t length,


### PR DESCRIPTION
From: Yun-Hao Chung <howardchung@google.com>

Advertising manager has some properties that relies on kernel
information. Once we received the information from kernel, we should
emit property update.

Reviewed-by: apusaka <apusaka@chromium.org>
---

 src/advertising.c | 13 +++++++++++++
 1 file changed, 13 insertions(+)