### PR TITLE
[PW_SID:873169] Fix com.bluez.battery1 randomly missing percentage value

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/profiles/battery/battery.c
+++ b/profiles/battery/battery.c
@@ -94,13 +94,15 @@ static void parse_battery_level(struct batt *batt,
 	uint8_t percentage;
 
 	percentage = value[0];
+	
+	if (!batt->battery) {
+		warn("Trying to update an unregistered battery");
+		return;
+	}
+	
 	if (batt->percentage != percentage) {
 		batt->percentage = percentage;
 		DBG("Battery Level updated: %d%%", percentage);
-		if (!batt->battery) {
-			warn("Trying to update an unregistered battery");
-			return;
-		}
 		btd_battery_update(batt->battery, batt->percentage);
 	}
 }


### PR DESCRIPTION
Fix an error related to "Trying to update an unregistered battery",
which causes the battery1 dbus service to fail to provide the
initial value until the battery level changes.

battery.c:batt_io_value_cb() maybe run earlier than
battery.c:batt_io_ccc_written_cb(), which causes the percentage
to be updated in the batt structure when the dbus interface
has not been registered.

After the dbus interface is registered, the function to update
the battery percentage is skipped again because the battery level
has not changed yet.
---
 profiles/battery/battery.c | 10 ++++++----
 1 file changed, 6 insertions(+), 4 deletions(-)