### PR TITLE
[PW_SID:866579] [BlueZ,v1] l2test: replace sprintf() with snprintf() in recv_mode()

### DIFF
--- a/tools/l2test.c
+++ b/tools/l2test.c
@@ -913,7 +913,7 @@ static void recv_mode(int sk)
 					timestamp = 0;
 					memset(ts, 0, sizeof(ts));
 				} else {
-					sprintf(ts, "[%lld.%lld] ",
+					snprintf(ts, sizeof(ts), "[%lld.%lld] ",
 							(long long)tv.tv_sec,
 							(long long)tv.tv_usec);
 				}


### PR DESCRIPTION
Use snprintf() instead of sprintf() to avoid buffer overflow.

Found with the SVACE static analysis tool
---
 tools/l2test.c | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)