### PR TITLE
[PW_SID:840719] [BlueZ] adapter: add support for setting NO_ERRQUEUE_POLL experimental feature

### DIFF
--- a/src/adapter.c
+++ b/src/adapter.c
@@ -148,6 +148,13 @@ static const struct mgmt_exp_uuid iso_socket_uuid = {
 	.str = "6fbaf188-05e0-496a-9885-d6ddfdb4e03e"
 };
 
+/* 69518c4c-b69f-4679-8bc1-c021b47b5733 */
+static const struct mgmt_exp_uuid no_errqueue_poll_uuid = {
+	.val = { 0x33, 0x57, 0x7b, 0xb4, 0x21, 0xc0, 0xc1, 0x8b,
+		0x79, 0x46, 0x9f, 0xb6, 0x4c, 0x8c, 0x51, 0x69 },
+	.str = "69518c4c-b69f-4679-8bc1-c021b47b5733"
+};
+
 static DBusConnection *dbus_conn = NULL;
 
 static uint32_t kernel_features = 0;
@@ -10027,6 +10034,44 @@ static void iso_socket_func(struct btd_adapter *adapter, uint8_t action)
 	btd_error(adapter->dev_id, "Failed to set ISO Socket");
 }
 
+static void no_errqueue_poll_complete(uint8_t status, uint16_t len,
+				const void *param, void *user_data)
+{
+	struct exp_pending *pending = user_data;
+	struct btd_adapter *adapter = pending->adapter;
+	uint8_t action;
+
+	if (status != 0) {
+		error("Set No Errqueue Poll failed with status 0x%02x (%s)",
+						status, mgmt_errstr(status));
+		return;
+	}
+
+	action = btd_kernel_experimental_enabled(no_errqueue_poll_uuid.str);
+
+	DBG("No Errqueue Poll successfully %s", action ? "set" : "reset");
+
+	if (action)
+		queue_push_tail(adapter->exps,
+					(void *)no_errqueue_poll_uuid.val);
+}
+
+static void no_errqueue_poll_func(struct btd_adapter *adapter, uint8_t action)
+{
+	struct mgmt_cp_set_exp_feature cp;
+
+	memset(&cp, 0, sizeof(cp));
+	memcpy(cp.uuid, no_errqueue_poll_uuid.val, 16);
+	cp.action = action;
+
+	if (exp_mgmt_send(adapter, MGMT_OP_SET_EXP_FEATURE,
+			MGMT_INDEX_NONE, sizeof(cp), &cp,
+			no_errqueue_poll_complete))
+		return;
+
+	btd_error(adapter->dev_id, "Failed to set No Errqueue Poll");
+}
+
 static const struct exp_feat {
 	uint32_t flag;
 	const struct mgmt_exp_uuid *uuid;
@@ -10041,6 +10086,8 @@ static const struct exp_feat {
 	EXP_FEAT(EXP_FEAT_CODEC_OFFLOAD, &codec_offload_uuid,
 		codec_offload_func),
 	EXP_FEAT(EXP_FEAT_ISO_SOCKET, &iso_socket_uuid, iso_socket_func),
+	EXP_FEAT(EXP_FEAT_NO_ERRQUEUE_POLL, &no_errqueue_poll_uuid,
+							no_errqueue_poll_func),
 };
 
 static void read_exp_features_complete(uint8_t status, uint16_t length,

--- a/src/adapter.h
+++ b/src/adapter.h
@@ -268,6 +268,7 @@ enum experimental_features {
 	EXP_FEAT_RPA_RESOLUTION		= 1 << 3,
 	EXP_FEAT_CODEC_OFFLOAD		= 1 << 4,
 	EXP_FEAT_ISO_SOCKET		= 1 << 5,
+	EXP_FEAT_NO_ERRQUEUE_POLL	= 1 << 6,
 };
 
 bool btd_adapter_has_exp_feature(struct btd_adapter *adapter, uint32_t feature);

--- a/src/main.c
+++ b/src/main.c
@@ -707,6 +707,7 @@ static const char *valid_uuids[] = {
 	"330859bc-7506-492d-9370-9a6f0614037f",
 	"a6695ace-ee7f-4fb9-881a-5fac66c629af",
 	"6fbaf188-05e0-496a-9885-d6ddfdb4e03e",
+	"69518c4c-b69f-4679-8bc1-c021b47b5733",
 	"*"
 };
 

--- a/src/main.conf
+++ b/src/main.conf
@@ -136,6 +136,7 @@
 # 330859bc-7506-492d-9370-9a6f0614037f (BlueZ Experimental Bluetooth Quality Report)
 # a6695ace-ee7f-4fb9-881a-5fac66c629af (BlueZ Experimental Offload Codecs)
 # 6fbaf188-05e0-496a-9885-d6ddfdb4e03e (BlueZ Experimental ISO socket)
+# 69518c4c-b69f-4679-8bc1-c021b47b5733 (BlueZ Experimental No Errqueue Poll)
 # Defaults to false.
 #KernelExperimental = false
 


### PR DESCRIPTION
Add support for setting No Errqueue Poll experimental UUID which enables
the use of the BT_NO_ERRQUEUE_POLL socket option.
---
 src/adapter.c | 47 +++++++++++++++++++++++++++++++++++++++++++++++
 src/adapter.h |  1 +
 src/main.c    |  1 +
 src/main.conf |  1 +
 4 files changed, 50 insertions(+)