### PR TITLE
[PW_SID:864750] [v1] Bluetooth : Update the mas session structure

### DIFF
--- a/obexd/plugins/mas.c
+++ b/obexd/plugins/mas.c
@@ -51,6 +51,8 @@
 #define ML_BODY_END "</MAP-msg-listing>"
 
 struct mas_session {
+	uint8_t notification_status;
+	char *path;
 	struct mas_request *request;
 	void *backend_data;
 	gboolean finished;
@@ -59,7 +61,6 @@ struct mas_session {
 	GObexApparam *inparams;
 	GObexApparam *outparams;
 	gboolean ap_sent;
-	uint8_t notification_status;
 };
 
 static const uint8_t MAS_TARGET[TARGET_SIZE] = {
@@ -125,6 +126,7 @@ static void *mas_connect(struct obex_session *os, int *err)
 		goto failed;
 
 	manager_register_session(os);
+	mas->path = NULL;
 
 	return mas;
 


### PR DESCRIPTION
Update the 'mas_session' structure such that manager_emit_transfer_property(os->service_data, "Size")
will get the proper structure in arguments as expected like structure 'obex_transfer' and transfer->path
won't be populated with inappropriate value.

As there is no new tranfer registered during mas connect, hence setting the path to NULL
to avoid invoking the g_dbus_emit_property_changed() property.

Signed-off-by: Amisha Jain <quic_amisjain@quicinc.com>
---
 obexd/plugins/mas.c | 4 +++-
 1 file changed, 3 insertions(+), 1 deletion(-)