### PR TITLE
[PW_SID:853469] [BlueZ,v1,1/2] shared/ad: Add bt_ad_length

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/src/advertising.c
+++ b/src/advertising.c
@@ -884,6 +884,13 @@ static int get_adv_flags(struct btd_adv_client *client)
 
 	flags |= client->flags;
 
+	/* Detect if the length is bigger that legacy and secondary is not set
+	 * then force it to be set to ensure the kernel uses EA.
+	 */
+	if (bt_ad_length(client->data) > BT_AD_MAX_DATA_LEN &&
+			!(flags & MGMT_ADV_FLAG_SEC_MASK))
+		flags |= MGMT_ADV_FLAG_SEC_1M;
+
 	return flags;
 }
 

--- a/src/shared/ad.c
+++ b/src/shared/ad.c
@@ -520,9 +520,14 @@ static size_t data_length(struct queue *queue)
 	return length;
 }
 
-static size_t calculate_length(struct bt_ad *ad)
+size_t bt_ad_length(struct bt_ad *ad)
 {
-	size_t length = 0;
+	size_t length;
+
+	if (!ad)
+		return 0;
+
+	length = 0;
 
 	length += uuid_list_length(ad->service_uuids);
 
@@ -698,7 +703,7 @@ uint8_t *bt_ad_generate(struct bt_ad *ad, size_t *length)
 	if (!ad)
 		return NULL;
 
-	*length = calculate_length(ad);
+	*length = bt_ad_length(ad);
 
 	if (*length > ad->max_len)
 		return NULL;

--- a/src/shared/ad.h
+++ b/src/shared/ad.h
@@ -108,6 +108,8 @@ struct bt_ad *bt_ad_ref(struct bt_ad *ad);
 
 void bt_ad_unref(struct bt_ad *ad);
 
+size_t bt_ad_length(struct bt_ad *ad);
+
 uint8_t *bt_ad_generate(struct bt_ad *ad, size_t *length);
 
 bool bt_ad_is_empty(struct bt_ad *ad);


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

This adds bt_ad_length which can be used to return the current size of
the bt_ad data.
---
 src/shared/ad.c | 11 ++++++++---
 src/shared/ad.h |  2 ++
 2 files changed, 10 insertions(+), 3 deletions(-)