### PR TITLE
[PW_SID:866685] [BlueZ,v2,1/2] org.bluez.LEAdvertisement: Promote experimental properties to stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/doc/org.bluez.LEAdvertisement.rst
+++ b/doc/org.bluez.LEAdvertisement.rst
@@ -83,8 +83,8 @@ dict ServiceData
 	Service Data elements to include. The keys are the UUID to associate
 	with the data.
 
-dict Data [Experimental]
-````````````````````````
+dict Data
+`````````
 
 	Advertising Data to include. Key is the advertising type and value is
 	the data as byte array.
@@ -101,8 +101,8 @@ dict Data [Experimental]
 		<Transport Discovery> <Organization Flags...>
 		0x26                   0x01         0x01...
 
-bool Discoverable [Experimental]
-````````````````````````````````
+bool Discoverable
+`````````````````
 
 	Advertise as general discoverable. When present this will override
 	adapter Discoverable property.
@@ -110,8 +110,8 @@ bool Discoverable [Experimental]
 	Note: This property shall not be set when **Type** is set to
 	"broadcast".
 
-uint16 DiscoverableTimeout [Experimental]
-`````````````````````````````````````````
+uint16 DiscoverableTimeout
+``````````````````````````
 
 	The discoverable timeout in seconds. A value of zero means that the
 	timeout is disabled and it will stay in discoverable/limited mode
@@ -158,8 +158,8 @@ uint16_t Timeout
 	Timeout of the advertisement in seconds. This defines the lifetime of
 	the advertisement.
 
-string SecondaryChannel [Experimental]
-``````````````````````````````````````
+string SecondaryChannel
+```````````````````````
 
 	Secondary channel to be used. Primary channel is always set to "1M"
 	except when "Coded" is set.
@@ -170,24 +170,24 @@ string SecondaryChannel [Experimental]
 	:"2M":
 	:"Coded":
 
-uint32 MinInterval [Experimental]
-`````````````````````````````````
+uint32 MinInterval
+``````````````````
 
 	Minimum advertising interval to be used by the advertising set, in
 	milliseconds. Acceptable values are in the range [20ms, 10,485s].
 	If the provided MinInterval is larger than the provided MaxInterval,
 	the registration will return failure.
 
-uint32 MaxInterval [Experimental]
-`````````````````````````````````
+uint32 MaxInterval
+``````````````````
 
 	Maximum advertising interval to be used by the advertising set, in
 	milliseconds. Acceptable values are in the range [20ms, 10,485s]. If the
 	provided MinInterval is larger than the provided MaxInterval, the
 	registration will return failure.
 
-int16 TxPower [Experimental]
-````````````````````````````
+int16 TxPower
+`````````````
 
 	Requested transmission power of this advertising set. The provided value
 	is used only if the "CanSetTxPower" feature is enabled on the

--- a/doc/org.bluez.LEAdvertisingManager.rst
+++ b/doc/org.bluez.LEAdvertisingManager.rst
@@ -89,8 +89,8 @@ array{string} SupportedIncludes [readonly]
 	:"local-name":
 	:"rsi":
 
-array{string} SupportedSecondaryChannels [readonly, Experimental]
-`````````````````````````````````````````````````````````````````
+array{string} SupportedSecondaryChannels [readonly]
+```````````````````````````````````````````````````
 
 	List of supported Secondary channels. Secondary channels can be used to
 	advertise with the corresponding PHY.
@@ -101,8 +101,8 @@ array{string} SupportedSecondaryChannels [readonly, Experimental]
 	:"2M":
 	:"Coded":
 
-dict SupportedCapabilities [readonly, Experimental]
-```````````````````````````````````````````````````
+dict SupportedCapabilities [readonly]
+`````````````````````````````````````
 
 	Enumerates Advertising-related controller capabilities useful to the
 	client.
@@ -125,8 +125,8 @@ dict SupportedCapabilities [readonly, Experimental]
 
 		Max advertising tx power (dBm)
 
-array{string} SupportedFeatures [readonly,optional,Experimental]
-````````````````````````````````````````````````````````````````
+array{string} SupportedFeatures [readonly,optional]
+```````````````````````````````````````````````````
 
 	List of supported platform features. If no features are available on
 	the platform, the SupportedFeatures array will be empty.

--- a/src/advertising.c
+++ b/src/advertising.c
@@ -1129,10 +1129,6 @@ static bool parse_min_interval(DBusMessageIter *iter,
 {
 	uint32_t min_interval_ms;
 
-	/* Only consider this property if experimental setting is applied */
-	if (!(g_dbus_get_flags() & G_DBUS_FLAG_ENABLE_EXPERIMENTAL))
-		return true;
-
 	if (!iter) {
 		client->min_interval = 0;
 		return false;
@@ -1162,10 +1158,6 @@ static bool parse_max_interval(DBusMessageIter *iter,
 {
 	uint32_t max_interval_ms;
 
-	/* Only consider this property if experimental setting is applied */
-	if (!(g_dbus_get_flags() & G_DBUS_FLAG_ENABLE_EXPERIMENTAL))
-		return true;
-
 	if (!iter) {
 		client->max_interval = 0;
 		return false;
@@ -1194,10 +1186,6 @@ static bool parse_tx_power(DBusMessageIter *iter,
 					struct btd_adv_client *client)
 {
 	int16_t val;
-
-	/* Only consider this property if experimental setting is applied */
-	if (!(g_dbus_get_flags() & G_DBUS_FLAG_ENABLE_EXPERIMENTAL))
-		return true;
 
 	if (!iter) {
 		client->tx_power = ADV_TX_POWER_NO_PREFERENCE;
@@ -1841,10 +1829,8 @@ static const GDBusPropertyTable properties[] = {
 	{ "SupportedIncludes", "as", get_supported_includes, NULL, NULL },
 	{ "SupportedSecondaryChannels", "as", get_supported_secondary, NULL,
 							secondary_exists },
-	{ "SupportedFeatures", "as", get_supported_features, NULL, NULL,
-					G_DBUS_PROPERTY_FLAG_EXPERIMENTAL},
-	{ "SupportedCapabilities", "a{sv}", get_supported_cap, NULL, NULL,
-					G_DBUS_PROPERTY_FLAG_EXPERIMENTAL},
+	{ "SupportedFeatures", "as", get_supported_features, NULL, NULL },
+	{ "SupportedCapabilities", "a{sv}", get_supported_cap, NULL, NULL },
 	{ }
 };
 
@@ -1998,8 +1984,7 @@ static struct btd_adv_manager *manager_create(struct btd_adapter *adapter,
 	/* Query controller capabilities. This will be used to display valid
 	 * advertising tx power range to the client.
 	 */
-	if (g_dbus_get_flags() & G_DBUS_FLAG_ENABLE_EXPERIMENTAL &&
-			btd_has_kernel_features(KERNEL_HAS_CONTROLLER_CAP_CMD))
+	if (btd_has_kernel_features(KERNEL_HAS_CONTROLLER_CAP_CMD))
 		mgmt_send(manager->mgmt, MGMT_OP_READ_CONTROLLER_CAP,
 			manager->mgmt_index, 0, NULL,
 			read_controller_cap_complete, manager, NULL);


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

This promotes experimental properties to stable since they have been in
use for quite a while without any changes.
---
 doc/org.bluez.LEAdvertisement.rst      | 28 +++++++++++++-------------
 doc/org.bluez.LEAdvertisingManager.rst | 12 +++++------
 2 files changed, 20 insertions(+), 20 deletions(-)