### PR TITLE
[PW_SID:868563] fix errors found by SVACE static analyzer #2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/obexd/plugins/filesystem.c
+++ b/obexd/plugins/filesystem.c
@@ -113,6 +113,7 @@ static char *file_stat_line(char *filename, struct stat *fstat,
 {
 	char perm[51], atime[18], ctime[18], mtime[18];
 	char *escaped, *ret = NULL;
+	struct tm a_gmtime, c_gmtime, m_gmtime;
 
 	snprintf(perm, 50, "user-perm=\"%s%s%s\" group-perm=\"%s%s%s\" "
 			"other-perm=\"%s%s%s\"",
@@ -126,9 +127,16 @@ static char *file_stat_line(char *filename, struct stat *fstat,
 			(fstat->st_mode & 0002 ? "W" : ""),
 			(dstat->st_mode & 0002 ? "D" : ""));
 
-	strftime(atime, 17, "%Y%m%dT%H%M%SZ", gmtime(&fstat->st_atime));
-	strftime(ctime, 17, "%Y%m%dT%H%M%SZ", gmtime(&fstat->st_ctime));
-	strftime(mtime, 17, "%Y%m%dT%H%M%SZ", gmtime(&fstat->st_mtime));
+	if (!gmtime_r(&fstat->st_atime, &a_gmtime) ||
+			!gmtime_r(&fstat->st_ctime, &c_gmtime) ||
+			!gmtime_r(&fstat->st_mtime, &m_gmtime)) {
+		error("gmtime_r() returned NULL");
+		return ret;
+	}
+
+	strftime(atime, 17, "%Y%m%dT%H%M%SZ", &a_gmtime);
+	strftime(ctime, 17, "%Y%m%dT%H%M%SZ", &c_gmtime);
+	strftime(mtime, 17, "%Y%m%dT%H%M%SZ", &m_gmtime);
 
 	escaped = g_markup_escape_text(filename, -1);
 

--- a/src/settings.c
+++ b/src/settings.c
@@ -232,7 +232,7 @@ static int gatt_db_load(struct gatt_db *db, GKeyFile *key_file, char **keys)
 		value = g_key_file_get_string(key_file, "Attributes", *handle,
 									NULL);
 
-		if (sscanf(value, "%[^:]:", type) != 1) {
+		if (!value || sscanf(value, "%[^:]:", type) != 1) {
 			g_free(value);
 			return -EIO;
 		}
@@ -255,7 +255,7 @@ static int gatt_db_load(struct gatt_db *db, GKeyFile *key_file, char **keys)
 		value = g_key_file_get_string(key_file, "Attributes", *handle,
 									NULL);
 
-		if (sscanf(value, "%[^:]:", type) != 1) {
+		if (!value || sscanf(value, "%[^:]:", type) != 1) {
 			g_free(value);
 			return -EIO;
 		}

--- a/src/shared/shell.c
+++ b/src/shared/shell.c
@@ -1333,7 +1333,7 @@ void bt_shell_init(int argc, char **argv, const struct bt_shell_opt *opt)
 				}
 			}
 
-			if (opt) {
+			if (opt && index >= offset) {
 				if (c != opt->options[index - offset].val) {
 					usage(argc, argv, opt);
 					exit(EXIT_SUCCESS);

--- a/tools/isotest.c
+++ b/tools/isotest.c
@@ -51,6 +51,8 @@
 #define DEFAULT_BIG_ID 0x01
 #define DEFAULT_BIS_ID 0x01
 
+#define MAX_DATA_SIZE 0x40000000
+
 /* Test modes */
 enum {
 	SEND,
@@ -1253,7 +1255,7 @@ int main(int argc, char *argv[])
 			break;
 
 		case 'b':
-			if (optarg)
+			if (optarg && atoi(optarg) < MAX_DATA_SIZE)
 				data_size = atoi(optarg);
 			break;
 

--- a/tools/rctest.c
+++ b/tools/rctest.c
@@ -41,6 +41,8 @@
 #define SIOCGSTAMP_OLD SIOCGSTAMP
 #endif
 
+#define MAX_DATA_SIZE 0x40000000
+
 /* Test modes */
 enum {
 	SEND,
@@ -749,7 +751,8 @@ int main(int argc, char *argv[])
 			break;
 
 		case 'b':
-			data_size = atoi(optarg);
+			if (optarg && atoi(optarg) < MAX_DATA_SIZE)
+				data_size = atoi(optarg);
 			break;
 
 		case 'i':


### PR DESCRIPTION
gmtime() may return NULL. It is necessary to prevent
dereferencing of a NULL pointer.

Found with the SVACE static analysis tool.
---
 obexd/plugins/filesystem.c | 14 +++++++++++---
 1 file changed, 11 insertions(+), 3 deletions(-)