### PR TITLE
[PW_SID:864148] Fix null pointer dereference in util_ltv_foreach

### DIFF
--- a/src/shared/util.c
+++ b/src/shared/util.c
@@ -182,7 +182,7 @@ bool util_ltv_foreach(const uint8_t *data, uint8_t len, uint8_t *type,
 	struct iovec iov;
 	int i;
 
-	if (!func)
+	if (!func || !data)
 		return false;
 
 	iov.iov_base = (void *) data;


### PR DESCRIPTION
In the existing code, iov.iov_base is initialized with (void *) data,assuming
data is always valid. However, if "data" happens to be NULL,dereferencing
iov.iov_base in util_iov_pull_u8(&iov, &l) leading to segmentation fault.

To address this issue added explicit checks for data at the beginning of the
function to ensure its not NULL before proceeding with any operations.

The following log was captured while running Broadcast Sink setup:

==79178==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000
(pc 0x5631fc6550b1 bp 0x7ffedd247450 sp 0x7ffedd2473a0 T0)
==79178==The signal is caused by a READ memory access.
==79178==Hint: address points to the zero page.
    #0 0x5631fc6550b1 in get_u8 src/shared/util.h:206
    #1 0x5631fc6550b1 in util_iov_pull_u8 src/shared/util.c:680
    #2 0x5631fc6552f7 in util_ltv_foreach src/shared/util.c:194
    #3 0x5631fc4b57eb in parse_base profiles/audio/bap.c:1189
    #4 0x5631fc4b57eb in iso_pa_sync_confirm_cb profiles/audio/bap.c:1253
    #5 0x5631fc4d5990 in server_cb btio/btio.c:265
    #6 0x5631fc4d5990 in server_cb btio/btio.c:242
    #7 0x71d33511bc43 in g_main_context_dispatch
    (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x55c43)
    #8 0x71d3351712b7  (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0xab2b7)
    #9 0x71d33511b2b2 in g_main_loop_run
    (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x552b2)
    #10 0x5631fc738ea8 in mainloop_run src/shared/mainloop-glib.c:66
    #11 0x5631fc7397b6 in mainloop_run_with_signal
    src/shared/mainloop-notify.c:189
    #12 0x5631fc355c3a in main src/main.c:1467
    #13 0x71d334429d8f in __libc_start_call_main
    ../sysdeps/nptl/libc_start_call_main.h:58
    #14 0x71d334429e3f in __libc_start_main_impl ../csu/libc-start.c:392
---
 src/shared/util.c | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)