### PR TITLE
[PW_SID:841263] V2: Fix busy loop when disabling BT

### DIFF
--- a/src/adapter.c
+++ b/src/adapter.c
@@ -7486,7 +7486,7 @@ static void adapter_remove_connection(struct btd_adapter *adapter,
 		device_cancel_authentication(device, TRUE);
 
 	/* If another bearer is still connected */
-	if (btd_device_is_connected(device))
+	if (btd_device_state_is_connected(device))
 		return;
 
 	adapter->connections = g_slist_remove(adapter->connections, device);

--- a/src/device.c
+++ b/src/device.c
@@ -3273,11 +3273,16 @@ uint8_t btd_device_get_bdaddr_type(struct btd_device *dev)
 
 bool btd_device_is_connected(struct btd_device *dev)
 {
-	if (dev->bredr_state.connected || dev->le_state.connected)
+	if (btd_device_state_is_connected(dev))
 		return true;
 
 	return find_service_with_state(dev->services,
 						BTD_SERVICE_STATE_CONNECTED);
+}
+
+bool btd_device_state_is_connected(struct btd_device *dev)
+{
+	return dev->bredr_state.connected || dev->le_state.connected;
 }
 
 static void clear_temporary_timer(struct btd_device *dev)

--- a/src/device.h
+++ b/src/device.h
@@ -104,6 +104,7 @@ void device_set_rssi(struct btd_device *device, int8_t rssi);
 void device_set_tx_power(struct btd_device *device, int8_t tx_power);
 void device_set_flags(struct btd_device *device, uint8_t flags);
 bool btd_device_is_connected(struct btd_device *dev);
+bool btd_device_state_is_connected(struct btd_device *dev);
 uint8_t btd_device_get_bdaddr_type(struct btd_device *dev);
 bool device_is_retrying(struct btd_device *device);
 void device_bonding_complete(struct btd_device *device, uint8_t bdaddr_type,


### PR DESCRIPTION
Splitting the service state test out of btd_device_is_connected
and using the state-specific test from adapter_remove_connection.

This intends to fix a busy loop that happens when BT is disabled
from userspace with e.g. "rfkill block bluetooth".
---
 src/adapter.c | 2 +-
 src/device.c  | 7 ++++++-
 src/device.h  | 1 +
 3 files changed, 8 insertions(+), 2 deletions(-)