### PR TITLE
[PW_SID:856047] Add new BAP BSRC/SCC tests

### DIFF
--- a/src/shared/bap.c
+++ b/src/shared/bap.c
@@ -2051,7 +2051,7 @@ static void bap_bcast_set_state(struct bt_bap_stream *stream, uint8_t state)
 	}
 
 	/* Post notification updates */
-	switch (stream->state) {
+	switch (state) {
 	case BT_ASCS_ASE_STATE_IDLE:
 		if (stream->ops && stream->ops->detach)
 			stream->ops->detach(stream);
@@ -5293,6 +5293,7 @@ unsigned int bt_bap_stream_config(struct bt_bap_stream *stream,
 					void *user_data)
 {
 	unsigned int id;
+	struct bt_bap *bap;
 
 	if (!bap_stream_valid(stream))
 		return 0;
@@ -5303,9 +5304,11 @@ unsigned int bt_bap_stream_config(struct bt_bap_stream *stream,
 	if (!bt_bap_ref_safe(stream->bap))
 		return 0;
 
+	bap = stream->bap;
+
 	id = stream->ops->config(stream, qos, data, func, user_data);
 
-	bt_bap_unref(stream->bap);
+	bt_bap_unref(bap);
 
 	return id;
 }
@@ -5565,6 +5568,7 @@ unsigned int bt_bap_stream_enable(struct bt_bap_stream *stream,
 					void *user_data)
 {
 	unsigned int id;
+	struct bt_bap *bap;
 
 	if (!bap_stream_valid(stream))
 		return 0;
@@ -5575,10 +5579,12 @@ unsigned int bt_bap_stream_enable(struct bt_bap_stream *stream,
 	if (!bt_bap_ref_safe(stream->bap))
 		return 0;
 
+	bap = stream->bap;
+
 	id = stream->ops->enable(stream, enable_links, metadata, func,
 					user_data);
 
-	bt_bap_unref(stream->bap);
+	bt_bap_unref(bap);
 
 	return id;
 }
@@ -5588,6 +5594,7 @@ unsigned int bt_bap_stream_start(struct bt_bap_stream *stream,
 					void *user_data)
 {
 	unsigned int id;
+	struct bt_bap *bap;
 
 	if (!bap_stream_valid(stream))
 		return 0;
@@ -5598,9 +5605,11 @@ unsigned int bt_bap_stream_start(struct bt_bap_stream *stream,
 	if (!bt_bap_ref_safe(stream->bap))
 		return 0;
 
+	bap = stream->bap;
+
 	id = stream->ops->start(stream, func, user_data);
 
-	bt_bap_unref(stream->bap);
+	bt_bap_unref(bap);
 
 	return id;
 }
@@ -5611,6 +5620,7 @@ unsigned int bt_bap_stream_disable(struct bt_bap_stream *stream,
 					void *user_data)
 {
 	unsigned int id;
+	struct bt_bap *bap;
 
 	if (!bap_stream_valid(stream))
 		return 0;
@@ -5621,9 +5631,11 @@ unsigned int bt_bap_stream_disable(struct bt_bap_stream *stream,
 	if (!bt_bap_ref_safe(stream->bap))
 		return 0;
 
+	bap = stream->bap;
+
 	id = stream->ops->disable(stream, disable_links, func, user_data);
 
-	bt_bap_unref(stream->bap);
+	bt_bap_unref(bap);
 
 	return id;
 }

--- a/src/shared/bap.c
+++ b/src/shared/bap.c
@@ -2056,10 +2056,6 @@ static void bap_bcast_set_state(struct bt_bap_stream *stream, uint8_t state)
 		if (stream->ops && stream->ops->detach)
 			stream->ops->detach(stream);
 		break;
-	case BT_ASCS_ASE_STATE_DISABLING:
-		bap_stream_io_detach(stream);
-		stream_set_state(stream, BT_BAP_STREAM_STATE_QOS);
-		break;
 	case BT_ASCS_ASE_STATE_RELEASING:
 		bap_stream_io_detach(stream);
 		stream_set_state(stream, BT_BAP_STREAM_STATE_IDLE);

--- a/unit/test-bap.c
+++ b/unit/test-bap.c
@@ -6169,10 +6169,53 @@ static void test_bsrc_scc_estab(void)
 		NULL, test_bcast, &cfg_bsrc_8_1_1_estab, IOV_NULL);
 }
 
+static void bsrc_state_disable(struct bt_bap_stream *stream, uint8_t old_state,
+				uint8_t new_state, void *user_data)
+{
+	switch (new_state) {
+	case BT_BAP_STREAM_STATE_CONFIG:
+		if (old_state == BT_BAP_STREAM_STATE_IDLE)
+			bt_bap_stream_enable(stream, true, NULL, NULL, NULL);
+		else if (old_state == BT_BAP_STREAM_STATE_STREAMING)
+			tester_test_passed();
+		else
+			/* Other transitions to CONFIG state are invalid. */
+			tester_test_failed();
+		break;
+	case BT_BAP_STREAM_STATE_ENABLING:
+		bt_bap_stream_start(stream, NULL, NULL);
+		break;
+	case BT_BAP_STREAM_STATE_STREAMING:
+		bt_bap_stream_disable(stream, true, NULL, NULL);
+		break;
+	}
+}
+
+static struct test_config cfg_bsrc_8_1_1_disable = {
+	.cc = LC3_CONFIG_8_1,
+	.qos = LC3_QOS_8_1_1_B,
+	.src = true,
+	.state_func = bsrc_state_disable,
+};
+
+/* Test Purpose:
+ * Verify that a Broadcast Source IUT can disable a broadcast
+ * Audio Stream.
+ *
+ * Pass verdict:
+ * The IUT sends a BIG_TERMINATE_IND PDU in step 1.
+ */
+static void test_bsrc_scc_disable(void)
+{
+	define_test("BAP/BSRC/SCC/BV-36-C [Disables Broadcast]",
+		NULL, test_bcast, &cfg_bsrc_8_1_1_disable, IOV_NULL);
+}
+
 static void test_bsrc_scc(void)
 {
 	test_bsrc_scc_config();
 	test_bsrc_scc_estab();
+	test_bsrc_scc_disable();
 }
 
 static struct test_config cfg_bsnk_8_1 = {

--- a/unit/test-bap.c
+++ b/unit/test-bap.c
@@ -549,16 +549,13 @@ static void bsrc_pac_added(struct bt_bap_pac *pac, void *user_data)
 					&data->cfg->cc, NULL, data);
 }
 
-static void bsrc_state(struct bt_bap_stream *stream, uint8_t old_state,
+static void bsrc_state_cfg(struct bt_bap_stream *stream, uint8_t old_state,
 				uint8_t new_state, void *user_data)
 {
 	struct test_data *data = user_data;
 
 	switch (new_state) {
 	case BT_BAP_STREAM_STATE_CONFIG:
-		bt_bap_stream_enable(stream, true, NULL, NULL, NULL);
-		break;
-	case BT_BAP_STREAM_STATE_ENABLING:
 		data->base = bt_bap_stream_get_base(stream);
 
 		g_assert(data->base);
@@ -566,9 +563,6 @@ static void bsrc_state(struct bt_bap_stream *stream, uint8_t old_state,
 		g_assert(memcmp(data->base->iov_base, data->cfg->base.iov_base,
 				data->base->iov_len) == 0);
 
-		bt_bap_stream_start(stream, NULL, NULL);
-		break;
-	case BT_BAP_STREAM_STATE_STREAMING:
 		tester_test_passed();
 		break;
 	}
@@ -5608,7 +5602,7 @@ static struct test_config cfg_bsrc_8_1_1 = {
 	.qos = LC3_QOS_8_1_1_B,
 	.base = UTIL_IOV_INIT(BASE_LC3_8_1),
 	.src = true,
-	.state_func = bsrc_state,
+	.state_func = bsrc_state_cfg,
 };
 
 static struct test_config cfg_bsrc_8_1_2 = {
@@ -5616,7 +5610,7 @@ static struct test_config cfg_bsrc_8_1_2 = {
 	.qos = LC3_QOS_8_1_2_B,
 	.base = UTIL_IOV_INIT(BASE_LC3_8_1),
 	.src = true,
-	.state_func = bsrc_state,
+	.state_func = bsrc_state_cfg,
 };
 
 #define LC3_CFG_8_2 \
@@ -5632,7 +5626,7 @@ static struct test_config cfg_bsrc_8_2_1 = {
 	.qos = LC3_QOS_8_2_1_B,
 	.base = UTIL_IOV_INIT(BASE_LC3_8_2),
 	.src = true,
-	.state_func = bsrc_state,
+	.state_func = bsrc_state_cfg,
 };
 
 static struct test_config cfg_bsrc_8_2_2 = {
@@ -5640,7 +5634,7 @@ static struct test_config cfg_bsrc_8_2_2 = {
 	.qos = LC3_QOS_8_2_2_B,
 	.base = UTIL_IOV_INIT(BASE_LC3_8_2),
 	.src = true,
-	.state_func = bsrc_state,
+	.state_func = bsrc_state_cfg,
 };
 
 #define LC3_CFG_16_1 \
@@ -5656,7 +5650,7 @@ static struct test_config cfg_bsrc_16_1_1 = {
 	.qos = LC3_QOS_16_1_1_B,
 	.base = UTIL_IOV_INIT(BASE_LC3_16_1),
 	.src = true,
-	.state_func = bsrc_state,
+	.state_func = bsrc_state_cfg,
 };
 
 static struct test_config cfg_bsrc_16_1_2 = {
@@ -5664,7 +5658,7 @@ static struct test_config cfg_bsrc_16_1_2 = {
 	.qos = LC3_QOS_16_1_2_B,
 	.base = UTIL_IOV_INIT(BASE_LC3_16_1),
 	.src = true,
-	.state_func = bsrc_state,
+	.state_func = bsrc_state_cfg,
 };
 
 #define LC3_CFG_16_2 \
@@ -5680,7 +5674,7 @@ static struct test_config cfg_bsrc_16_2_1 = {
 	.qos = LC3_QOS_16_2_1_B,
 	.base = UTIL_IOV_INIT(BASE_LC3_16_2),
 	.src = true,
-	.state_func = bsrc_state,
+	.state_func = bsrc_state_cfg,
 };
 
 static struct test_config cfg_bsrc_16_2_2 = {
@@ -5688,7 +5682,7 @@ static struct test_config cfg_bsrc_16_2_2 = {
 	.qos = LC3_QOS_16_2_2_B,
 	.base = UTIL_IOV_INIT(BASE_LC3_16_2),
 	.src = true,
-	.state_func = bsrc_state,
+	.state_func = bsrc_state_cfg,
 };
 
 #define LC3_CFG_24_1 \
@@ -5704,7 +5698,7 @@ static struct test_config cfg_bsrc_24_1_1 = {
 	.qos = LC3_QOS_24_1_1_B,
 	.base = UTIL_IOV_INIT(BASE_LC3_24_1),
 	.src = true,
-	.state_func = bsrc_state,
+	.state_func = bsrc_state_cfg,
 };
 
 static struct test_config cfg_bsrc_24_1_2 = {
@@ -5712,7 +5706,7 @@ static struct test_config cfg_bsrc_24_1_2 = {
 	.qos = LC3_QOS_24_1_2_B,
 	.base = UTIL_IOV_INIT(BASE_LC3_24_1),
 	.src = true,
-	.state_func = bsrc_state,
+	.state_func = bsrc_state_cfg,
 };
 
 #define LC3_CFG_24_2 \
@@ -5728,7 +5722,7 @@ static struct test_config cfg_bsrc_24_2_1 = {
 	.qos = LC3_QOS_24_2_1_B,
 	.base = UTIL_IOV_INIT(BASE_LC3_24_2),
 	.src = true,
-	.state_func = bsrc_state,
+	.state_func = bsrc_state_cfg,
 };
 
 static struct test_config cfg_bsrc_24_2_2 = {
@@ -5736,7 +5730,7 @@ static struct test_config cfg_bsrc_24_2_2 = {
 	.qos = LC3_QOS_24_2_2_B,
 	.base = UTIL_IOV_INIT(BASE_LC3_24_2),
 	.src = true,
-	.state_func = bsrc_state,
+	.state_func = bsrc_state_cfg,
 };
 
 #define LC3_CFG_32_1 \
@@ -5752,7 +5746,7 @@ static struct test_config cfg_bsrc_32_1_1 = {
 	.qos = LC3_QOS_32_1_1_B,
 	.base = UTIL_IOV_INIT(BASE_LC3_32_1),
 	.src = true,
-	.state_func = bsrc_state,
+	.state_func = bsrc_state_cfg,
 };
 
 static struct test_config cfg_bsrc_32_1_2 = {
@@ -5760,7 +5754,7 @@ static struct test_config cfg_bsrc_32_1_2 = {
 	.qos = LC3_QOS_32_1_2_B,
 	.base = UTIL_IOV_INIT(BASE_LC3_32_1),
 	.src = true,
-	.state_func = bsrc_state,
+	.state_func = bsrc_state_cfg,
 };
 
 #define LC3_CFG_32_2 \
@@ -5776,7 +5770,7 @@ static struct test_config cfg_bsrc_32_2_1 = {
 	.qos = LC3_QOS_32_2_1_B,
 	.base = UTIL_IOV_INIT(BASE_LC3_32_2),
 	.src = true,
-	.state_func = bsrc_state,
+	.state_func = bsrc_state_cfg,
 };
 
 static struct test_config cfg_bsrc_32_2_2 = {
@@ -5784,7 +5778,7 @@ static struct test_config cfg_bsrc_32_2_2 = {
 	.qos = LC3_QOS_32_2_2_B,
 	.base = UTIL_IOV_INIT(BASE_LC3_32_2),
 	.src = true,
-	.state_func = bsrc_state,
+	.state_func = bsrc_state_cfg,
 };
 
 #define LC3_CFG_44_1 \
@@ -5800,7 +5794,7 @@ static struct test_config cfg_bsrc_44_1_1 = {
 	.qos = LC3_QOS_44_1_1_B,
 	.base = UTIL_IOV_INIT(BASE_LC3_44_1),
 	.src = true,
-	.state_func = bsrc_state,
+	.state_func = bsrc_state_cfg,
 };
 
 static struct test_config cfg_bsrc_44_1_2 = {
@@ -5808,7 +5802,7 @@ static struct test_config cfg_bsrc_44_1_2 = {
 	.qos = LC3_QOS_44_1_2_B,
 	.base = UTIL_IOV_INIT(BASE_LC3_44_1),
 	.src = true,
-	.state_func = bsrc_state,
+	.state_func = bsrc_state_cfg,
 };
 
 #define LC3_CFG_44_2 \
@@ -5824,7 +5818,7 @@ static struct test_config cfg_bsrc_44_2_1 = {
 	.qos = LC3_QOS_44_2_1_B,
 	.base = UTIL_IOV_INIT(BASE_LC3_44_2),
 	.src = true,
-	.state_func = bsrc_state,
+	.state_func = bsrc_state_cfg,
 };
 
 static struct test_config cfg_bsrc_44_2_2 = {
@@ -5832,7 +5826,7 @@ static struct test_config cfg_bsrc_44_2_2 = {
 	.qos = LC3_QOS_44_2_2_B,
 	.base = UTIL_IOV_INIT(BASE_LC3_44_2),
 	.src = true,
-	.state_func = bsrc_state,
+	.state_func = bsrc_state_cfg,
 };
 
 #define LC3_CFG_48_1 \
@@ -5848,7 +5842,7 @@ static struct test_config cfg_bsrc_48_1_1 = {
 	.qos = LC3_QOS_48_1_1_B,
 	.base = UTIL_IOV_INIT(BASE_LC3_48_1),
 	.src = true,
-	.state_func = bsrc_state,
+	.state_func = bsrc_state_cfg,
 };
 
 static struct test_config cfg_bsrc_48_1_2 = {
@@ -5856,7 +5850,7 @@ static struct test_config cfg_bsrc_48_1_2 = {
 	.qos = LC3_QOS_48_1_2_B,
 	.base = UTIL_IOV_INIT(BASE_LC3_48_1),
 	.src = true,
-	.state_func = bsrc_state,
+	.state_func = bsrc_state_cfg,
 };
 
 #define LC3_CFG_48_2 \
@@ -5872,7 +5866,7 @@ static struct test_config cfg_bsrc_48_2_1 = {
 	.qos = LC3_QOS_48_2_1_B,
 	.base = UTIL_IOV_INIT(BASE_LC3_48_2),
 	.src = true,
-	.state_func = bsrc_state,
+	.state_func = bsrc_state_cfg,
 };
 
 static struct test_config cfg_bsrc_48_2_2 = {
@@ -5880,7 +5874,7 @@ static struct test_config cfg_bsrc_48_2_2 = {
 	.qos = LC3_QOS_48_2_2_B,
 	.base = UTIL_IOV_INIT(BASE_LC3_48_2),
 	.src = true,
-	.state_func = bsrc_state,
+	.state_func = bsrc_state_cfg,
 };
 
 #define LC3_CFG_48_3 \
@@ -5896,7 +5890,7 @@ static struct test_config cfg_bsrc_48_3_1 = {
 	.qos = LC3_QOS_48_3_1_B,
 	.base = UTIL_IOV_INIT(BASE_LC3_48_3),
 	.src = true,
-	.state_func = bsrc_state,
+	.state_func = bsrc_state_cfg,
 };
 
 static struct test_config cfg_bsrc_48_3_2 = {
@@ -5904,7 +5898,7 @@ static struct test_config cfg_bsrc_48_3_2 = {
 	.qos = LC3_QOS_48_3_2_B,
 	.base = UTIL_IOV_INIT(BASE_LC3_48_3),
 	.src = true,
-	.state_func = bsrc_state,
+	.state_func = bsrc_state_cfg,
 };
 
 #define LC3_CFG_48_4 \
@@ -5920,7 +5914,7 @@ static struct test_config cfg_bsrc_48_4_1 = {
 	.qos = LC3_QOS_48_4_1_B,
 	.base = UTIL_IOV_INIT(BASE_LC3_48_4),
 	.src = true,
-	.state_func = bsrc_state,
+	.state_func = bsrc_state_cfg,
 };
 
 static struct test_config cfg_bsrc_48_4_2 = {
@@ -5928,7 +5922,7 @@ static struct test_config cfg_bsrc_48_4_2 = {
 	.qos = LC3_QOS_48_4_2_B,
 	.base = UTIL_IOV_INIT(BASE_LC3_48_4),
 	.src = true,
-	.state_func = bsrc_state,
+	.state_func = bsrc_state_cfg,
 };
 
 #define LC3_CFG_48_5 \
@@ -5944,7 +5938,7 @@ static struct test_config cfg_bsrc_48_5_1 = {
 	.qos = LC3_QOS_48_5_1_B,
 	.base = UTIL_IOV_INIT(BASE_LC3_48_5),
 	.src = true,
-	.state_func = bsrc_state,
+	.state_func = bsrc_state_cfg,
 };
 
 static struct test_config cfg_bsrc_48_5_2 = {
@@ -5952,7 +5946,7 @@ static struct test_config cfg_bsrc_48_5_2 = {
 	.qos = LC3_QOS_48_5_2_B,
 	.base = UTIL_IOV_INIT(BASE_LC3_48_5),
 	.src = true,
-	.state_func = bsrc_state,
+	.state_func = bsrc_state_cfg,
 };
 
 #define LC3_CFG_48_6 \
@@ -5968,7 +5962,7 @@ static struct test_config cfg_bsrc_48_6_1 = {
 	.qos = LC3_QOS_48_6_1_B,
 	.base = UTIL_IOV_INIT(BASE_LC3_48_6),
 	.src = true,
-	.state_func = bsrc_state,
+	.state_func = bsrc_state_cfg,
 };
 
 static struct test_config cfg_bsrc_48_6_2 = {
@@ -5976,7 +5970,7 @@ static struct test_config cfg_bsrc_48_6_2 = {
 	.qos = LC3_QOS_48_6_2_B,
 	.base = UTIL_IOV_INIT(BASE_LC3_48_6),
 	.src = true,
-	.state_func = bsrc_state,
+	.state_func = bsrc_state_cfg,
 };
 
 #define VS_CC \
@@ -6012,7 +6006,7 @@ static struct test_config cfg_bsrc_vs = {
 	.base = UTIL_IOV_INIT(BASE_VS),
 	.vs = true,
 	.src = true,
-	.state_func = bsrc_state,
+	.state_func = bsrc_state_cfg,
 };
 
 /* Test Purpose:

--- a/unit/test-bap.c
+++ b/unit/test-bap.c
@@ -6029,7 +6029,7 @@ static struct test_config cfg_bsrc_vs = {
  * Each value included in the Codec_Specific_Configuration is formatted in
  * an LTV structure with the length, type, and value specified in Table 4.74.
  */
-static void test_bsrc_scc(void)
+static void test_bsrc_scc_config(void)
 {
 	define_test("BAP/BSRC/SCC/BV-01-C [Config Broadcast, LC3 8_1_1]",
 		NULL, test_bcast, &cfg_bsrc_8_1_1, IOV_NULL);
@@ -6129,6 +6129,50 @@ static void test_bsrc_scc(void)
 
 	define_test("BAP/BSRC/SCC/BV-33-C [Config Broadcast, VS]",
 		NULL, test_bcast, &cfg_bsrc_vs, IOV_NULL);
+}
+
+static void bsrc_state_estab(struct bt_bap_stream *stream, uint8_t old_state,
+				uint8_t new_state, void *user_data)
+{
+	switch (new_state) {
+	case BT_BAP_STREAM_STATE_CONFIG:
+		bt_bap_stream_enable(stream, true, NULL, NULL, NULL);
+		break;
+	case BT_BAP_STREAM_STATE_ENABLING:
+		bt_bap_stream_start(stream, NULL, NULL);
+		break;
+	case BT_BAP_STREAM_STATE_STREAMING:
+		tester_test_passed();
+		break;
+	}
+}
+
+static struct test_config cfg_bsrc_8_1_1_estab = {
+	.cc = LC3_CONFIG_8_1,
+	.qos = LC3_QOS_8_1_1_B,
+	.src = true,
+	.state_func = bsrc_state_estab,
+};
+
+/* Test Purpose:
+ * Verify that a Broadcast Source IUT can establish a broadcast
+ * Audio Stream.
+ *
+ * Pass verdict:
+ * The IUT sends AUX_SYNC_IND PDUs with an Extended Header
+ * containing BIGInfo in the ACAD field. The IUT sends BIS Data
+ * PDUs over the broadcast Audio Stream.
+ */
+static void test_bsrc_scc_estab(void)
+{
+	define_test("BAP/BSRC/SCC/BV-35-C [Establishes Broadcast]",
+		NULL, test_bcast, &cfg_bsrc_8_1_1_estab, IOV_NULL);
+}
+
+static void test_bsrc_scc(void)
+{
+	test_bsrc_scc_config();
+	test_bsrc_scc_estab();
 }
 
 static struct test_config cfg_bsnk_8_1 = {


### PR DESCRIPTION
This removes the switch case for the DISABLING state from
bap_bcast_set_state, since this state is not used for broadcast.
---
 src/shared/bap.c | 4 ----
 1 file changed, 4 deletions(-)