### PR TITLE
[PW_SID:866086] [BlueZ] plugins/sixaxis: add NULL check in setup_device()

### DIFF
--- a/plugins/sixaxis.c
+++ b/plugins/sixaxis.c
@@ -346,6 +346,11 @@ static bool setup_device(int fd, const char *sysfs_path,
 
 	device = btd_adapter_get_device(adapter, &device_bdaddr, BDADDR_BREDR);
 
+	if (!device) {
+		error("sixaxis: unable to set up a new device");
+		return false;
+	}
+
 	info("sixaxis: setting up new device");
 
 	btd_device_device_set_name(device, cp->name);


### PR DESCRIPTION
btd_adapter_get_device() may return NULL on the next call stack:

btd_adapter_get_device()
    adapter_create_device()
        device_create()
	    device_new()
                g_try_malloc0()

It is necessary to prevent this to avoid dereferencing a null
pointer further.
---
 plugins/sixaxis.c | 5 +++++
 1 file changed, 5 insertions(+)