### PR TITLE
[PW_SID:871704] [v1] monitor/intel: Add decoding of Intel Read Version event fields

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/monitor/intel.c
+++ b/monitor/intel.c
@@ -205,6 +205,9 @@ static void print_version_tlv_img_type(const struct intel_version_tlv *tlv,
 	case 0x01:
 		str = "Bootloader";
 		break;
+	case 0x02:
+		str = "Intermediate loader";
+		break;
 	case 0x03:
 		str = "Firmware";
 		break;
@@ -252,6 +255,12 @@ static void print_version_tlv_mfg(const struct intel_version_tlv *tlv,
 						bt_compidtostr(mfg_id), mfg_id);
 }
 
+static void print_version_tlv_fw_id(const struct intel_version_tlv *tlv,
+				    const char *type_str)
+{
+	print_field("%s(%u): %s", type_str, tlv->type, tlv->val);
+}
+
 static const struct intel_version_tlv_desc {
 	uint8_t type;
 	const char *type_str;
@@ -291,6 +300,8 @@ static const struct intel_version_tlv_desc {
 	{ 47, "SBE Type", print_version_tlv_u8 },
 	{ 48, "OTP BDADDR", print_version_tlv_otp_bdaddr },
 	{ 49, "Unlocked State", print_version_tlv_enabled },
+	{ 50, "Firmware SHA1", print_version_tlv_u32},
+	{ 80, "Firmware ID", print_version_tlv_fw_id},
 	{ 0, NULL, NULL },
 };
 


### PR DESCRIPTION
Add decoding of Image type, Firmware SHA1 and Firmware ID fields.

snoop traces:

< HCI Command: Intel Read Version (0x3f|0x0005) plen 1
        Requested Type:
          All Supported Types(0xff)
> HCI Event: Command Complete (0x0e) plen 126
      Intel Read Version (0x3f|0x0005) ncmd 32
        Status: Success (0x00)
        CNVi TOP(16): 0x01080900
        CNVr TOP(17): 0x02001910
        CNVi BT(18): 0x001e3700
        CNVr OTP(21): 0x0432
        Device Rev ID(22): 0x0000
        USB VID(23): 0x8087
        USB PID(24): 0x0037
        Image Type(28): Intermediate loader(0x02)
        Time Stamp(29): 24-27
        Build Type(30): 0x03
        Build Num(31): 0x00010060
        OTP Patch Version(39): 0x00
        Secure Boot(40): Enabled(1)
        Key From Header(41): Disabled(0)
        OTP Lock(42): Disabled(0)
        API Lock(43): Enabled(1)
        Debug Lock(44): Disabled(0)
        Minimum FW(45): 1-10.2014
        Limited CCE(46): Disabled(0)
        SBE Type(47): 0x01
        OTP BDADDR: DC:97:BA:54:1F:72 (OUI DC-97-BA)
        Unlocked State(49): Disabled(0)
        Firmware SHA1(50): 0xe4a9801b
        Unknown Type(51):
        00 00 00 00
        Unknown Type(54):
        02
        Unknown Type(56):
        01
        Unknown Type(57):
        01 00
        Unknown Type(58):
        05 00
        Firmware ID(80): usb
---
 monitor/intel.c | 11 +++++++++++
 1 file changed, 11 insertions(+)