### PR TITLE
[PW_SID:868402] Fix a number of static analysis issues #5

### DIFF
--- a/emulator/amp.c
+++ b/emulator/amp.c
@@ -680,7 +680,8 @@ static void cmd_read_local_amp_assoc(struct bt_amp *amp,
 {
 	const struct bt_hci_cmd_read_local_amp_assoc *cmd = data;
 	struct bt_hci_rsp_read_local_amp_assoc rsp;
-	uint16_t len_so_far, remain_assoc_len, fragment_len;
+	uint16_t len_so_far, remain_assoc_len;
+	size_t fragment_len;
 
 	if (cmd->phy_handle != amp->phy_handle) {
 		cmd_status(amp, BT_HCI_ERR_INVALID_PARAMETERS,

--- a/emulator/bthost.c
+++ b/emulator/bthost.c
@@ -3290,6 +3290,7 @@ static void set_pa_data(struct bthost *bthost, const uint8_t *data,
 {
 	struct bt_hci_cmd_le_set_pa_data *cp;
 	uint8_t buf[sizeof(*cp) + BT_PA_MAX_DATA_LEN];
+	size_t data_len;
 
 	cp = (void *)buf;
 
@@ -3299,14 +3300,14 @@ static void set_pa_data(struct bthost *bthost, const uint8_t *data,
 	cp->handle = 1;
 
 	if (len - offset > BT_PA_MAX_DATA_LEN) {
-		cp->data_len = BT_PA_MAX_DATA_LEN;
+		data_len = BT_PA_MAX_DATA_LEN;
 
 		if (!offset)
 			cp->operation = 0x01;
 		else
 			cp->operation = 0x00;
 	} else {
-		cp->data_len = len - offset;
+		data_len = len - offset;
 
 		if (!offset)
 			cp->operation = 0x03;
@@ -3314,7 +3315,8 @@ static void set_pa_data(struct bthost *bthost, const uint8_t *data,
 			cp->operation = 0x02;
 	}
 
-	memcpy(cp->data, data + offset, cp->data_len);
+	memcpy(cp->data, data + offset, data_len);
+	cp->data_len = data_len;
 
 	send_command(bthost, BT_HCI_CMD_LE_SET_PA_DATA, buf,
 					sizeof(*cp) + cp->data_len);

--- a/lib/sdp.c
+++ b/lib/sdp.c
@@ -582,6 +582,8 @@ int sdp_attr_add(sdp_record_t *rec, uint16_t attr, sdp_data_t *d)
 
 	if (p)
 		return -1;
+	if (!d)
+		return -1;
 
 	d->attrId = attr;
 	rec->attrlist = sdp_list_insert_sorted(rec->attrlist, d, sdp_attrid_comp_func);
@@ -964,6 +966,8 @@ static void data_seq_free(sdp_data_t *seq)
 
 void sdp_data_free(sdp_data_t *d)
 {
+	if (!d)
+		return;
 	switch (d->dtd) {
 	case SDP_SEQ8:
 	case SDP_SEQ16:

--- a/lib/sdp.c
+++ b/lib/sdp.c
@@ -506,7 +506,7 @@ sdp_data_t *sdp_seq_alloc_with_length(void **dtds, void **values, int *length,
 
 	for (i = 0; i < len; i++) {
 		sdp_data_t *data;
-		int8_t dtd = *(uint8_t *) dtds[i];
+		uint8_t dtd = *(uint8_t *) dtds[i];
 
 		if (dtd >= SDP_SEQ8 && dtd <= SDP_ALT32)
 			data = (sdp_data_t *) values[i];

--- a/mesh/pb-adv.c
+++ b/mesh/pb-adv.c
@@ -166,7 +166,7 @@ static void send_adv_segs(struct pb_adv_session *session, const uint8_t *data,
 	consumed = init_size;
 
 	for (i = 1; i <= max_seg; i++) {
-		uint8_t seg_size; /* Amount of payload data being sent */
+		size_t seg_size; /* Amount of payload data being sent */
 
 		if (size - consumed > PB_ADV_MTU - 1)
 			seg_size = PB_ADV_MTU - 1;

--- a/src/shared/gatt-server.c
+++ b/src/shared/gatt-server.c
@@ -1118,7 +1118,7 @@ static struct read_mult_data *read_mult_data_new(struct bt_gatt_server *server,
 	data->server = server;
 	data->num_handles = num_handles;
 	data->cur_handle = 0;
-	data->mtu = bt_att_get_mtu(server->att);
+	data->mtu = MAX(bt_att_get_mtu(server->att), BT_ATT_DEFAULT_LE_MTU);
 	data->length = 0;
 	data->rsp_data = new0(uint8_t, data->mtu - 1);
 

--- a/src/shared/gatt-server.c
+++ b/src/shared/gatt-server.c
@@ -908,7 +908,7 @@ static void read_complete_cb(struct gatt_db_attribute *attr, int err,
 	struct async_read_op *op = user_data;
 	struct bt_gatt_server *server = op->server;
 	uint8_t rsp_opcode;
-	uint16_t mtu;
+	size_t mtu;
 	uint16_t handle;
 
 	DBG(server, "Read Complete: err %d", err);
@@ -916,7 +916,7 @@ static void read_complete_cb(struct gatt_db_attribute *attr, int err,
 	mtu = bt_att_get_mtu(server->att);
 	handle = gatt_db_attribute_get_handle(attr);
 
-	if (err) {
+	if (err || mtu <= 1) {
 		bt_att_chan_send_error_rsp(op->chan, op->opcode, handle, err);
 		async_read_op_destroy(op);
 		return;
@@ -925,7 +925,7 @@ static void read_complete_cb(struct gatt_db_attribute *attr, int err,
 	rsp_opcode = get_read_rsp_opcode(op->opcode);
 
 	bt_att_chan_send_rsp(op->chan, rsp_opcode, len ? value : NULL,
-					MIN((unsigned int) mtu - 1, len));
+					MIN(mtu - 1, len));
 	async_read_op_destroy(op);
 }
 

--- a/src/shared/ringbuf.c
+++ b/src/shared/ringbuf.c
@@ -237,7 +237,7 @@ int ringbuf_vprintf(struct ringbuf *ringbuf, const char *format, va_list ap)
 		ringbuf->in_tracing(ringbuf->buffer + offset, end,
 							ringbuf->in_data);
 
-	if (len - end > 0) {
+	if ((size_t) len > end) {
 		/* Put the remainder of string at the beginning */
 		memcpy(ringbuf->buffer, str + end, len - end);
 

--- a/src/shared/shell.c
+++ b/src/shared/shell.c
@@ -1117,8 +1117,10 @@ static char **shell_completion(const char *text, int start, int end)
 	if (start > 0) {
 		wordexp_t w;
 
-		if (wordexp(rl_line_buffer, &w, WRDE_NOCMD))
+		if (wordexp(rl_line_buffer, &w, WRDE_NOCMD)) {
+			wordfree(&w);
 			return NULL;
+		}
 
 		matches = menu_completion(default_menu, text, w.we_wordc,
 							w.we_wordv[0]);
@@ -1421,15 +1423,20 @@ int bt_shell_exec(const char *input)
 	err = wordexp(input, &w, WRDE_NOCMD);
 	switch (err) {
 	case WRDE_BADCHAR:
+		wordfree(&w);
 		return -EBADMSG;
 	case WRDE_BADVAL:
 	case WRDE_SYNTAX:
+		wordfree(&w);
 		return -EINVAL;
 	case WRDE_NOSPACE:
+		wordfree(&w);
 		return -ENOMEM;
 	case WRDE_CMDSUB:
-		if (wordexp(input, &w, 0))
+		if (wordexp(input, &w, 0)) {
+			wordfree(&w);
 			return -ENOEXEC;
+		}
 		break;
 	};
 

--- a/src/shared/shell.c
+++ b/src/shared/shell.c
@@ -1306,11 +1306,12 @@ void bt_shell_init(int argc, char **argv, const struct bt_shell_opt *opt)
 			data.mode = 1;
 			goto done;
 		case 's':
-			if (optarg)
+			if (optarg && data.init_fd < 0) {
 				data.init_fd = open(optarg, O_RDONLY);
-			if (data.init_fd < 0)
-				printf("Unable to open %s: %s (%d)\n", optarg,
+				if (data.init_fd < 0)
+					printf("Unable to open %s: %s (%d)\n", optarg,
 						strerror(errno), errno);
+			}
 			break;
 		case 't':
 			if (optarg)

--- a/src/shared/shell.c
+++ b/src/shared/shell.c
@@ -525,6 +525,7 @@ static int cmd_exec(const struct bt_shell_menu_entry *entry,
 		print_text(COLOR_HIGHLIGHT,
 			"Unable to parse mandatory command arguments: %s", man );
 		free(man);
+		wordfree(&w);
 		return -EINVAL;
 	}
 
@@ -545,6 +546,7 @@ optional:
 		print_text(COLOR_HIGHLIGHT,
 			"Unable to parse optional command arguments: %s", opt);
 		free(opt);
+		wordfree(&w);
 		return -EINVAL;
 	}
 

--- a/tools/btsnoop.c
+++ b/tools/btsnoop.c
@@ -448,7 +448,7 @@ next_packet:
 		acl_flags = buf[2] >> 4;
 
 		/* use only packet with ACL start flag */
-		if (acl_flags & 0x02) {
+		if ((acl_flags & 0x02) && len > 9) {
 			if (current_cid == 0x0040 && pdu_len > 0) {
 				int i;
 				if (!pdu_first)
@@ -472,7 +472,7 @@ next_packet:
 			current_cid = buf[8] << 8 | buf[7];
 			memcpy(pdu_buf, buf + 9, len - 9);
 			pdu_len = len - 9;
-		} else if (acl_flags & 0x01) {
+		} else if ((acl_flags & 0x01) && len > 5) {
 			memcpy(pdu_buf + pdu_len, buf + 5, len - 5);
 			pdu_len += len - 5;
 		}

--- a/tools/mesh/mesh-db.c
+++ b/tools/mesh/mesh-db.c
@@ -503,7 +503,8 @@ static void load_remotes(json_object *jcfg)
 		uint8_t uuid[16];
 		uint16_t unicast, key_idx;
 		const char *str;
-		int ele_cnt, key_cnt;
+		uint8_t ele_cnt;
+		int key_cnt;
 		int j;
 
 		jnode = json_object_array_get_idx(jnodes, i);
@@ -532,9 +533,6 @@ static void load_remotes(json_object *jcfg)
 			continue;
 
 		ele_cnt = json_object_array_length(jarray);
-
-		if (ele_cnt > MAX_ELE_COUNT)
-			continue;
 
 		json_object_object_get_ex(jnode, "netKeys", &jarray);
 		if (!jarray || json_object_get_type(jarray) != json_type_array)


### PR DESCRIPTION
Set a lower-bound to the data MTU to avoid allocating -1 elements if
bt_att_get_mtu() returns zero.

Error: OVERRUN (CWE-119): [#def36] [important]
bluez-5.76/src/shared/gatt-server.c:1121:2: zero_return: Function call "bt_att_get_mtu(server->att)" returns 0.
bluez-5.76/src/shared/gatt-server.c:1121:2: assignment: Assigning: "data->mtu" = "bt_att_get_mtu(server->att)". The value of "data->mtu" is now 0.
bluez-5.76/src/shared/gatt-server.c:1123:19: assignment: Assigning: "__n" = "(size_t)(data->mtu - 1UL)". The value of "__n" is now 18446744073709551615.
bluez-5.76/src/shared/gatt-server.c:1123:19: assignment: Assigning: "__s" = "1UL".
bluez-5.76/src/shared/gatt-server.c:1123:19: overrun-buffer-arg: Calling "memset" with "__p" and "__n * __s" is suspicious because of the very large index, 18446744073709551615. The index may be due to a negative parameter being interpreted as unsigned. [Note: The source code implementation of the function has been overridden by a builtin model.]
1121|		data->mtu = bt_att_get_mtu(server->att);
1122|		data->length = 0;
1123|->		data->rsp_data = new0(uint8_t, data->mtu - 1);
1124|
1125|		return data;
---
 src/shared/gatt-server.c | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)