### PR TITLE
[PW_SID:866862] [BlueZ] policy: Fix AutoEnable default when main.conf doesn't exist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/plugins/policy.c
+++ b/plugins/policy.c
@@ -74,6 +74,7 @@ static GSList *reconnects = NULL;
 static unsigned int service_id = 0;
 static GSList *devices = NULL;
 
+static const bool default_auto_enable = true;
 static bool auto_enable = false;
 
 struct policy_data {
@@ -858,6 +859,7 @@ static int policy_init(void)
 						sizeof(*reconnect_intervals);
 		reconnect_intervals = util_memdup(default_intervals,
 						sizeof(default_intervals));
+		auto_enable = default_auto_enable;
 		goto done;
 	}
 
@@ -895,7 +897,7 @@ static int policy_init(void)
 								&gerr);
 	if (gerr) {
 		g_clear_error(&gerr);
-		auto_enable = true;
+		auto_enable = default_auto_enable;
 	}
 
 	resume_delay = g_key_file_get_integer(


### PR DESCRIPTION
180cf09933b2d8eb03972c8638063429fe5fece5 changed the default to true
if the config file did not set it, but it still remained false if
the config file did not exist at all. This change fixes that.

Fixes: https://github.com/bluez/bluez/issues/886
---
 plugins/policy.c | 4 +++-
 1 file changed, 3 insertions(+), 1 deletion(-)