### PR TITLE
[PW_SID:838695] [BlueZ,v1] obexd: Fix "Size" use g_dbus_emit_property_changed_full() to emit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/obexd/src/manager.c
+++ b/obexd/src/manager.c
@@ -528,8 +528,13 @@ void manager_emit_transfer_property(struct obex_transfer *transfer,
 	if (transfer->path == NULL)
 		return;
 
-	g_dbus_emit_property_changed(connection, transfer->path,
-					TRANSFER_INTERFACE, name);
+	if (strcasecmp("Size", name) == 0)
+		g_dbus_emit_property_changed_full(connection, transfer->path,
+					TRANSFER_INTERFACE, name,
+					G_DBUS_PROPERTY_CHANGED_FLAG_FLUSH);
+	else
+		g_dbus_emit_property_changed(connection, transfer->path,
+						TRANSFER_INTERFACE, name);
 }
 
 void manager_emit_transfer_started(struct obex_transfer *transfer)


### PR DESCRIPTION
This is the comment for g_dbus_emit_property_changed()
/*
 * Note that when multiple properties for a given object path are changed
 * in the same mainloop iteration, they will be grouped with the last
 * property changed. If this behaviour is undesired, use
 * g_dbus_emit_property_changed_full() with the
 * G_DBUS_PROPERTY_CHANGED_FLAG_FLUSH flag, causing the signal to ignore
 * any grouping.
 */

When receiving a "small file" through Bluetooth, When using Blueman to
transfer files to the configured directory, "small files" in the cache
will not be moved to the configured directory. Debugging found that the
three properties "Size" "Transferred" and "complete" were reported at once
through the g_dbus_emit_property_changed function, but the "Size" property
did not have a value, it appears that there are the following errors
"UnicodeDecodeError: 'utf-8' codec can't decode byte 0xb5 in position 0:
invalid start byte" in Blueman log.
So let the "Size" property use g_dbus_emit_property_changed_full to
single emit, if use g_dbus_emit_property_changed（grouped）to emit,
there is a possibility that "Size" property value has been freed

The following is the issue log

dbus-monitor log:

signal time=1710900297.140618 sender=:1.50 -> destination=(null)
serial=59 path=/org/bluez/obex/server/session4/transfer3;
interface=org.freedesktop.DBus.Properties; member=PropertiesChanged

   string "org.bluez.obex.Transfer1"
   array [
      dict entry(
         string "Status"
         variant             string "complete"
      )
      dict entry(
         string "Transferred"
         variant             uint64 0
      )
   ]
   array [
      string "Size"
   ]
method call time=1710900297.141361 sender=:1.39 -> destination=:1.50
serial=417 path=/org/bluez/obex/server/session4/transfer3;
 interface=org.freedesktop.DBus.Properties; member=Get

   string "org.bluez.obex.Transfer1"
   string "Size"
error time=1710900297.141596 sender=:1.50 -> destination=:1.39
error_name=org.freedesktop.DBus.Error.InvalidArgs reply_serial=417

   string "No such property 'Size'"

blueman log

blueman.desktop[2368]: blueman-applet 09.42.04 DEBUG
Transfer:25 do_g_properties_changed: /org/bluez/obex/server/session2/
transfer1 Transferred 0
blueman.desktop[2368]: blueman-applet 09.42.04 DEBUG
Base:74 do_g_properties_changed: /org/bluez/obex/server/session2
{'Source': 'xxx', 'Destination': 'xxx', 'Root': 'xxx/.cache/obexd'}
blueman.desktop[2368]: blueman-applet 09.42.04 ERROR
TransferService:97 _authorize_push: Failed to get StatusIcon
blueman.desktop[2368]: blueman-applet 09.42.15 INFO
Notification:239 do_g_signal: accept
blueman.desktop[2368]: blueman-applet 09.42.15 INFO
TransferService:57 on_action : Action accept
blueman.desktop[2368]: blueman-applet 09.42.15 INFO
Notification:239 do_g_signal: 3
blueman.desktop[2368]: blueman-applet 09.42.15 DEBUG
Notification:247 do_g_signal: The notification was closed by a call
to CloseNotification.
blueman.desktop[2368]:UnicodeDecodeError: 'utf-8' codec can't decode byte
0xb5 in position 0: invalid start byte
blueman.desktop[2368]: blueman-applet 09.42.15 INFO
Manager:73 _on_object_removed: /org/bluez/obex/server/session2/transfer1
blueman.desktop[2368]: blueman-applet 09.42.15 INFO
Manager:80 _on_object_removed: /org/bluez/obex/server/session2

After fix, The following log

dbus-monitor log:

signal time=1711000976.672383 sender=:1.724 -> destination=(null)
serial=18 path=/org/bluez/obex/server/session1/transfer0;
interface=org.freedesktop.DBus.Properties; member=PropertiesChanged

   string "org.bluez.obex.Transfer1"
   array [
      dict entry(
         string "Size"
         variant             uint64 50
      )
   ]
   array [
   ]
signal time=1711000976.672483 sender=:1.724 -> destination=(null)
serial=19 path=/org/bluez/obex/server/session1/transfer0;
interface=org.freedesktop.DBus.Properties; member=PropertiesChanged

   string "org.bluez.obex.Transfer1"
   array [
      dict entry(
         string "Status"
         variant             string "complete"
      )
      dict entry(
         string "Transferred"
         variant             uint64 0
      )
   ]
   array [
   ]

blueman log

blueman.desktop[2368]: blueman-applet 14.13.29 DEBUG
Transfer:25 do_g_properties_changed: /org/bluez/obex/server/session2/
transfer1 Transferred 0
blueman.desktop[2368]: blueman-applet 14.13.29 DEBUG
Base:74 do_g_properties_changed: /org/bluez/obex/server/session2
{'Source': 'xxx', 'Destination': 'xxx', 'Root': 'xxx'}
blueman.desktop[2368]: blueman-applet 14.13.29 ERROR
TransferService:97 _authorize_push: Failed to get StatusIcon
blueman.desktop[2368]: blueman-applet 14.13.36 INFO
Notification:239 do_g_signal: accept
blueman.desktop[2368]: blueman-applet 14.13.36 INFO
TransferService:57 on_action : Action accept
blueman.desktop[2368]: blueman-applet 14.13.36 INFO
Notification:239 do_g_signal: 3
blueman.desktop[2368]: blueman-applet 14.13.36 DEBUG
Notification:247 do_g_signal: The notification was closed by a call to
CloseNotification.
blueman.desktop[2368]: blueman-applet 14.13.36 DEBUG
Transfer:25 do_g_properties_changed: /org/bluez/obex/server/session2/
transfer1 Size 50
blueman.desktop[2368]: blueman-applet 14.13.36 DEBUG
Transfer:25 do_g_properties_changed: /org/bluez/obex/server/session2/
transfer1 Status complete
blueman.desktop[2368]: blueman-applet 14.13.36 INFO
Manager:86 _on_transfer_completed: /org/bluez/obex/server/session2/
transfer1 True
blueman.desktop[2368]: blueman-applet 14.13.36 INFO
TransferService:275 _on_transfer_completed: Destination file exists,
renaming to: xxx.txt
blueman.desktop[2368]: blueman-applet 14.13.36 ERROR
TransferService:256 _notify_kwargs: No statusicon found
blueman.desktop[2368]: blueman-applet 14.13.36 INFO
TransferService:241 _add_open : adding action
blueman.desktop[2368]: blueman-applet 14.13.36 DEBUG
Transfer:25 do_g_properties_changed: /org/bluez/obex/server/session2/
transfer1 Transferred 0
blueman.desktop[2368]: blueman-applet 14.13.36 INFO
Manager:73 _on_object_removed: /org/bluez/obex/server/session2/transfer1
blueman.desktop[2368]: blueman-applet 14.13.36 INFO
Manager:80 _on_object_removed: /org/bluez/obex/server/session2

Signed-off-by: Youwan Wang <youwan@nfschina.com>
---
 obexd/src/manager.c | 9 +++++++--
 1 file changed, 7 insertions(+), 2 deletions(-)