### PR TITLE
[PW_SID:860868] [BlueZ,v1,1/2] shared/gatt-db: Fix gatt_db_clone

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/src/settings.c
+++ b/src/settings.c
@@ -58,13 +58,17 @@ static int load_desc(struct gatt_db *db, char *handle, char *value,
 	uint16_t val;
 	bt_uuid_t uuid, ext_uuid;
 
-	if (sscanf(handle, "%04hx", &handle_int) != 1)
+	if (sscanf(handle, "%04hx", &handle_int) != 1) {
+		DBG("Failed to parse handle: %s", handle);
 		return -EIO;
+	}
 
 	/* Check if there is any value stored, otherwise it is just the UUID */
 	if (sscanf(value, "%04hx:%36s", &val, uuid_str) != 2) {
-		if (sscanf(value, "%36s", uuid_str) != 1)
+		if (sscanf(value, "%36s", uuid_str) != 1) {
+			DBG("Failed to parse value: %s", value);
 			return -EIO;
+		}
 		val = 0;
 	}
 
@@ -104,8 +108,10 @@ static int load_chrc(struct gatt_db *db, char *handle, char *value,
 	size_t val_len;
 	bt_uuid_t uuid;
 
-	if (sscanf(handle, "%04hx", &handle_int) != 1)
+	if (sscanf(handle, "%04hx", &handle_int) != 1) {
+		DBG("Failed to parse handle: %s", handle);
 		return -EIO;
+	}
 
 	/* Check if there is any value stored */
 	if (sscanf(value, GATT_CHARAC_UUID_STR ":%04hx:%02hx:%32s:%36s",
@@ -148,12 +154,16 @@ static int load_incl(struct gatt_db *db, char *handle, char *value,
 	struct gatt_db_attribute *att;
 	uint16_t start, end;
 
-	if (sscanf(handle, "%04hx", &start) != 1)
+	if (sscanf(handle, "%04hx", &start) != 1) {
+		DBG("Failed to parse handle: %s", handle);
 		return -EIO;
+	}
 
 	if (sscanf(value, GATT_INCLUDE_UUID_STR ":%04hx:%04hx:%36s", &start,
-							&end, uuid_str) != 3)
+							&end, uuid_str) != 3) {
+		DBG("Failed to parse value: %s", value);
 		return -EIO;
+	}
 
 	/* Log debug message. */
 	DBG("loading included service: 0x%04x, end: 0x%04x, uuid: %s",
@@ -178,11 +188,15 @@ static int load_service(struct gatt_db *db, char *handle, char *value)
 	bt_uuid_t uuid;
 	bool primary;
 
-	if (sscanf(handle, "%04hx", &start) != 1)
+	if (sscanf(handle, "%04hx", &start) != 1) {
+		DBG("Failed to parse handle: %s", handle);
 		return -EIO;
+	}
 
-	if (sscanf(value, "%[^:]:%04hx:%36s", type, &end, uuid_str) != 3)
+	if (sscanf(value, "%[^:]:%04hx:%36s", type, &end, uuid_str) != 3) {
+		DBG("Failed to parse value: %s", value);
 		return -EIO;
+	}
 
 	if (g_str_equal(type, GATT_PRIM_SVC_UUID_STR))
 		primary = true;

--- a/src/shared/gatt-db.c
+++ b/src/shared/gatt-db.c
@@ -281,18 +281,35 @@ static void service_clone(void *data, void *user_data)
 		/* Only clone values for characteristics declaration since that
 		 * is considered when calculating the db hash.
 		 */
-		if (bt_uuid_len(&attr->uuid) == 2 &&
-				attr->uuid.value.u16 == GATT_CHARAC_UUID)
+		if (bt_uuid_len(&attr->uuid) != 2) {
+			clone->attributes[i] = new_attribute(clone,
+							attr->handle,
+							&attr->uuid,
+							NULL, 0);
+			continue;
+		}
+
+		/* Attribute values that are used for generating the hash needs
+		 * to be cloned as well.
+		 */
+		switch (attr->uuid.value.u16) {
+		case GATT_PRIM_SVC_UUID:
+		case GATT_SND_SVC_UUID:
+		case GATT_INCLUDE_UUID:
+		case GATT_CHARAC_UUID:
 			clone->attributes[i] = new_attribute(clone,
 							attr->handle,
 							&attr->uuid,
 							attr->value,
 							attr->value_len);
-		else
+			break;
+		default:
 			clone->attributes[i] = new_attribute(clone,
 							attr->handle,
 							&attr->uuid,
 							NULL, 0);
+			break;
+		}
 	}
 
 	queue_push_tail(db->services, clone);


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

The process of cloning an existing db shall also clone certain values
that are considered when calculating the hash since the resulting clone
shall have the same hash.
---
 src/shared/gatt-db.c | 23 ++++++++++++++++++++---
 1 file changed, 20 insertions(+), 3 deletions(-)