### PR TITLE
[PW_SID:840594] iso-tester: Add test for Broadcast Receiver Get BASE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/emulator/bthost.c
+++ b/emulator/bthost.c
@@ -5,7 +5,7 @@
  *
  *  Copyright (C) 2011-2012  Intel Corporation
  *  Copyright (C) 2004-2010  Marcel Holtmann <marcel@holtmann.org>
- *  Copyright 2023 NXP
+ *  Copyright 2023-2024 NXP
  *
  *
  */
@@ -3125,6 +3125,52 @@ void bthost_set_pa_params(struct bthost *bthost)
 	memset(&cp, 0, sizeof(cp));
 	cp.handle = 0x01;
 	send_command(bthost, BT_HCI_CMD_LE_SET_PA_PARAMS, &cp, sizeof(cp));
+}
+
+static void set_pa_data(struct bthost *bthost, const uint8_t *data,
+				uint8_t len, uint8_t offset)
+{
+	struct bt_hci_cmd_le_set_pa_data *cp;
+	uint8_t buf[sizeof(*cp) + HCI_MAX_PER_AD_LENGTH];
+
+	cp = (void *)buf;
+
+	memset(cp, 0, sizeof(*cp));
+	memset(cp->data, 0, HCI_MAX_PER_AD_LENGTH);
+
+	cp->handle = 1;
+
+	if (len - offset > HCI_MAX_PER_AD_LENGTH) {
+		cp->data_len = HCI_MAX_PER_AD_LENGTH;
+
+		if (!offset)
+			cp->operation = 0x01;
+		else
+			cp->operation = 0x00;
+	} else {
+		cp->data_len = len - offset;
+
+		if (!offset)
+			cp->operation = 0x03;
+		else
+			cp->operation = 0x02;
+	}
+
+	memcpy(cp->data, data + offset, cp->data_len);
+
+	send_command(bthost, BT_HCI_CMD_LE_SET_PA_DATA, buf,
+					sizeof(*cp) + cp->data_len);
+
+	if (cp->operation == 0x01 || cp->operation == 0x00) {
+		offset += cp->data_len;
+		set_pa_data(bthost, data, len, offset);
+	}
+}
+
+void bthost_set_pa_data(struct bthost *bthost, const uint8_t *data,
+							uint8_t len)
+{
+	set_pa_data(bthost, data, len, 0);
 }
 
 void bthost_set_pa_enable(struct bthost *bthost, uint8_t enable)

--- a/emulator/bthost.h
+++ b/emulator/bthost.h
@@ -5,7 +5,7 @@
  *
  *  Copyright (C) 2011-2012  Intel Corporation
  *  Copyright (C) 2004-2010  Marcel Holtmann <marcel@holtmann.org>
- *  Copyright 2023 NXP
+ *  Copyright 2023-2024 NXP
  *
  *
  */
@@ -102,6 +102,8 @@ void bthost_set_ext_adv_data(struct bthost *bthost, const uint8_t *data,
 void bthost_set_ext_adv_params(struct bthost *bthost);
 void bthost_set_ext_adv_enable(struct bthost *bthost, uint8_t enable);
 void bthost_set_pa_params(struct bthost *bthost);
+void bthost_set_pa_data(struct bthost *bthost, const uint8_t *data,
+								uint8_t len);
 void bthost_set_pa_enable(struct bthost *bthost, uint8_t enable);
 void bthost_create_big(struct bthost *bthost, uint8_t num_bis, uint8_t enc,
 				const uint8_t *bcode);

--- a/lib/bluetooth.h
+++ b/lib/bluetooth.h
@@ -6,7 +6,7 @@
  *  Copyright (C) 2000-2001  Qualcomm Incorporated
  *  Copyright (C) 2002-2003  Maxim Krasnyansky <maxk@qualcomm.com>
  *  Copyright (C) 2002-2010  Marcel Holtmann <marcel@holtmann.org>
- *  Copyright 2023 NXP
+ *  Copyright 2023-2024 NXP
  *
  *
  */
@@ -190,6 +190,9 @@ struct bt_iso_bcast_qos {
 	uint8_t  mse;
 	uint16_t timeout;
 };
+
+#define HCI_MAX_PER_AD_LENGTH	252
+#define EIR_SERVICE_DATA_LENGTH	4
 
 /* (HCI_MAX_PER_AD_LENGTH - EIR_SERVICE_DATA_LENGTH) */
 #define BASE_MAX_LENGTH 248

--- a/tools/iso-tester.c
+++ b/tools/iso-tester.c
@@ -23,6 +23,7 @@
 #include "lib/bluetooth.h"
 #include "lib/iso.h"
 #include "lib/mgmt.h"
+#include "lib/uuid.h"
 
 #include "monitor/bt.h"
 #include "emulator/vhci.h"
@@ -33,6 +34,8 @@
 #include "src/shared/mgmt.h"
 #include "src/shared/util.h"
 #include "src/shared/queue.h"
+
+#define EIR_SERVICE_DATA_16	0x16
 
 #define QOS_IO(_interval, _latency, _sdu, _phy, _rtn) \
 { \
@@ -487,6 +490,7 @@ struct iso_client_data {
 	size_t base_len;
 	bool listen_bind;
 	bool pa_bind;
+	bool big;
 };
 
 typedef bool (*iso_defer_accept_t)(struct test_data *data, GIOChannel *io);
@@ -1301,6 +1305,7 @@ static const struct iso_client_data bcast_16_2_1_recv = {
 	.recv = &send_16_2_1,
 	.bcast = true,
 	.server = true,
+	.big = true,
 };
 
 static const struct iso_client_data bcast_enc_16_2_1_recv = {
@@ -1309,6 +1314,7 @@ static const struct iso_client_data bcast_enc_16_2_1_recv = {
 	.recv = &send_16_2_1,
 	.bcast = true,
 	.server = true,
+	.big = true,
 };
 
 static const struct iso_client_data bcast_16_2_1_recv_defer = {
@@ -1319,6 +1325,7 @@ static const struct iso_client_data bcast_16_2_1_recv_defer = {
 	.bcast = true,
 	.server = true,
 	.listen_bind = true,
+	.big = true,
 };
 
 static const struct iso_client_data bcast_16_2_1_recv_defer_no_bis = {
@@ -1327,6 +1334,7 @@ static const struct iso_client_data bcast_16_2_1_recv_defer_no_bis = {
 	.defer = true,
 	.bcast = true,
 	.server = true,
+	.big = true,
 };
 
 static const struct iso_client_data bcast_16_2_1_recv_defer_pa_bind = {
@@ -1336,6 +1344,17 @@ static const struct iso_client_data bcast_16_2_1_recv_defer_pa_bind = {
 	.bcast = true,
 	.server = true,
 	.pa_bind = true,
+	.big = true,
+};
+
+static const struct iso_client_data bcast_16_2_1_recv_defer_get_base = {
+	.qos = QOS_IN_16_2_1,
+	.expect_err = 0,
+	.defer = true,
+	.bcast = true,
+	.server = true,
+	.base = base_lc3_ac_12,
+	.base_len = sizeof(base_lc3_ac_12),
 };
 
 static const struct iso_client_data bcast_ac_12 = {
@@ -1498,9 +1517,28 @@ static void setup_powered_callback(uint8_t status, uint16_t length,
 		if (isodata->bcast) {
 			bthost_set_pa_params(host);
 			bthost_set_pa_enable(host, 0x01);
-			bthost_create_big(host, 1,
-					isodata->qos.bcast.encryption,
-					isodata->qos.bcast.bcode);
+
+			if (isodata->base) {
+				uint8_t eir[HCI_MAX_PER_AD_LENGTH] = {0};
+				uint16_t eir_len = 0;
+
+				eir[eir_len++] = EIR_SERVICE_DATA_LENGTH - 1 +
+							isodata->base_len;
+				eir[eir_len++] = EIR_SERVICE_DATA_16;
+				put_le16(BAA_SERVICE, &eir[eir_len]);
+				eir_len += 2;
+				memcpy(&eir[eir_len], isodata->base,
+							isodata->base_len);
+				eir_len += isodata->base_len;
+
+				bthost_set_pa_data(host, eir, eir_len);
+			}
+
+			if (isodata->big)
+				bthost_create_big(host, 1,
+						isodata->qos.bcast.encryption,
+						isodata->qos.bcast.bcode);
+
 		} else if (!isodata->send && isodata->recv) {
 			const uint8_t *bdaddr;
 
@@ -2183,6 +2221,7 @@ static gboolean iso_connect(GIOChannel *io, GIOCondition cond,
 	socklen_t len;
 	struct bt_iso_qos qos;
 	bool ret = true;
+	uint8_t base[BASE_MAX_LENGTH] = {0};
 
 	sk = g_io_channel_unix_get_fd(io);
 
@@ -2209,6 +2248,27 @@ static gboolean iso_connect(GIOChannel *io, GIOCondition cond,
 		data->step = 0;
 		tester_test_failed();
 		return FALSE;
+	}
+
+	if (isodata->bcast && isodata->server && isodata->base) {
+		len = BASE_MAX_LENGTH;
+
+		if (getsockopt(sk, SOL_BLUETOOTH, BT_ISO_BASE,
+				base, &len) < 0) {
+			tester_warn("Can't get socket option : %s (%d)",
+						strerror(errno), errno);
+			data->step = 0;
+			tester_test_failed();
+			return FALSE;
+		}
+
+		if (len != isodata->base_len ||
+				memcmp(base, isodata->base, len)) {
+			tester_warn("Unexpected BASE");
+			data->step = 0;
+			tester_test_failed();
+			return FALSE;
+		}
 	}
 
 	len = sizeof(sk_err);
@@ -3383,6 +3443,10 @@ int main(int argc, char *argv[])
 					&bcast_16_2_1_recv_defer_pa_bind,
 					setup_powered,
 					test_bcast_recv_defer);
+	test_iso("ISO Broadcaster Receiver Defer Get BASE - Success",
+					&bcast_16_2_1_recv_defer_get_base,
+					setup_powered,
+					test_bcast_recv);
 
 	test_iso("ISO Broadcaster AC 12 - Success", &bcast_ac_12, setup_powered,
 							test_bcast);


### PR DESCRIPTION
This adds the HCI_MAX_PER_AD_LENGTH and EIR_SERVICE_DATA_LENGTH macros.
---
 lib/bluetooth.h | 5 ++++-
 1 file changed, 4 insertions(+), 1 deletion(-)