### PR TITLE
[PW_SID:869066] [BlueZ] client/player: fix incompatible pointer type

### DIFF
--- a/client/player.c
+++ b/client/player.c
@@ -5147,7 +5147,7 @@ static void cmd_send_transport(int argc, char *argv[])
 			struct sockaddr_iso addr;
 			socklen_t optlen = sizeof(addr);
 
-			err = getpeername(transport->sk, &addr, &optlen);
+			err = getpeername(transport->sk, (struct sockaddr *)&addr, &optlen);
 			if (!err) {
 				if (!(bacmp(&addr.iso_bdaddr, BDADDR_ANY)))
 					err = transport_send(transport, fd,


### PR DESCRIPTION
In function 'cmd_send_transport':
error: passing argument 2 of 'getpeername' from incompatible pointer type
[-Wincompatible-pointer-types]

err = getpeername(transport->sk, &addr, &optlen);
|       |                        ^~~~~
|       |                        |
|       |                        struct sockaddr_iso *

note: expected 'struct sockaddr * restrict' but argument is of
type 'struct sockaddr_iso *'
int getpeername (int, struct sockaddr *__restrict, socklen_t *__restrict);

To resolve the compiler warnings, cast the pointer with (struct sockaddr *).
---
 client/player.c | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)