### PR TITLE
[PW_SID:867869] [v3] Set BREDR not supported bit in AD Flag when discoverable is off

### DIFF
--- a/src/advertising.c
+++ b/src/advertising.c
@@ -734,8 +734,7 @@ static bool set_flags(struct btd_adv_client *client, uint8_t flags)
 	/* Set BR/EDR Not Supported if adapter is not discoverable but the
 	 * instance is.
 	 */
-	if ((flags & (BT_AD_FLAG_GENERAL | BT_AD_FLAG_LIMITED)) &&
-			!btd_adapter_get_discoverable(client->manager->adapter))
+	if (!btd_adapter_get_discoverable(client->manager->adapter))
 		flags |= BT_AD_FLAG_NO_BREDR;
 
 	if (!bt_ad_add_flags(client->data, &flags, 1))
@@ -1486,6 +1485,12 @@ static DBusMessage *parse_advertisement(struct btd_adv_client *client)
 				client->min_interval, client->max_interval);
 		goto fail;
 	}
+
+	/* GAP.TS.p44 Test Spec GAP/DISC/NONM/BV-02-C
+	 * BR/EDR Not Supported BIT shall be included
+	 * in the AD Type flag.
+	 */
+	set_flags(client, bt_ad_get_flags(client->data));
 
 	err = refresh_advertisement(client, add_adv_callback);
 


### PR DESCRIPTION
From: Prathibha Madugonde <quic_prathm@quicinc.com>

Fix for GAP/DISC/NONM/BV-02-C
As per GAP.TS.p44 test spec
IUT does not contain General Discoverable mode and Limited Discoverable
mode in the AD Type Flag. IUT shall send AD Type Flag to PASS the test
case, thus set BR/EDR not supported bit in the AD Type Flag when
discoverable is off.

Test steps:
From DUT, bluetoothctl go to menu advertise
set discoverable to off and then advertise on.
In AD Flags BR/EDR not supported BIT shall be set.

---
 src/advertising.c | 9 +++++++--
 1 file changed, 7 insertions(+), 2 deletions(-)