### PR TITLE
[PW_SID:846336] [BlueZ] bap: call select_cb on bt_bap_cancel_select() to clean up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/profiles/audio/media.c
+++ b/profiles/audio/media.c
@@ -1055,7 +1055,6 @@ static void pac_cancel_select(struct bt_bap_pac *lpac, bt_bap_pac_select_t cb,
 			continue;
 		}
 
-		req->cb = NULL;
 		media_endpoint_cancel(req);
 		l = endpoint->requests;
 	}


### PR DESCRIPTION
Have bt_bap_cancel_select() to trigger the callback function with error
code, simplifying the cleanup when ep is freed while SelectProperties is
ongoing.

Fixes bap_data->selecting not being decremented when ep setup is
canceled, which results to transports not being created thereafter.

Fixes: 41d6c4e1c92f ("bap: cancel ongoing SelectProperties() before freeing the ep")
---
 profiles/audio/media.c | 1 -
 1 file changed, 1 deletion(-)