### PR TITLE
[PW_SID:866519] adapter: Add retry when bonding device returns connection failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/src/adapter.c
+++ b/src/adapter.c
@@ -8367,6 +8367,16 @@ static void bonding_attempt_complete(struct btd_adapter *adapter,
 		}
 	}
 
+	if (status == MGMT_STATUS_CONNECT_FAILED) {
+		if (device != NULL) {
+
+			DBG("status is 0x%x, retry it.", status);
+
+			if (device_bonding_attempt_retry(device) == 0)
+				return;
+		}
+	}
+
 	/* Ignore disconnects during retry. */
 	if (status == MGMT_STATUS_DISCONNECTED &&
 					device && device_is_retrying(device))


### PR DESCRIPTION
When a user initiates pairing with a BLE Bluetooth mouse,
MGMT_STATUS_CONNECT_FAILED(0x04) is returned with a low
probability, resulting in pairing failure. To improve
user experience, retry bonding is performed when
MGMT_STATUS_CONNECT_FAILED is returned.

log:
bluetoothd[1539]: src/adapter.c:pair_device_complete() Connect Failed (0x04)
bluetoothd[1539]: src/adapter.c:bonding_attempt_complete() hci0 bdaddr DD:EC:0F:57:A9:2E type 2 status 0x4
bluetoothd[1539]: src/device.c:device_bonding_complete() bonding 0x5591f87230 status 0x04
bluetoothd[1539]: src/device.c:btd_device_set_temporary() temporary 1
bluetoothd[1539]: src/device.c:device_bonding_failed() status 4

HCI package:
Frame 2969: 7 bytes on wire (56 bits), 7 bytes captured (56 bits)
Bluetooth
Bluetooth HCI H4
Bluetooth HCI Event - Disconnect Complete
    Event Code: Disconnect Complete (0x05)
    Parameter Total Length: 4
    Status: Success (0x00)
    Connection Handle: 0x0040
    Reason: Connection Failed to be Established (0x3e)
---
 src/adapter.c | 10 ++++++++++
 1 file changed, 10 insertions(+)