### PR TITLE
[PW_SID:867473] [BlueZ,v4] obex: Move size emit signal to plugins instead of obex.c

### DIFF
--- a/obexd/plugins/ftp.c
+++ b/obexd/plugins/ftp.c
@@ -175,6 +175,9 @@ int ftp_chkput(struct obex_session *os, void *user_data)
 
 	ret = obex_put_stream_start(os, path);
 
+	if (obex_get_size(os) != OBJECT_SIZE_DELETE && obex_get_size(os) != OBJECT_SIZE_UNKNOWN)
+		manager_emit_transfer_property(ftp->transfer, "Size");
+
 	if (ret == 0)
 		manager_emit_transfer_started(ftp->transfer);
 

--- a/obexd/plugins/opp.c
+++ b/obexd/plugins/opp.c
@@ -87,6 +87,9 @@ skip_auth:
 
 	err = obex_put_stream_start(os, path);
 
+	if (obex_get_size(os) != OBJECT_SIZE_DELETE && obex_get_size(os) != OBJECT_SIZE_UNKNOWN)
+		manager_emit_transfer_property(user_data, "Size");
+
 	g_free(path);
 
 	if (err < 0)

--- a/obexd/src/obex.c
+++ b/obexd/src/obex.c
@@ -716,9 +716,6 @@ int obex_put_stream_start(struct obex_session *os, const char *filename)
 		return err;
 	}
 
-	if (os->size != OBJECT_SIZE_DELETE && os->size != OBJECT_SIZE_UNKNOWN)
-		manager_emit_transfer_property(os->service_data, "Size");
-
 	os->path = g_strdup(filename);
 
 	return 0;


### PR DESCRIPTION
Instead of emitting the property "Size" from obex_put_stream_start(),
Call the function manager_emit_transfer_property() from plugins/*.c
wherever plugin has transfer object present.
Remove the code from obex.c which is generic for all profiles.

This change resolves the type mismatch issue when calling the
manager_emit_transfer_property from obex.c. We are passing
'os->service_data' of plugin session type but the
manager_emit_transfer_property() expects the 'obex_transfer'
type, therefore size is not set properly and might cause
crash/disconnection.

---
 obexd/plugins/ftp.c | 3 +++
 obexd/plugins/opp.c | 3 +++
 obexd/src/obex.c    | 3 ---
 3 files changed, 6 insertions(+), 3 deletions(-)