### PR TITLE
[PW_SID:841385] Autoconnecttimeout max value increased to 20480 msecs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/src/main.c
+++ b/src/main.c
@@ -657,7 +657,7 @@ static void parse_le_config(GKeyFile *config)
 		  &btd_opts.defaults.le.autoconnect_timeout,
 		  sizeof(btd_opts.defaults.le.autoconnect_timeout),
 		  0x0001,
-		  0x4000},
+		  0x5000},  /*max val: 20480 msec*/
 		{ "AdvMonAllowlistScanDuration",
 		  &btd_opts.defaults.le.advmon_allowlist_scan_duration,
 		  sizeof(btd_opts.defaults.le.advmon_allowlist_scan_duration),


### PR DESCRIPTION
- In current implementation Autoconnecttimeout max value is
   16384[0x4000] msecs.
 - Since some controllers need some more time to respond to cmd
   'LE Extended Create Connection' hence increased this
   Autoconnecttimeout max value to 20480[0x5000] msecs.

For ex:
- In some controllers, If we include LE-Coded PHY in the initiating
 PHY List, BLE INIT scheduler selects the 1M and Coded PHY scanning
 as an initiator in round robin manner, and due to this available
 bandwidth gets distributed between 1M and Coded PHY, and this
 results in longer time taken for connection establishment by
 the controller.
- If ref device is advertising at 1.5 sec intervals, with create
 connection timeout of 4 sec,  the controller gets only 2 opportunities
 for the connection. Without the inclusion of LE-coded PHY,
 DUT takes ~3.8 sec for the connection establishment.Hence as described
 in above point  with the inclusion of LE-coded PHY it is difficult to
 achieve 100% connection success with the device having
 adv interval of 1.5 sec.

Hence increased Autoconnecttimeout max value to 20480[0x5000] msecs.

Signed-off-by: Mahesh Talewad <mahesh.talewad@nxp.com>
---
 src/main.c | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)