### PR TITLE
[PW_SID:868334] [BlueZ,v2] client/player: add error code handling to transport_recv()

### DIFF
--- a/client/player.c
+++ b/client/player.c
@@ -4514,7 +4514,13 @@ static bool transport_recv(struct io *io, void *user_data)
 	uint8_t buf[1024];
 	int ret, len;
 
-	ret = read(io_get_fd(io), buf, sizeof(buf));
+	ret = io_get_fd(io);
+	if (ret < 0) {
+		bt_shell_printf("io_get_fd() returned %d\n", ret);
+		return true;
+	}
+
+	ret = read(ret, buf, sizeof(buf));
 	if (ret < 0) {
 		bt_shell_printf("Failed to read: %s (%d)\n", strerror(errno),
 								-errno);


### PR DESCRIPTION
It is necessary to add return value check as in sock_send().

Found with the SVACE static analysis tool.
---
 V1 -> V2: the name of the patch has been shortened 
 client/player.c | 8 +++++++-
 1 file changed, 7 insertions(+), 1 deletion(-)