### PR TITLE
[PW_SID:861326] [BlueZ,v1,1/2] device: Fix storing conn parameters without first attempting to use them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/profiles/gap/gas.c
+++ b/profiles/gap/gas.c
@@ -182,18 +182,18 @@ static void read_ppcp_cb(bool success, uint8_t att_ecode,
 	latency = get_le16(&value[4]);
 	timeout = get_le16(&value[6]);
 
+	/* 0xffff indicates no specific min/max */
+	if (min_interval == 0xffff)
+		min_interval = 0x0018; /* 30.0ms */
+
+	if (max_interval == 0xffff)
+		max_interval = 0x0028; /* 50.0ms */
+
 	DBG("GAP Peripheral Preferred Connection Parameters:");
 	DBG("\tMinimum connection interval: %u", min_interval);
 	DBG("\tMaximum connection interval: %u", max_interval);
 	DBG("\tSlave latency: %u", latency);
 	DBG("\tConnection Supervision timeout multiplier: %u", timeout);
-
-	/* 0xffff indicates no specific min/max */
-	if (min_interval == 0xffff)
-		min_interval = 6;
-
-	if (max_interval == 0xffff)
-		max_interval = 3200;
 
 	/* avoid persisting connection parameters that are not valid */
 	if (min_interval > max_interval ||

--- a/src/device.c
+++ b/src/device.c
@@ -7346,10 +7346,10 @@ void btd_device_set_conn_param(struct btd_device *device, uint16_t min_interval,
 					uint16_t max_interval, uint16_t latency,
 					uint16_t timeout)
 {
-	btd_adapter_store_conn_param(device->adapter, &device->bdaddr,
-					device->bdaddr_type, min_interval,
-					max_interval, latency,
-					timeout);
+	/* Attempt to load the new connection parameters, in case it is
+	 * successful the MGMT_EV_NEW_CONN_PARAM will be generated which will
+	 * then trigger btd_adapter_store_conn_param.
+	 */
 	btd_adapter_load_conn_param(device->adapter, &device->bdaddr,
 					device->bdaddr_type, min_interval,
 					max_interval, latency,


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

Some controller seems to have problems to use connections parameters
that comes from PPCP as seem bellow, so instead of storing the
parameters immediately this wait the MGMT_EV_NEW_CONN_PARAM to confirm
the connection parameters are save to be stored:

< HCI Command: LE Extended Create Connection (0x08|0x0043) plen 42
        Filter policy: Accept list is not used (0x00)
        Own address type: Public (0x00)
        Peer address type: Random (0x01)
        Peer address: FE:D5:D9:EC:AB:99 (Static)
        Initiating PHYs: 0x03
        Entry 0: LE 1M
          Scan interval: 60.000 msec (0x0060)
          Scan window: 60.000 msec (0x0060)
          Min connection interval: 7.50 msec (0x0006)
          Max connection interval: 4000.00 msec (0x0c80)
          Connection latency: 0 (0x0000)
          Supervision timeout: 5000 msec (0x01f4)
          Min connection length: 0.000 msec (0x0000)
          Max connection length: 0.000 msec (0x0000)
        Entry 1: LE 2M
          Scan interval: 60.000 msec (0x0060)
          Scan window: 60.000 msec (0x0060)
          Min connection interval: 7.50 msec (0x0006)
          Max connection interval: 4000.00 msec (0x0c80)
          Connection latency: 0 (0x0000)
          Supervision timeout: 5000 msec (0x01f4)
          Min connection length: 0.000 msec (0x0000)
          Max connection length: 0.000 msec (0x0000)
> HCI Event: Command Status (0x0f) plen 4
      LE Extended Create Connection (0x08|0x0043) ncmd 1
        Status: Invalid HCI Command Parameters (0x12)
---
 src/device.c | 8 ++++----
 1 file changed, 4 insertions(+), 4 deletions(-)