### PR TITLE
[PW_SID:865048] [BlueZ,v1] hog-lib: Fix passing wrong parameters to bt_uhid_get_report_reply

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/profiles/input/hog-lib.c
+++ b/profiles/input/hog-lib.c
@@ -904,7 +904,7 @@ static void report_reply(struct bt_hog *hog, uint8_t status, uint8_t id,
 
 	hog->getrep_att = 0;
 
-	err = bt_uhid_get_report_reply(hog->uhid, hog->getrep_id, status, id,
+	err = bt_uhid_get_report_reply(hog->uhid, hog->getrep_id, id, status,
 					data, len);
 	if (err < 0)
 		error("bt_uhid_get_report_reply: %s", strerror(-err));


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

The parameters of bt_uhid_get_report_reply are number followed by
status, not status followed by number, so the order needs to be
swapped.

Fixes: https://github.com/bluez/bluez/issues/880
---
 profiles/input/hog-lib.c | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)