### PR TITLE
[PW_SID:844685] [BlueZ,v1] shared/uhid: Fix crash if bt_uhid_destroy free replay structure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/src/shared/uhid.c
+++ b/src/shared/uhid.c
@@ -507,6 +507,7 @@ int bt_uhid_destroy(struct bt_uhid *uhid)
 
 	uhid->created = false;
 	uhid_replay_free(uhid->replay);
+	uhid->replay = NULL;
 
 	return err;
 }


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

Id replay structured has been allocated it shall be set back to NULL
after calling uhid_replay_free otherwise it may cause the following
crash:

Invalid read of size 1
   at 0x1D8FC4: bt_uhid_record (uhid.c:116)
   by 0x1D912C: uhid_read_handler (uhid.c:158)
   by 0x201A64: watch_callback (io-glib.c:157)
   by 0x48D4198: g_main_dispatch.lto_priv.0 (gmain.c:3344)
   by 0x49333BE: UnknownInlinedFun (gmain.c:4152)
   by 0x49333BE: g_main_context_iterate_unlocked.isra.0 (gmain.c:4217)
   by 0x48D4DC6: g_main_loop_run (gmain.c:4419)
   by 0x2020F4: mainloop_run (mainloop-glib.c:66)
   by 0x20254B: mainloop_run_with_signal (mainloop-notify.c:188)
   by 0x12D6D4: main (main.c:1456)
 Address 0x53ae9c0 is 0 bytes inside a block of size 40 free'd
   at 0x48468CF: free (vg_replace_malloc.c:985)
   by 0x1D8E19: uhid_replay_free (uhid.c:68)
   by 0x1D8E19: uhid_replay_free (uhid.c:59)
   by 0x1D8E19: bt_uhid_destroy (uhid.c:509)
   by 0x1591F5: uhid_disconnect (device.c:183)

Fixes: https://github.com/bluez/bluez/issues/815
---
 src/shared/uhid.c | 1 +
 1 file changed, 1 insertion(+)