### PR TITLE
[PW_SID:841052] Fix descriptor display issue in btmon

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/monitor/att.c
+++ b/monitor/att.c
@@ -515,7 +515,7 @@ static struct gatt_db_attribute *insert_chrc(const struct l2cap_frame *frame,
 	if (!db)
 		return NULL;
 
-	return gatt_db_insert_characteristic(db, handle, uuid, 0, prop, NULL,
+	return gatt_db_append_characteristic(db, handle, uuid, 0, prop, NULL,
 							NULL, NULL);
 }
 
@@ -4153,7 +4153,7 @@ static struct gatt_db_attribute *insert_desc(const struct l2cap_frame *frame,
 	if (!db)
 		return NULL;
 
-	return gatt_db_insert_descriptor(db, handle, uuid, 0, NULL, NULL, NULL);
+	return gatt_db_append_descriptor(db, handle, uuid, 0, NULL, NULL, NULL);
 }
 
 static void att_find_info_rsp_16(const struct l2cap_frame *frame)

--- a/monitor/att.c
+++ b/monitor/att.c
@@ -4153,7 +4153,7 @@ static struct gatt_db_attribute *insert_desc(const struct l2cap_frame *frame,
 	if (!db)
 		return NULL;
 
-	return gatt_db_append_descriptor(db, handle, uuid, 0, NULL, NULL, NULL);
+	return gatt_db_insert_descriptor(db, handle, uuid, 0, NULL, NULL, NULL);
 }
 
 static void att_find_info_rsp_16(const struct l2cap_frame *frame)

--- a/src/gatt-database.c
+++ b/src/gatt-database.c
@@ -3178,7 +3178,7 @@ static bool database_add_desc(struct external_service *service,
 		return false;
 	}
 
-	desc->attrib = gatt_db_service_insert_descriptor(service->attrib,
+	desc->attrib = gatt_db_service_append_descriptor(service->attrib,
 							handle, &uuid,
 							desc->perm,
 							desc_read_cb,
@@ -3351,7 +3351,7 @@ static bool database_add_chrc(struct external_service *service,
 		return false;
 	}
 
-	chrc->attrib = gatt_db_service_insert_characteristic(service->attrib,
+	chrc->attrib = gatt_db_service_append_characteristic(service->attrib,
 						handle, &uuid, chrc->perm,
 						chrc->props, chrc_read_cb,
 						chrc_write_cb, chrc);

--- a/src/settings.c
+++ b/src/settings.c
@@ -78,7 +78,7 @@ static int load_desc(struct gatt_db *db, char *handle, char *value,
 	if (!bt_uuid_cmp(&uuid, &ext_uuid) && !val)
 		return -EIO;
 
-	att = gatt_db_service_insert_descriptor(service, handle_int, &uuid,
+	att = gatt_db_service_append_descriptor(service, handle_int, &uuid,
 							0, NULL, NULL, NULL);
 	if (!att || gatt_db_attribute_get_handle(att) != handle_int)
 		return -EIO;
@@ -125,7 +125,7 @@ static int load_chrc(struct gatt_db *db, char *handle, char *value,
 				handle_int, value_handle,
 				properties, val_len ? val_str : "", uuid_str);
 
-	att = gatt_db_service_insert_characteristic(service, value_handle,
+	att = gatt_db_service_append_characteristic(service, value_handle,
 							&uuid, 0, properties,
 							NULL, NULL, NULL);
 	if (!att || gatt_db_attribute_get_handle(att) != value_handle)

--- a/src/shared/gatt-client.c
+++ b/src/shared/gatt-client.c
@@ -638,7 +638,7 @@ static void discover_incl_cb(bool success, uint8_t att_ecode,
 			continue;
 		}
 
-		attr = gatt_db_insert_included(client->db, handle, attr);
+		attr = gatt_db_append_included(client->db, handle, attr);
 		if (!attr) {
 			DBG(client,
 				"Unable to add include attribute at 0x%04x",
@@ -734,7 +734,7 @@ static bool discover_descs(struct discovery_op *op, bool *discovering)
 			op->cur_svc = svc;
 		}
 
-		attr = gatt_db_insert_characteristic(client->db,
+		attr = gatt_db_append_characteristic(client->db,
 							chrc_data->value_handle,
 							&chrc_data->uuid, 0,
 							chrc_data->properties,
@@ -788,7 +788,7 @@ static bool discover_descs(struct discovery_op *op, bool *discovering)
 			 */
 			bt_uuid16_create(&ccc_uuid,
 					GATT_CLIENT_CHARAC_CFG_UUID);
-			attr = gatt_db_insert_descriptor(client->db, desc_start,
+			attr = gatt_db_append_descriptor(client->db, desc_start,
 							&ccc_uuid, 0, NULL,
 							NULL, NULL);
 			if (attr) {
@@ -952,7 +952,7 @@ static void discover_descs_cb(bool success, uint8_t att_ecode,
 
 		DBG(client, "handle: 0x%04x, uuid: %s", handle, uuid_str);
 
-		attr = gatt_db_insert_descriptor(client->db, handle,
+		attr = gatt_db_append_descriptor(client->db, handle,
 							&uuid, 0, NULL, NULL,
 							NULL);
 		if (!attr) {

--- a/src/shared/gatt-db.c
+++ b/src/shared/gatt-db.c
@@ -845,7 +845,7 @@ static uint16_t get_handle_at_index(struct gatt_db_service *service,
 }
 
 static struct gatt_db_attribute *
-service_insert_characteristic(struct gatt_db_service *service,
+service_append_characteristic(struct gatt_db_service *service,
 					uint16_t handle,
 					const bt_uuid_t *uuid,
 					uint32_t permissions,
@@ -912,7 +912,7 @@ service_insert_characteristic(struct gatt_db_service *service,
 }
 
 struct gatt_db_attribute *
-gatt_db_insert_characteristic(struct gatt_db *db,
+gatt_db_append_characteristic(struct gatt_db *db,
 					uint16_t handle,
 					const bt_uuid_t *uuid,
 					uint32_t permissions,
@@ -927,14 +927,14 @@ gatt_db_insert_characteristic(struct gatt_db *db,
 	if (!attrib)
 		return NULL;
 
-	return service_insert_characteristic(attrib->service, handle, uuid,
+	return service_append_characteristic(attrib->service, handle, uuid,
 						permissions, properties,
 						read_func, write_func,
 						user_data);
 }
 
 struct gatt_db_attribute *
-gatt_db_service_insert_characteristic(struct gatt_db_attribute *attrib,
+gatt_db_service_append_characteristic(struct gatt_db_attribute *attrib,
 					uint16_t handle,
 					const bt_uuid_t *uuid,
 					uint32_t permissions,
@@ -946,7 +946,7 @@ gatt_db_service_insert_characteristic(struct gatt_db_attribute *attrib,
 	if (!attrib)
 		return NULL;
 
-	return service_insert_characteristic(attrib->service, handle, uuid,
+	return service_append_characteristic(attrib->service, handle, uuid,
 						permissions, properties,
 						read_func, write_func,
 						user_data);
@@ -964,14 +964,14 @@ gatt_db_service_add_characteristic(struct gatt_db_attribute *attrib,
 	if (!attrib)
 		return NULL;
 
-	return service_insert_characteristic(attrib->service, 0, uuid,
+	return service_append_characteristic(attrib->service, 0, uuid,
 						permissions, properties,
 						read_func, write_func,
 						user_data);
 }
 
 static struct gatt_db_attribute *
-service_insert_descriptor(struct gatt_db_service *service,
+service_append_descriptor(struct gatt_db_service *service,
 					uint16_t handle,
 					const bt_uuid_t *uuid,
 					uint32_t permissions,
@@ -1003,7 +1003,7 @@ service_insert_descriptor(struct gatt_db_service *service,
 }
 
 struct gatt_db_attribute *
-gatt_db_insert_descriptor(struct gatt_db *db,
+gatt_db_append_descriptor(struct gatt_db *db,
 					uint16_t handle,
 					const bt_uuid_t *uuid,
 					uint32_t permissions,
@@ -1017,13 +1017,13 @@ gatt_db_insert_descriptor(struct gatt_db *db,
 	if (!attrib)
 		return NULL;
 
-	return service_insert_descriptor(attrib->service, handle, uuid,
+	return service_append_descriptor(attrib->service, handle, uuid,
 					permissions, read_func, write_func,
 					user_data);
 }
 
 struct gatt_db_attribute *
-gatt_db_service_insert_descriptor(struct gatt_db_attribute *attrib,
+gatt_db_service_append_descriptor(struct gatt_db_attribute *attrib,
 					uint16_t handle,
 					const bt_uuid_t *uuid,
 					uint32_t permissions,
@@ -1034,7 +1034,7 @@ gatt_db_service_insert_descriptor(struct gatt_db_attribute *attrib,
 	if (!attrib)
 		return NULL;
 
-	return service_insert_descriptor(attrib->service, handle, uuid,
+	return service_append_descriptor(attrib->service, handle, uuid,
 					permissions, read_func, write_func,
 					user_data);
 }
@@ -1050,7 +1050,7 @@ gatt_db_service_add_descriptor(struct gatt_db_attribute *attrib,
 	if (!attrib)
 		return NULL;
 
-	return service_insert_descriptor(attrib->service, 0, uuid,
+	return service_append_descriptor(attrib->service, 0, uuid,
 					permissions, read_func, write_func,
 					user_data);
 }
@@ -1088,7 +1088,7 @@ gatt_db_service_add_ccc(struct gatt_db_attribute *attrib, uint32_t permissions)
 	if (!value || value->notify_func)
 		return NULL;
 
-	ccc = service_insert_descriptor(attrib->service, 0, &ccc_uuid,
+	ccc = service_append_descriptor(attrib->service, 0, &ccc_uuid,
 					permissions,
 					db->ccc->read_func,
 					db->ccc->write_func,
@@ -1121,7 +1121,7 @@ void gatt_db_ccc_register(struct gatt_db *db, gatt_db_read_t read_func,
 }
 
 static struct gatt_db_attribute *
-service_insert_included(struct gatt_db_service *service, uint16_t handle,
+service_append_included(struct gatt_db_service *service, uint16_t handle,
 					struct gatt_db_attribute *include)
 {
 	struct gatt_db_service *included;
@@ -1186,22 +1186,22 @@ gatt_db_service_add_included(struct gatt_db_attribute *attrib,
 	if (!attrib || !include)
 		return NULL;
 
-	return service_insert_included(attrib->service, 0, include);
+	return service_append_included(attrib->service, 0, include);
 }
 
 struct gatt_db_attribute *
-gatt_db_service_insert_included(struct gatt_db_attribute *attrib,
+gatt_db_service_append_included(struct gatt_db_attribute *attrib,
 				uint16_t handle,
 				struct gatt_db_attribute *include)
 {
 	if (!attrib || !handle || !include)
 		return NULL;
 
-	return service_insert_included(attrib->service, handle, include);
+	return service_append_included(attrib->service, handle, include);
 }
 
 struct gatt_db_attribute *
-gatt_db_insert_included(struct gatt_db *db, uint16_t handle,
+gatt_db_append_included(struct gatt_db *db, uint16_t handle,
 			struct gatt_db_attribute *include)
 {
 	struct gatt_db_attribute *attrib;
@@ -1210,7 +1210,7 @@ gatt_db_insert_included(struct gatt_db *db, uint16_t handle,
 	if (!attrib)
 		return NULL;
 
-	return service_insert_included(attrib->service, handle, include);
+	return service_append_included(attrib->service, handle, include);
 }
 
 bool gatt_db_service_set_active(struct gatt_db_attribute *attrib, bool active)

--- a/src/shared/gatt-db.h
+++ b/src/shared/gatt-db.h
@@ -81,6 +81,15 @@ gatt_db_append_characteristic(struct gatt_db *db,
 					void *user_data);
 
 struct gatt_db_attribute *
+gatt_db_insert_descriptor(struct gatt_db *db,
+					uint16_t handle,
+					const bt_uuid_t *uuid,
+					uint32_t permissions,
+					gatt_db_read_t read_func,
+					gatt_db_write_t write_func,
+					void *user_data);
+
+struct gatt_db_attribute *
 gatt_db_append_descriptor(struct gatt_db *db,
 					uint16_t handle,
 					const bt_uuid_t *uuid,

--- a/src/shared/gatt-db.h
+++ b/src/shared/gatt-db.h
@@ -61,7 +61,7 @@ gatt_db_service_add_characteristic(struct gatt_db_attribute *attrib,
 					gatt_db_write_t write_func,
 					void *user_data);
 struct gatt_db_attribute *
-gatt_db_service_insert_characteristic(struct gatt_db_attribute *attrib,
+gatt_db_service_append_characteristic(struct gatt_db_attribute *attrib,
 					uint16_t handle,
 					const bt_uuid_t *uuid,
 					uint32_t permissions,
@@ -71,7 +71,7 @@ gatt_db_service_insert_characteristic(struct gatt_db_attribute *attrib,
 					void *user_data);
 
 struct gatt_db_attribute *
-gatt_db_insert_characteristic(struct gatt_db *db,
+gatt_db_append_characteristic(struct gatt_db *db,
 					uint16_t handle,
 					const bt_uuid_t *uuid,
 					uint32_t permissions,
@@ -81,7 +81,7 @@ gatt_db_insert_characteristic(struct gatt_db *db,
 					void *user_data);
 
 struct gatt_db_attribute *
-gatt_db_insert_descriptor(struct gatt_db *db,
+gatt_db_append_descriptor(struct gatt_db *db,
 					uint16_t handle,
 					const bt_uuid_t *uuid,
 					uint32_t permissions,
@@ -98,7 +98,7 @@ gatt_db_service_add_descriptor(struct gatt_db_attribute *attrib,
 					void *user_data);
 
 struct gatt_db_attribute *
-gatt_db_service_insert_descriptor(struct gatt_db_attribute *attrib,
+gatt_db_service_append_descriptor(struct gatt_db_attribute *attrib,
 					uint16_t handle,
 					const bt_uuid_t *uuid,
 					uint32_t permissions,
@@ -110,14 +110,14 @@ struct gatt_db_attribute *
 gatt_db_service_add_ccc(struct gatt_db_attribute *attrib, uint32_t permissions);
 
 struct gatt_db_attribute *
-gatt_db_insert_included(struct gatt_db *db, uint16_t handle,
+gatt_db_append_included(struct gatt_db *db, uint16_t handle,
 			struct gatt_db_attribute *include);
 
 struct gatt_db_attribute *
 gatt_db_service_add_included(struct gatt_db_attribute *attrib,
 					struct gatt_db_attribute *include);
 struct gatt_db_attribute *
-gatt_db_service_insert_included(struct gatt_db_attribute *attrib,
+gatt_db_service_append_included(struct gatt_db_attribute *attrib,
 				uint16_t handle,
 				struct gatt_db_attribute *include);
 

--- a/unit/test-gatt.c
+++ b/unit/test-gatt.c
@@ -1236,7 +1236,7 @@ add_char_with_value(struct gatt_db_attribute *service_att, uint16_t handle,
 	struct gatt_db_attribute *attrib;
 
 	if (handle)
-		attrib = gatt_db_service_insert_characteristic(service_att,
+		attrib = gatt_db_service_append_characteristic(service_att,
 								handle, uuid,
 								att_permissions,
 								char_properties,
@@ -1265,7 +1265,7 @@ add_desc_with_value(struct gatt_db_attribute *att, uint16_t handle,
 	struct gatt_db_attribute *desc_att;
 
 	if (handle)
-		desc_att = gatt_db_service_insert_descriptor(att, handle, uuid,
+		desc_att = gatt_db_service_append_descriptor(att, handle, uuid,
 							att_perms, NULL, NULL,
 							NULL);
 	else


### PR DESCRIPTION
Many of the Gatt insert functions are actually append. They append an
attribute to the end of the service attributes list.
This simply rename these functions.

Reviewed-by: Archie Pusaka <apusaka@chromium.org>
---

 monitor/att.c            |  4 ++--
 src/gatt-database.c      |  4 ++--
 src/settings.c           |  4 ++--
 src/shared/gatt-client.c |  8 ++++----
 src/shared/gatt-db.c     | 38 +++++++++++++++++++-------------------
 src/shared/gatt-db.h     | 12 ++++++------
 unit/test-gatt.c         |  4 ++--
 7 files changed, 37 insertions(+), 37 deletions(-)