### PR TITLE
[PW_SID:861655] [BlueZ,v1] client/player: Fix transport.send

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/client/player.c
+++ b/client/player.c
@@ -5140,7 +5140,7 @@ static void cmd_send_transport(int argc, char *argv[])
 			err = transport_send(transport, fd, NULL);
 		} else {
 			struct sockaddr_iso addr;
-			socklen_t optlen;
+			socklen_t optlen = sizeof(addr);
 
 			err = getpeername(transport->sk, &addr, &optlen);
 			if (!err) {
@@ -5154,7 +5154,7 @@ static void cmd_send_transport(int argc, char *argv[])
 		}
 
 		if (err < 0) {
-			bt_shell_printf("Unable to send: %s (%d)",
+			bt_shell_printf("Unable to send: %s (%d)\n",
 						strerror(-err), -err);
 			close(fd);
 			return bt_shell_noninteractive_quit(EXIT_FAILURE);


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

This fixes the usage of getpeername, introduced by 04153538aaf4
("client/player: Fix using unicast QoS for broadcast"), without
initializing optlen which causes the following problem:

Unable to send: Operation not permitted (1)
---
 client/player.c | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)