### PR TITLE
[PW_SID:867448] Fix a number of static analysis issues #4

### DIFF
--- a/lib/sdp.c
+++ b/lib/sdp.c
@@ -513,8 +513,10 @@ sdp_data_t *sdp_seq_alloc_with_length(void **dtds, void **values, int *length,
 		else
 			data = sdp_data_alloc_with_length(dtd, values[i], length[i]);
 
-		if (!data)
+		if (!data) {
+			sdp_data_free(seq);
 			return NULL;
+		}
 
 		if (curr)
 			curr->next = data;
@@ -541,8 +543,10 @@ sdp_data_t *sdp_seq_alloc(void **dtds, void **values, int len)
 		else
 			data = sdp_data_alloc(dtd, values[i]);
 
-		if (!data)
+		if (!data) {
+			sdp_data_free(seq);
 			return NULL;
+		}
 
 		if (curr)
 			curr->next = data;

--- a/lib/sdp.c
+++ b/lib/sdp.c
@@ -1538,6 +1538,11 @@ static sdp_data_t *sdp_copy_seq(sdp_data_t *data)
 		value = sdp_data_value(tmp, &len);
 		datatmp = sdp_data_alloc_with_length(tmp->dtd, value, len);
 
+		if (!datatmp) {
+			sdp_data_free(seq);
+			return NULL;
+		}
+
 		if (cur)
 			cur->next = datatmp;
 		else

--- a/mesh/prov-initiator.c
+++ b/mesh/prov-initiator.c
@@ -673,8 +673,13 @@ static void int_prov_rx(void *user_data, const void *dptr, uint16_t len)
 		goto failure;
 	}
 
-	if (type >= L_ARRAY_SIZE(expected_pdu_size) ||
-					len != expected_pdu_size[type]) {
+	if (type >= L_ARRAY_SIZE(expected_pdu_size)) {
+		l_error("Invalid PDU type %2.2x", type);
+		fail_code[1] = PROV_ERR_INVALID_FORMAT;
+		goto failure;
+	}
+
+	if (len != expected_pdu_size[type]) {
 		l_error("Expected PDU size %d, Got %d (type: %2.2x)",
 			expected_pdu_size[type], len, type);
 		fail_code[1] = PROV_ERR_INVALID_FORMAT;

--- a/obexd/plugins/messages-dummy.c
+++ b/obexd/plugins/messages-dummy.c
@@ -406,6 +406,7 @@ static void msg_element(GMarkupParseContext *ctxt, const char *element,
 	g_free(entry->reception_status);
 	g_free(entry->type);
 	g_free(entry->sender_addressing);
+	g_free(entry->recipient_addressing);
 	g_free(entry->subject);
 	g_free(entry->datetime);
 	g_free(entry->attachment_size);

--- a/obexd/plugins/messages-dummy.c
+++ b/obexd/plugins/messages-dummy.c
@@ -359,36 +359,45 @@ static void msg_element(GMarkupParseContext *ctxt, const char *element,
 
 	for (i = 0 ; names[i]; ++i) {
 		if (g_strcmp0(names[i], "handle") == 0) {
+			g_free(entry->handle);
 			entry->handle = g_strdup(values[i]);
 			mld->size++;
 			continue;
 		}
 		if (g_strcmp0(names[i], "attachment_size") == 0) {
+			g_free(entry->attachment_size);
 			entry->attachment_size = g_strdup(values[i]);
 			continue;
 		}
 		if (g_strcmp0(names[i], "datetime") == 0) {
+			g_free(entry->datetime);
 			entry->datetime = g_strdup(values[i]);
 			continue;
 		}
 		if (g_strcmp0(names[i], "subject") == 0) {
+			g_free(entry->subject);
 			entry->subject = g_strdup(values[i]);
 			continue;
 		}
 		if (g_strcmp0(names[i], "recipient_addressing") == 0) {
+			g_free(entry->recipient_addressing);
 			entry->recipient_addressing = g_strdup(values[i]);
 			continue;
 		}
 		if (g_strcmp0(names[i], "sender_addressing") == 0) {
+			g_free(entry->sender_addressing);
 			entry->sender_addressing = g_strdup(values[i]);
 			continue;
 		}
 		if (g_strcmp0(names[i], "type") == 0) {
+			g_free(entry->type);
 			entry->type = g_strdup(values[i]);
 			continue;
 		}
-		if (g_strcmp0(names[i], "reception_status") == 0)
+		if (g_strcmp0(names[i], "reception_status") == 0) {
+			g_free(entry->reception_status);
 			entry->reception_status = g_strdup(values[i]);
+		}
 	}
 
 	if (mld->size > mld->offset)

--- a/obexd/plugins/pcsuite.c
+++ b/obexd/plugins/pcsuite.c
@@ -376,6 +376,7 @@ static void *backup_open(const char *name, int oflag, mode_t mode,
 	obj->error_code = 0;
 
 	if (send_backup_dbus_message("open", obj, size) == FALSE) {
+		g_free(obj->cmd);
 		g_free(obj);
 		obj = NULL;
 	}

--- a/profiles/health/mcap.c
+++ b/profiles/health/mcap.c
@@ -2052,6 +2052,7 @@ static void connect_mcl_event_cb(GIOChannel *chan, GError *gerr,
 		set_default_cb(mcl);
 		if (util_getrandom(&val, sizeof(val), 0) < 0) {
 			mcap_instance_unref(mcl->mi);
+			g_free(mcl->cb);
 			g_free(mcl);
 			goto drop;
 		}

--- a/src/main.c
+++ b/src/main.c
@@ -420,9 +420,10 @@ static bool parse_config_string(GKeyFile *config, const char *group,
 					const char *key, char **val)
 {
 	GError *err = NULL;
-	char *tmp;
 
-	tmp = g_key_file_get_string(config, group, key, &err);
+	g_return_val_if_fail(val, false);
+
+	*val = g_key_file_get_string(config, group, key, &err);
 	if (err) {
 		if (err->code != G_KEY_FILE_ERROR_KEY_NOT_FOUND)
 			DBG("%s", err->message);
@@ -430,12 +431,7 @@ static bool parse_config_string(GKeyFile *config, const char *group,
 		return false;
 	}
 
-	DBG("%s.%s = %s", group, key, tmp);
-
-	if (val) {
-		g_free(*val);
-		*val = tmp;
-	}
+	DBG("%s.%s = %s", group, key, *val);
 
 	return true;
 }
@@ -1004,7 +1000,12 @@ static void parse_secure_conns(GKeyFile *config)
 
 static void parse_general(GKeyFile *config)
 {
-	parse_config_string(config, "General", "Name", &btd_opts.name);
+	char *str = NULL;
+
+	if (parse_config_string(config, "General", "Name", &str)) {
+		g_free(btd_opts.name);
+		btd_opts.name = str;
+	}
 	parse_config_hex(config, "General", "Class", &btd_opts.class);
 	parse_config_u32(config, "General", "DiscoverableTimeout",
 						&btd_opts.discovto,


### PR DESCRIPTION
The memory management done by parse_config_string() was quite
complicated, as it expected to be able to free the value in the return
variable if it was already allocated.

That particular behaviour was only used for a single variable which was
set to its default value during startup and might be overwritten after
this function call.

Use an intermediate variable to check whether we need to free
btd_opts.name and simplify parse_config_string().

Error: RESOURCE_LEAK (CWE-772): [#def39] [important]
bluez-5.75/src/main.c:425:2: alloc_fn: Storage is returned from allocation function "g_key_file_get_string".
bluez-5.75/src/main.c:425:2: var_assign: Assigning: "tmp" = storage returned from "g_key_file_get_string(config, group, key, &err)".
bluez-5.75/src/main.c:433:2: noescape: Assuming resource "tmp" is not freed or pointed-to as ellipsis argument to "btd_debug".
bluez-5.75/src/main.c:440:2: leaked_storage: Variable "tmp" going out of scope leaks the storage it points to.
438|	}
439|
440|->	return true;
441|   }
442|
---
 src/main.c | 19 ++++++++++---------
 1 file changed, 10 insertions(+), 9 deletions(-)