### PR TITLE
[PW_SID:854453] Update BAP Broadcast Source state machine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/profiles/audio/bap.c
+++ b/profiles/audio/bap.c
@@ -2474,7 +2474,7 @@ static uint8_t get_streams_nb_by_state(struct bap_setup *setup)
 			 */
 			return 1;
 		else if (bt_bap_stream_get_state(ent_setup->stream) !=
-				BT_BAP_STREAM_STATE_CONFIG)
+				BT_BAP_STREAM_STATE_ENABLING)
 			/* Not all streams form a BIG have received transport
 			 * acquire, so wait for the other streams to.
 			 */
@@ -2516,8 +2516,12 @@ static void bap_state_bcast_src(struct bt_bap_stream *stream, uint8_t old_state,
 			queue_remove(data->streams, stream);
 		break;
 	case BT_BAP_STREAM_STATE_CONFIG:
-		if (!setup || setup->id)
-			break;
+		// TO DO Reconfiguration
+		break;
+	/* On transport acquire use BT_BAP_STREAM_STATE_ENABLING
+	 * as a substate of BT_BAP_STREAM_STATE_CONFIG
+	 */
+	case BT_BAP_STREAM_STATE_ENABLING:
 		/* If the stream attached to a broadcast
 		 * source endpoint generate the base.
 		 */
@@ -2855,8 +2859,7 @@ static void bap_connecting_bcast(struct bt_bap_stream *stream, bool state,
 
 		setup->qos.bcast.big = iso_qos.bcast.big;
 		setup->qos.bcast.bis = iso_qos.bcast.bis;
-		bt_bap_stream_config(setup->stream, &setup->qos, setup->caps,
-							NULL, NULL);
+		bt_bap_stream_qos(setup->stream, &setup->qos, NULL, NULL);
 	}
 
 	DBG("stream %p fd %d: BIG 0x%02x BIS 0x%02x", stream, fd,

--- a/unit/test-bap.c
+++ b/unit/test-bap.c
@@ -547,10 +547,10 @@ static void bsrc_state(struct bt_bap_stream *stream, uint8_t old_state,
 	struct test_data *data = user_data;
 
 	switch (new_state) {
-	case BT_BAP_STREAM_STATE_QOS:
+	case BT_BAP_STREAM_STATE_CONFIG:
 		bt_bap_stream_enable(stream, true, NULL, NULL, NULL);
 		break;
-	case BT_BAP_STREAM_STATE_CONFIG:
+	case BT_BAP_STREAM_STATE_ENABLING:
 		data->base = bt_bap_stream_get_base(stream);
 
 		g_assert(data->base);


### PR DESCRIPTION
Update BAP Broadcast Source state machine states to use BAP define states
 for source Idle, Config, Streaming, and an intermediary state enabling.

Updated test-bap too.

---
 src/shared/bap.c | 39 ++++++++++++++++++++-------------------
 unit/test-bap.c  |  4 ++--
 2 files changed, 22 insertions(+), 21 deletions(-)