### PR TITLE
[PW_SID:862692] [BlueZ] transport: fix crash when freeing transport

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/profiles/audio/transport.c
+++ b/profiles/audio/transport.c
@@ -220,9 +220,6 @@ void media_transport_destroy(struct media_transport *transport)
 	g_dbus_unregister_interface(btd_get_dbus_connection(), path,
 						MEDIA_TRANSPORT_INTERFACE);
 
-	if (transport->remote_endpoint)
-		g_free(transport->remote_endpoint);
-
 	g_free(path);
 }
 
@@ -1271,6 +1268,7 @@ static void media_transport_free(void *data)
 	if (transport->ops && transport->ops->destroy)
 		transport->ops->destroy(transport->data);
 
+	g_free(transport->remote_endpoint);
 	g_free(transport->configuration);
 	g_free(transport->path);
 	g_free(transport);


### PR DESCRIPTION
Fix UAF by freeing transport->remote_endpoint in media_transport_free,
which also frees the struct (not in destroy after the struct is freed).

ERROR: AddressSanitizer: heap-use-after-free
READ of size 8 at 0x508000022ab8 thread T0
    #0 0x493624 in media_transport_destroy profiles/audio/transport.c:223
...
freed by thread T0 here:
    #1 0x7fb057d10294 in g_free (/lib64/libglib-2.0.so.0+0x5d294)
    #2 0x49dd2d in media_transport_free profiles/audio/transport.c:1276
    #3 0x7e0e99 in remove_interface gdbus/object.c:682
    #4 0x7e8f40 in g_dbus_unregister_interface gdbus/object.c:1430
    #5 0x4935a2 in media_transport_destroy profiles/audio/transport.c:220
---
 profiles/audio/transport.c | 4 +---
 1 file changed, 1 insertion(+), 3 deletions(-)