### PR TITLE
[PW_SID:848285] [BlueZ,v1,1/2] org.bluez.Gatt: Add org.bluez.Error.ImproperlyConfigured error to WriteValue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/doc/org.bluez.GattCharacteristic.rst
+++ b/doc/org.bluez.GattCharacteristic.rst
@@ -133,6 +133,7 @@ void WriteValue(array{byte} value, dict options)
 	:org.bluez.Error.InvalidValueLength:
 	:org.bluez.Error.NotAuthorized:
 	:org.bluez.Error.NotSupported:
+	:org.bluez.Error.ImproperlyConfigured:
 
 fd, uint16 AcquireWrite(dict options) [optional]
 ````````````````````````````````````````````````

--- a/doc/org.bluez.GattDescriptor.rst
+++ b/doc/org.bluez.GattDescriptor.rst
@@ -115,6 +115,7 @@ void WriteValue(array{byte} value, dict flags)
 	:org.bluez.Error.InvalidValueLength:
 	:org.bluez.Error.NotAuthorized:
 	:org.bluez.Error.NotSupported:
+	:org.bluez.Error.ImproperlyConfigured:
 
 Properties
 ----------

--- a/src/gatt-database.c
+++ b/src/gatt-database.c
@@ -2248,6 +2248,9 @@ static uint8_t dbus_error_to_att_ecode(const char *name, const char *msg,
 	if (strcmp(name, ERROR_INTERFACE ".InProgress") == 0)
 		return BT_ERROR_ALREADY_IN_PROGRESS;
 
+	if (strcmp(name, ERROR_INTERFACE ".ImproperlyConfigured"))
+		return BT_ERROR_CCC_IMPROPERLY_CONFIGURED;
+
 	if (strcmp(name, ERROR_INTERFACE ".NotPermitted") == 0)
 		return perm_err;
 


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

Some attributes may require to generate
BT_ERROR_CCC_IMPROPERLY_CONFIGURED when its CCC is not properly
configured so this adds the possibility to generate it by replying with
org.bluez.Error.ImproperlyConfigured error to WriteValue.
---
 doc/org.bluez.GattCharacteristic.rst | 1 +
 doc/org.bluez.GattDescriptor.rst     | 1 +
 2 files changed, 2 insertions(+)