### PR TITLE
[PW_SID:851667] configure.ac: fix sixaxis build without tools

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -226,7 +226,7 @@ AM_CONDITIONAL(MONITOR, test "${enable_monitor}" != "no")
 
 AC_ARG_ENABLE(udev, AS_HELP_STRING([--disable-udev],
 		[disable udev device support]), [enable_udev=${enableval}])
-if (test "${enable_tools}" != "no" && test "${enable_udev}" != "no"); then
+if (test "${enable_udev}" != "no"); then
 	PKG_CHECK_MODULES(UDEV, libudev >= 196)
 	AC_DEFINE(HAVE_UDEV, 1, [Define to 1 if udev is required])
 fi


### PR DESCRIPTION
Fix the following build failure with --enable-sixaxis --enable-udev
--disable-tools raised since version 5.73 and
https://git.kernel.org/pub/scm/bluetooth/bluez.git/commit/?id=9f71892b63f6b65dab874a633d88ae2dcad93a16:

/home/autobuild/autobuild/instance-2/output-1/host/lib/gcc/x86_64-buildroot-linux-musl/12.3.0/../../../../x86_64-buildroot-linux-musl/bin/ld: plugins/bluetoothd-sixaxis.o: in function `sixaxis_init':
sixaxis.c:(.text.sixaxis_init+0x23): undefined reference to `udev_new'

Fixes:
 - http://autobuild.buildroot.org/results/c337d0f473c5fbb3e6cda1317ba06f5e2b16a43e
---
 configure.ac | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)