### PR TITLE
[PW_SID:863185] [BlueZ,v1] gas: Fix reading attributes on every connection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/profiles/gap/gas.c
+++ b/profiles/gap/gas.c
@@ -342,6 +342,10 @@ static int gap_accept(struct btd_service *service)
 		goto _finish;
 	}
 
+	/* Check if attribute already has been discovered */
+	if (gas->attr)
+		goto _finish;
+
 	gas->db = gatt_db_ref(db);
 	gas->client = bt_gatt_client_clone(client);
 
@@ -364,10 +368,6 @@ _finish:
 
 static int gap_disconnect(struct btd_service *service)
 {
-	struct gas *gas = btd_service_get_user_data(service);
-
-	gas_reset(gas);
-
 	btd_service_disconnecting_complete(service, 0);
 
 	return 0;


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

Attributes only need to be read once after that they will be persisted
by the core so there is no need to keep reading them on every
reconnection.
---
 profiles/gap/gas.c | 8 ++++----
 1 file changed, 4 insertions(+), 4 deletions(-)