### PR TITLE
[PW_SID:844165] [BlueZ,1/2] shared/bap: clean up requests for a stream before freeing it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+


### PR DESCRIPTION
Cancel stream's queued requests before freeing the stream.

As the callbacks may do some cleanup on error, be sure to call them
before removing the requests.

Fixes:
=======================================================================
ERROR: AddressSanitizer: heap-use-after-free on address 0x60d000013430
READ of size 8 at 0x60d000013430 thread T0
    #0 0x89cb9f in stream_stop_complete src/shared/bap.c:1211
    #1 0x89c997 in bap_req_complete src/shared/bap.c:1192
    #2 0x8a105f in bap_process_queue src/shared/bap.c:1474
    #3 0x93c93f in timeout_callback src/shared/timeout-glib.c:25
...
freed by thread T0 here:
    #1 0x89b744 in bap_stream_free src/shared/bap.c:1105
    #2 0x89bac8 in bap_stream_detach src/shared/bap.c:1122
    #3 0x89dbfc in bap_stream_state_changed src/shared/bap.c:1261
    #4 0x8a2169 in bap_ucast_set_state src/shared/bap.c:1554
    #5 0x89e0d5 in stream_set_state src/shared/bap.c:1291
    #6 0x8a78b6 in bap_ucast_release src/shared/bap.c:1927
    #7 0x8d45bb in bt_bap_stream_release src/shared/bap.c:5516
    #8 0x8ba63f in remove_streams src/shared/bap.c:3538
    #9 0x7f23d0 in queue_foreach src/shared/queue.c:207
    #10 0x8bb875 in bt_bap_remove_pac src/shared/bap.c:3593
    #11 0x47416c in media_endpoint_destroy profiles/audio/media.c:185
=======================================================================
---
 src/shared/bap.c | 27 +++++++++++++++++++++++++++
 1 file changed, 27 insertions(+)