### PR TITLE
[PW_SID:869638] fix errors found by SVACE static analyzer #3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/profiles/health/mcap.c
+++ b/profiles/health/mcap.c
@@ -336,6 +336,9 @@ static void mcap_notify_error(struct mcap_mcl *mcl, GError *err)
 	case MCAP_MD_CREATE_MDL_REQ:
 		st = MDL_WAITING;
 		l = g_slist_find_custom(mcl->mdls, &st, cmp_mdl_state);
+		if (!l)
+			return;
+
 		mdl = l->data;
 		mcl->mdls = g_slist_remove(mcl->mdls, mdl);
 		mcap_mdl_unref(mdl);
@@ -345,6 +348,9 @@ static void mcap_notify_error(struct mcap_mcl *mcl, GError *err)
 	case MCAP_MD_ABORT_MDL_REQ:
 		st = MDL_WAITING;
 		l = g_slist_find_custom(mcl->mdls, &st, cmp_mdl_state);
+		if (!l)
+			return;
+
 		shutdown_mdl(l->data);
 		update_mcl_state(mcl);
 		con->cb.notify(err, con->user_data);
@@ -362,6 +368,9 @@ static void mcap_notify_error(struct mcap_mcl *mcl, GError *err)
 	case MCAP_MD_RECONNECT_MDL_REQ:
 		st = MDL_WAITING;
 		l = g_slist_find_custom(mcl->mdls, &st, cmp_mdl_state);
+		if (!l)
+			return;
+
 		shutdown_mdl(l->data);
 		update_mcl_state(mcl);
 		con->cb.op(NULL, err, con->user_data);

--- a/src/settings.c
+++ b/src/settings.c
@@ -243,13 +243,32 @@ static int gatt_db_load(struct gatt_db *db, GKeyFile *key_file, char **keys)
 	struct gatt_db_attribute *current_service;
 	char **handle, *value, type[MAX_LEN_UUID_STR];
 	int ret;
+	char pattern[6];
+	char *colon_pos;
+	size_t len;
 
 	/* first load service definitions */
 	for (handle = keys; *handle; handle++) {
 		value = g_key_file_get_string(key_file, "Attributes", *handle,
 									NULL);
+		if (!value)
+			return -EIO;
 
-		if (!value || sscanf(value, "%[^:]:", type) != 1) {
+		colon_pos = memchr(value, ':', MAX_LEN_UUID_STR);
+		if (!colon_pos) {
+			g_free(value);
+			return -EIO;
+		}
+
+		len = colon_pos - value;
+		if (!len) {
+			g_free(value);
+			return -EIO;
+		}
+
+		snprintf(pattern, sizeof(pattern), "%%%lds:", len);
+
+		if (sscanf(value, pattern, type) != 1) {
 			g_free(value);
 			return -EIO;
 		}
@@ -271,8 +290,24 @@ static int gatt_db_load(struct gatt_db *db, GKeyFile *key_file, char **keys)
 	for (handle = keys; *handle; handle++) {
 		value = g_key_file_get_string(key_file, "Attributes", *handle,
 									NULL);
+		if (!value)
+			return -EIO;
 
-		if (!value || sscanf(value, "%[^:]:", type) != 1) {
+		colon_pos = memchr(value, ':', MAX_LEN_UUID_STR);
+		if (!colon_pos) {
+			g_free(value);
+			return -EIO;
+		}
+
+		len = colon_pos - value;
+		if (!len) {
+			g_free(value);
+			return -EIO;
+		}
+
+		snprintf(pattern, sizeof(pattern), "%%%lds:", len);
+
+		if (sscanf(value, pattern, type) != 1) {
 			g_free(value);
 			return -EIO;
 		}

--- a/src/settings.c
+++ b/src/settings.c
@@ -187,13 +187,30 @@ static int load_service(struct gatt_db *db, char *handle, char *value)
 	char type[MAX_LEN_UUID_STR], uuid_str[MAX_LEN_UUID_STR];
 	bt_uuid_t uuid;
 	bool primary;
+	char pattern[16];
+	char *colon_pos;
+	size_t len;
 
 	if (sscanf(handle, "%04hx", &start) != 1) {
 		DBG("Failed to parse handle: %s", handle);
 		return -EIO;
 	}
 
-	if (sscanf(value, "%[^:]:%04hx:%36s", type, &end, uuid_str) != 3) {
+	colon_pos = memchr(value, ':', MAX_LEN_UUID_STR);
+	if (!colon_pos) {
+		DBG("Failed to parse value: %s", value);
+		return -EIO;
+	}
+
+	len = colon_pos - value;
+	if (!len) {
+		DBG("Failed to parse value: %s", value);
+		return -EIO;
+	}
+
+	snprintf(pattern, sizeof(pattern), "%%%lds:%%04hx:%%36s", len);
+
+	if (sscanf(value, pattern, type, &end, uuid_str) != 3) {
 		DBG("Failed to parse value: %s", value);
 		return -EIO;
 	}

--- a/src/shared/micp.c
+++ b/src/shared/micp.c
@@ -398,6 +398,10 @@ static void mics_mute_write(struct gatt_db_attribute *attrib,
 	}
 
 	micp_op = iov_pull_mem(&iov, sizeof(*micp_op));
+	if (!micp_op) {
+		DBG(micp, "iov_pull_mem() returned NULL");
+		goto respond;
+	}
 
 	if ((*micp_op == MICS_DISABLED) || (*micp_op != MICS_NOT_MUTED
 		&& *micp_op != MICS_MUTED)) {

--- a/src/shared/vcp.c
+++ b/src/shared/vcp.c
@@ -925,6 +925,10 @@ static void vcs_cp_write(struct gatt_db_attribute *attrib,
 	}
 
 	vcp_op = iov_pull_mem(&iov, sizeof(*vcp_op));
+	if (!vcp_op) {
+		DBG(vcp, "iov_pull_mem() returned NULL");
+		goto respond;
+	}
 
 	for (handler = vcp_handlers; handler && handler->str; handler++) {
 		if (handler->op != *vcp_op)
@@ -985,6 +989,10 @@ static void vocs_cp_write(struct gatt_db_attribute *attrib,
 	}
 
 	vcp_op = iov_pull_mem(&iov, sizeof(*vcp_op));
+	if (!vcp_op) {
+		DBG(vcp, "iov_pull_mem() returned NULL");
+		goto respond;
+	}
 
 	for (handler = vocp_handlers; handler && handler->str; handler++) {
 		if (handler->op != *vcp_op)
@@ -1517,6 +1525,10 @@ static void aics_ip_cp_write(struct gatt_db_attribute *attrib,
 	}
 
 	aics_op = iov_pull_mem(&iov, sizeof(*aics_op));
+	if (!aics_op) {
+		DBG(vcp, "iov_pull_mem() returned NULL");
+		goto respond;
+	}
 
 	for (handler = aics_handlers; handler && handler->str; handler++) {
 		if (handler->op != *aics_op)


### PR DESCRIPTION
It is necessary to prevent dereferencing of NULL pointers.

Found with the SVACE static analysis tool.
---
 profiles/health/mcap.c | 9 +++++++++
 1 file changed, 9 insertions(+)