### PR TITLE
[PW_SID:847218] [BlueZ,v1,1/3] gdbus: Add testing flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/gdbus/gdbus.h
+++ b/gdbus/gdbus.h
@@ -72,6 +72,7 @@ typedef void (* GDBusSecurityFunction) (DBusConnection *connection,
 
 enum GDBusFlags {
 	G_DBUS_FLAG_ENABLE_EXPERIMENTAL = (1 << 0),
+	G_DBUS_FLAG_ENABLE_TESTING      = (1 << 1),
 };
 
 enum GDBusMethodFlags {
@@ -79,16 +80,19 @@ enum GDBusMethodFlags {
 	G_DBUS_METHOD_FLAG_NOREPLY      = (1 << 1),
 	G_DBUS_METHOD_FLAG_ASYNC        = (1 << 2),
 	G_DBUS_METHOD_FLAG_EXPERIMENTAL = (1 << 3),
+	G_DBUS_METHOD_FLAG_TESTING      = (1 << 4),
 };
 
 enum GDBusSignalFlags {
 	G_DBUS_SIGNAL_FLAG_DEPRECATED   = (1 << 0),
 	G_DBUS_SIGNAL_FLAG_EXPERIMENTAL = (1 << 1),
+	G_DBUS_SIGNAL_FLAG_TESTING      = (1 << 2),
 };
 
 enum GDBusPropertyFlags {
 	G_DBUS_PROPERTY_FLAG_DEPRECATED   = (1 << 0),
 	G_DBUS_PROPERTY_FLAG_EXPERIMENTAL = (1 << 1),
+	G_DBUS_PROPERTY_FLAG_TESTING      = (1 << 2),
 };
 
 enum GDBusSecurityFlags {
@@ -186,6 +190,20 @@ struct GDBusSecurityTable {
 	.function = _function, \
 	.flags = G_DBUS_METHOD_FLAG_ASYNC | G_DBUS_METHOD_FLAG_EXPERIMENTAL
 
+#define GDBUS_TESTING_METHOD(_name, _in_args, _out_args, _function) \
+	.name = _name, \
+	.in_args = _in_args, \
+	.out_args = _out_args, \
+	.function = _function, \
+	.flags = G_DBUS_METHOD_FLAG_TESTING
+
+#define GDBUS_TESTING_ASYNC_METHOD(_name, _in_args, _out_args, _function) \
+	.name = _name, \
+	.in_args = _in_args, \
+	.out_args = _out_args, \
+	.function = _function, \
+	.flags = G_DBUS_METHOD_FLAG_ASYNC | G_DBUS_METHOD_FLAG_TESTING
+
 #define GDBUS_NOREPLY_METHOD(_name, _in_args, _out_args, _function) \
 	.name = _name, \
 	.in_args = _in_args, \
@@ -203,6 +221,11 @@ struct GDBusSecurityTable {
 	.flags = G_DBUS_SIGNAL_FLAG_DEPRECATED
 
 #define GDBUS_EXPERIMENTAL_SIGNAL(_name, _args) \
+	.name = _name, \
+	.args = _args, \
+	.flags = G_DBUS_SIGNAL_FLAG_EXPERIMENTAL
+
+#define GDBUS_TESTING_SIGNAL(_name, _args) \
 	.name = _name, \
 	.args = _args, \
 	.flags = G_DBUS_SIGNAL_FLAG_EXPERIMENTAL

--- a/gdbus/object.c
+++ b/gdbus/object.c
@@ -14,6 +14,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <stdbool.h>
 
 #include <glib.h>
 #include <dbus/dbus.h>
@@ -115,6 +116,14 @@ static gboolean check_experimental(int flags, int flag)
 	return !(global_flags & G_DBUS_FLAG_ENABLE_EXPERIMENTAL);
 }
 
+static bool check_testing(int flags, int flag)
+{
+	if (!(flags & flag))
+		return false;
+
+	return !(global_flags & G_DBUS_FLAG_ENABLE_TESTING);
+}
+
 static void generate_interface_xml(GString *gstr, struct interface_data *iface)
 {
 	const GDBusMethodTable *method;
@@ -124,6 +133,9 @@ static void generate_interface_xml(GString *gstr, struct interface_data *iface)
 	for (method = iface->methods; method && method->name; method++) {
 		if (check_experimental(method->flags,
 					G_DBUS_METHOD_FLAG_EXPERIMENTAL))
+			continue;
+
+		if (check_testing(method->flags, G_DBUS_METHOD_FLAG_TESTING))
 			continue;
 
 		g_string_append_printf(gstr, "<method name=\"%s\">",
@@ -146,6 +158,9 @@ static void generate_interface_xml(GString *gstr, struct interface_data *iface)
 					G_DBUS_SIGNAL_FLAG_EXPERIMENTAL))
 			continue;
 
+		if (check_testing(signal->flags, G_DBUS_SIGNAL_FLAG_TESTING))
+			continue;
+
 		g_string_append_printf(gstr, "<signal name=\"%s\">",
 								signal->name);
 		print_arguments(gstr, signal->args, NULL);
@@ -161,6 +176,10 @@ static void generate_interface_xml(GString *gstr, struct interface_data *iface)
 								property++) {
 		if (check_experimental(property->flags,
 					G_DBUS_PROPERTY_FLAG_EXPERIMENTAL))
+			continue;
+
+		if (check_testing(property->flags,
+					G_DBUS_PROPERTY_FLAG_TESTING))
 			continue;
 
 		g_string_append_printf(gstr, "<property name=\"%s\""
@@ -518,6 +537,9 @@ static void append_properties(struct interface_data *data,
 					G_DBUS_PROPERTY_FLAG_EXPERIMENTAL))
 			continue;
 
+		if (check_testing(p->flags, G_DBUS_PROPERTY_FLAG_TESTING))
+			continue;
+
 		if (p->get == NULL)
 			continue;
 
@@ -747,6 +769,9 @@ static inline const GDBusPropertyTable *find_property(const GDBusPropertyTable *
 
 		if (check_experimental(p->flags,
 					G_DBUS_PROPERTY_FLAG_EXPERIMENTAL))
+			break;
+
+		if (check_testing(p->flags, G_DBUS_PROPERTY_FLAG_TESTING))
 			break;
 
 		return p;
@@ -1061,6 +1086,9 @@ static DBusHandlerResult generic_message(DBusConnection *connection,
 					G_DBUS_METHOD_FLAG_EXPERIMENTAL))
 			return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
 
+		if (check_testing(method->flags, G_DBUS_METHOD_FLAG_TESTING))
+			return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
+
 		if (g_dbus_args_have_signature(method->in_args,
 							message) == FALSE)
 			continue;
@@ -1190,17 +1218,25 @@ static gboolean add_interface(struct generic_data *data,
 		if (!check_experimental(method->flags,
 					G_DBUS_METHOD_FLAG_EXPERIMENTAL))
 			goto done;
+
+		if (!check_testing(method->flags, G_DBUS_METHOD_FLAG_TESTING))
+			goto done;
 	}
 
 	for (signal = signals; signal && signal->name; signal++) {
 		if (!check_experimental(signal->flags,
 					G_DBUS_SIGNAL_FLAG_EXPERIMENTAL))
 			goto done;
+		if (!check_testing(signal->flags, G_DBUS_SIGNAL_FLAG_TESTING))
+			goto done;
 	}
 
 	for (property = properties; property && property->name; property++) {
 		if (!check_experimental(property->flags,
 					G_DBUS_PROPERTY_FLAG_EXPERIMENTAL))
+			goto done;
+		if (!check_testing(property->flags,
+					G_DBUS_PROPERTY_FLAG_TESTING))
 			goto done;
 	}
 

--- a/profiles/audio/ccp.c
+++ b/profiles/audio/ccp.c
@@ -206,19 +206,17 @@ ccp_server_remove(struct btd_profile *p,
 }
 
 static struct btd_profile ccp_profile = {
-	.name			= "ccp",
-	.priority		= BTD_PROFILE_PRIORITY_MEDIUM,
+	.name		= "ccp",
+	.priority	= BTD_PROFILE_PRIORITY_MEDIUM,
 	.remote_uuid	= GTBS_UUID_STR,
 	.device_probe	= ccp_probe,
 	.device_remove	= ccp_remove,
-	.accept			= ccp_accept,
-	.connect		= ccp_connect,
-	.disconnect		= ccp_disconnect,
-
+	.accept		= ccp_accept,
+	.connect	= ccp_connect,
+	.disconnect	= ccp_disconnect,
 	.adapter_probe	= ccp_server_probe,
 	.adapter_remove = ccp_server_remove,
-
-	.experimental	= true,
+	.testing	= true,
 };
 
 static int ccp_init(void)

--- a/src/bluetoothd.rst.in
+++ b/src/bluetoothd.rst.in
@@ -64,8 +64,13 @@ OPTIONS
 
 -C, --compat        Provide deprecated command line interfaces.
 
--E, --experimental  Enable experimental interfaces. Those interfaces are not
-                    guaranteed to be compatible or present in future releases.
+-E, --experimental  Enable D-Bus experimental interfaces.
+    These interfaces are not guaranteed to be compatible or present in future
+    releases.
+
+-T, --testing  Enable D-Bus testing interfaces.
+    These interfaces are only meant for test validation of the internals of
+    bluetoothd and shall not never be used by anything other than that.
 
 -K, --kernel=<uuid1>,<uuid2>,...
     Enable Kernel experimental features. Kernel experimental features are

--- a/src/btd.h
+++ b/src/btd.h
@@ -128,6 +128,7 @@ struct btd_opts {
 	bool		fast_conn;
 	bool		refresh_discovery;
 	bool		experimental;
+	bool		testing;
 	struct queue	*kernel;
 
 	uint16_t	did_source;

--- a/src/main.c
+++ b/src/main.c
@@ -87,6 +87,7 @@ static const char *supported_options[] = {
 	"TemporaryTimeout",
 	"RefreshDiscovery",
 	"Experimental",
+	"Testing",
 	"KernelExperimental",
 	"RemoteNameRequestRetryDelay",
 	NULL
@@ -1034,6 +1035,8 @@ static void parse_general(GKeyFile *config)
 	parse_secure_conns(config);
 	parse_config_bool(config, "General", "Experimental",
 						&btd_opts.experimental);
+	parse_config_bool(config, "General", "Testing",
+						&btd_opts.testing);
 	parse_kernel_exp(config);
 	parse_config_u32(config, "General", "RemoteNameRequestRetryDelay",
 					&btd_opts.name_request_retry_delay,
@@ -1344,6 +1347,8 @@ static GOptionEntry options[] = {
 				"Provide deprecated command line interfaces" },
 	{ "experimental", 'E', 0, G_OPTION_ARG_NONE, &btd_opts.experimental,
 				"Enable experimental D-Bus interfaces" },
+	{ "testing", 'T', 0, G_OPTION_ARG_NONE, &btd_opts.testing,
+				"Enable testing D-Bus interfaces" },
 	{ "kernel", 'K', G_OPTION_FLAG_OPTIONAL_ARG, G_OPTION_ARG_CALLBACK,
 				parse_kernel_experimental,
 				"Enable kernel experimental features" },
@@ -1409,6 +1414,9 @@ int main(int argc, char *argv[])
 
 	if (btd_opts.experimental)
 		gdbus_flags = G_DBUS_FLAG_ENABLE_EXPERIMENTAL;
+
+	if (btd_opts.testing)
+		gdbus_flags |= G_DBUS_FLAG_ENABLE_TESTING;
 
 	g_dbus_set_flags(gdbus_flags);
 

--- a/src/main.conf
+++ b/src/main.conf
@@ -126,6 +126,10 @@
 # Possible values: true or false
 #Experimental = false
 
+# Enables D-Bus testing interfaces
+# Possible values: true or false
+#Testing = false
+
 # Enables kernel experimental features, alternatively a list of UUIDs
 # can be given.
 # Possible values: true,false,<UUID List>

--- a/src/profile.c
+++ b/src/profile.c
@@ -781,6 +781,12 @@ int btd_profile_register(struct btd_profile *profile)
 		return -ENOTSUP;
 	}
 
+	if (profile->testing && !(g_dbus_get_flags() &
+					G_DBUS_FLAG_ENABLE_TESTING)) {
+		DBG("D-Bus testing not enabled");
+		return -ENOTSUP;
+	}
+
 	profiles = g_slist_append(profiles, profile);
 	return 0;
 }

--- a/src/profile.h
+++ b/src/profile.h
@@ -33,6 +33,11 @@ struct btd_profile {
 	 */
 	bool experimental;
 
+	/* Indicates the profile for testing only and shall only be registered
+	 * when testing has been enabled (see: main.conf:Testing).
+	 */
+	bool testing;
+
 	int (*device_probe) (struct btd_service *service);
 	void (*device_remove) (struct btd_service *service);
 


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

This adds testing flags which are similar to experimental but are only
available for testing.
---
 gdbus/gdbus.h  | 23 +++++++++++++++++++++++
 gdbus/object.c | 36 ++++++++++++++++++++++++++++++++++++
 2 files changed, 59 insertions(+)