### PR TITLE
[PW_SID:869076] [BlueZ,v2] client/player: fix incompatible pointer type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/client/player.c
+++ b/client/player.c
@@ -5147,7 +5147,7 @@ static void cmd_send_transport(int argc, char *argv[])
 			struct sockaddr_iso addr;
 			socklen_t optlen = sizeof(addr);
 
-			err = getpeername(transport->sk, &addr, &optlen);
+			err = getpeername(transport->sk, (struct sockaddr *)&addr, &optlen);
 			if (!err) {
 				if (!(bacmp(&addr.iso_bdaddr, BDADDR_ANY)))
 					err = transport_send(transport, fd,


### PR DESCRIPTION
In function 'cmd_send_transport':
error: passing argument 2 of 'getpeername' from incompatible pointer
type [-Wincompatible-pointer-types]

err = getpeername(transport->sk, &addr, &optlen);
|       |                        ^~~~~
|       |                        |
|       |                        struct sockaddr_iso *

note: expected 'struct sockaddr * restrict' but argument is of
type 'struct sockaddr_iso *'

To resolve the compiler warnings, cast the pointer with
(struct sockaddr *).
---
 client/player.c | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)