### PR TITLE
[PW_SID:874247] [BlueZ] shared/bap: improve channel allocation logic in bt_bap_select()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+


### PR DESCRIPTION
Currently bt_bap_select() determines the need for multi-stream
configurations in a way that depends on accidental GATT detail (whether
Locations is read before or after the PAC) that shouldn't have any
effect on the configuration.

Whether a device gets configured with 1 (AC 1) or 2 (AC 6i) sink ASEs,
consider two devices: Galaxy Buds2 Pro:

    profiles/audio/bap.c:bap_attached() 0x60e000001c40
    src/shared/bap.c:foreach_pacs_char() PAC Context found: handle 0x0050
    src/shared/bap.c:foreach_pacs_char() PAC Supported Context found: handle 0x0053
    src/shared/bap.c:foreach_pacs_char() Sink PAC Location found: handle 0x0056
    src/shared/bap.c:foreach_pacs_char() Sink PAC found: handle 0x0059

    Sink PACS Locations: 0x401
    One local PAC, with Locations: all bits
    rpac bt_bap_chan.location == 0x401 (PACS Locations read before PAC)
    -> bt_select() ChannelAllocation: 0x401

Earfun Air Pro 3:

    profiles/audio/bap.c:bap_attached() 0x60e000001e00
    src/shared/bap.c:foreach_pacs_char() Sink PAC found: handle 0x004b
    src/shared/bap.c:foreach_pacs_char() Sink PAC found: handle 0x004e
    src/shared/bap.c:foreach_pacs_char() Sink PAC found: handle 0x0051
    src/shared/bap.c:foreach_pacs_char() Sink PAC found: handle 0x0054
    src/shared/bap.c:foreach_pacs_char() Sink PAC Location found: handle 0x0057

    Sink PACS Locations: 0x3
    One local PAC, with Locations: all bits
    rpac bt_bap_chan.location == 0x0 (PACS Locations read after PAC)
    -> bt_select() ChannelAllocation: 0x1 (ASE 1)
    -> bt_select() ChannelAllocation: 0x2 (ASE 2)

Both devices have 2+ Sink ASEs and two bits set in Locations, but
bt_bap_select() configures them differently. This occurs due to the
"if (!rc->location) { ... rc->location &= BIT(i);" logic which gets entered
only because of the ordering in which characteristics was read.  Without
"&= BIT(i)" branch, "map.location &= ~(map.location & rc->location)"
causes only one ASE be configured.  The behavior appears accidental,
and e.g. the BIT(i) logic in general is wrong as the rpac index i doesn't
have a relation to channel locations.

Rewrite the multi-ASE configuration logic, and make it independent of
chr read ordering.

Decide first whether to configure 1 or 2 ASE.  Use 2 ASE if locations
contain left/right channel pair and only 1 channel per ASE is supported.

The "right" result depends on what you want to do so this heuristic
tries to aim for a "common" configuration. See eg the above two devices:
their PAC/ASE data only differs in which two location bits are set, but
they need to be configured differently.

If 1 ASE, leave channel allocation to sound server.

If multiple ASE, multiplex as many as possible on each of them.

Remove bt_bap_chan as it's not needed -- also the PACS Locations
is global to the whole device and there are no per-PAC Locations in the
specification, so probably we shouldn't have something like that in the
internal model.
---

Notes:
    The BAP specification doesn't say that the ordering of characteristics
    in the PACS service should have a meaning, and the current logic looks
    wrong to me.
    
    From what's written in the spec, I don't see that there is a "right"
    configuration here to pick, so it seems we are forced to use some
    heuristic here.  It is hardcoded here, and we probably should make some
    changes later on to make it possible for the sound server to control
    which locations exactly are selected.
    
    One design could be to have the local PAC provide a list of Locations
    bitmasks, and BlueZ checks *in order* if the remote device has all the
    bits set in its Locations. If a match is found, BlueZ assigns exactly
    those bits to ASEs using multiple ASE, if needed. Otherwise, BlueZ uses
    a single ASE and punts the channel decision to the sound server.
    
    This would more or less be the same as what is done in this patch,
    except that the configs[] array is provided by the sound server in the
    local Client PAC.
    
    Also, if there are multiple codecs, bt_bap_select() probably should try
    to select them in order, and stop at the first successful selection.
    
    An alternative would be to leave all this to the sound server: change
    API so that SelectProperties() can return a multi-ASE configuration.
    
    The sound server already has to handle low-level details such as
    deciding which PAC configuration is best. This choice however depends on
    whether ASE multiplexing is done or not, so trying to do the decision
    partly in BlueZ and partly in sound server probably just makes things
    more complicated than they need to be. Sound server can first decide
    what Locations to connect, then allocate PACs multiplexing as much as
    possible. BAP Sec. 3.5.3 guarantees there are enough ASEs for all
    location bits.

 src/shared/bap.c | 196 ++++++++++++++++++++++-------------------------
 1 file changed, 93 insertions(+), 103 deletions(-)