### PR TITLE
[PW_SID:862686] [BlueZ,v2] shared/bap: make BT_BAP_* direction defines valid bitmasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/src/shared/bap-defs.h
+++ b/src/shared/bap-defs.h
@@ -15,10 +15,10 @@
 #define __packed __attribute__((packed))
 #endif
 
-#define BT_BAP_SINK			0x01
-#define	BT_BAP_SOURCE			0x02
-#define	BT_BAP_BCAST_SOURCE		0x03
-#define	BT_BAP_BCAST_SINK		0x04
+#define BT_BAP_SINK			BIT(0)
+#define	BT_BAP_SOURCE			BIT(1)
+#define	BT_BAP_BCAST_SOURCE		BIT(2)
+#define	BT_BAP_BCAST_SINK		BIT(3)
 
 #define BT_BAP_STREAM_TYPE_UCAST	0x01
 #define	BT_BAP_STREAM_TYPE_BCAST	0x02


### PR DESCRIPTION
The directions appear to be intended as bitmasks, as
bt_bap_stream_io_dir() will bitwise or linked stream directions.

Fix the defines to be separate bits.

Fixes confusion due to BT_BAP_BCAST_SOURCE == BT_BAP_SINK|BT_BAP_SOURCE,
which causes e.g. unicast transports to be in PENDING state after QoS
although this does not make sense for BAP unicast Client.
---

Notes:
    v2: use BIT macro

 src/shared/bap-defs.h | 8 ++++----
 1 file changed, 4 insertions(+), 4 deletions(-)