### PR TITLE
[PW_SID:858380] [BlueZ,v2,1/3] shared/csip: Fix memory leak

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/src/device.c
+++ b/src/device.c
@@ -6994,6 +6994,27 @@ struct gatt_db *btd_device_get_gatt_db(struct btd_device *device)
 	return device->db;
 }
 
+bool btd_device_set_gatt_db(struct btd_device *device, struct gatt_db *db)
+{
+	struct gatt_db *clone;
+
+	if (!device)
+		return false;
+
+	clone = gatt_db_clone(db);
+	if (clone)
+		return false;
+
+	gatt_db_unregister(device->db, device->db_id);
+	gatt_db_unref(device->db);
+
+	device->db = clone;
+	device->db_id = gatt_db_register(device->db, gatt_service_added,
+					gatt_service_removed, device, NULL);
+
+	return true;
+}
+
 struct bt_gatt_client *btd_device_get_gatt_client(struct btd_device *device)
 {
 	if (!device)

--- a/src/device.h
+++ b/src/device.h
@@ -66,6 +66,7 @@ struct gatt_primary *btd_device_get_primary(struct btd_device *device,
 							const char *uuid);
 GSList *btd_device_get_primaries(struct btd_device *device);
 struct gatt_db *btd_device_get_gatt_db(struct btd_device *device);
+bool btd_device_set_gatt_db(struct btd_device *device, struct gatt_db *db);
 struct bt_gatt_client *btd_device_get_gatt_client(struct btd_device *device);
 struct bt_gatt_server *btd_device_get_gatt_server(struct btd_device *device);
 bool btd_device_is_initiator(struct btd_device *device);

--- a/src/shared/csip.c
+++ b/src/shared/csip.c
@@ -128,6 +128,15 @@ void bt_csip_detach(struct bt_csip *csip)
 	queue_foreach(csip_cbs, csip_detached, csip);
 }
 
+static void csis_free(struct bt_csis *csis)
+{
+	if (!csis)
+		return;
+
+	free(csis->sirk_val);
+	free(csis);
+}
+
 static void csip_db_free(void *data)
 {
 	struct bt_csip_db *cdb = data;
@@ -137,7 +146,7 @@ static void csip_db_free(void *data)
 
 	gatt_db_unref(cdb->db);
 
-	free(cdb->csis);
+	csis_free(cdb->csis);
 	free(cdb);
 }
 

--- a/src/shared/gatt-db.c
+++ b/src/shared/gatt-db.c
@@ -278,8 +278,8 @@ static void service_clone(void *data, void *user_data)
 	for (i = 0; i < service->num_handles; i++) {
 		struct gatt_db_attribute *attr = service->attributes[i];
 
-		/* Only clone values for characteristics since that is
-		 * cacheable.
+		/* Only clone values for characteristics declaration since that
+		 * is considered when calculating the db hash.
 		 */
 		if (bt_uuid_len(&attr->uuid) == 2 &&
 				attr->uuid.value.u16 == GATT_CHARAC_UUID)

--- a/src/shared/gatt-db.h
+++ b/src/shared/gatt-db.h
@@ -12,6 +12,7 @@ struct gatt_db;
 struct gatt_db_attribute;
 
 struct gatt_db *gatt_db_new(void);
+struct gatt_db *gatt_db_clone(struct gatt_db *db);
 
 struct gatt_db *gatt_db_ref(struct gatt_db *db);
 void gatt_db_unref(struct gatt_db *db);


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

This fixes the following leak:

102 bytes in 6 blocks are definitely lost in loss record 660 of 909
   at 0x484282F: malloc (vg_replace_malloc.c:446)
   by 0x5A078B: util_malloc (util.c:46)
   by 0x649162: read_sirk (csip.c:485)
   by 0x5C74FA: read_cb (gatt-client.c:2713)
   by 0x5C4137: handle_rsp (att.c:880)
   by 0x5C4137: can_read_data (att.c:1072)
   by 0x65DDA4: watch_callback (io-glib.c:157)
   by 0x49656AB: ??? (in /usr/lib64/libglib-2.0.so.0.8000.2)
   by 0x49C6707: ??? (in /usr/lib64/libglib-2.0.so.0.8000.2)
   by 0x496B666: g_main_loop_run (in /usr/lib64/libglib-2.0.so.0.8000.2)
   by 0x65FE3D: mainloop_run (mainloop-glib.c:66)
   by 0x6605A3: mainloop_run_with_signal (mainloop-notify.c:188)
   by 0x31DEFA: main (main.c:1468)
---
 src/shared/csip.c | 11 ++++++++++-
 1 file changed, 10 insertions(+), 1 deletion(-)