### PR TITLE
[PW_SID:875511] [BlueZ,v1,1/4] client/player: Fix not setting config target_latency with edpoint.config

### DIFF
--- a/client/player.c
+++ b/client/player.c
@@ -1790,9 +1790,9 @@ static void append_ucast_qos(DBusMessageIter *iter, struct endpoint_config *cfg)
 					DBUS_TYPE_UINT32, &qos->delay);
 
 	if (cfg->target_latency) {
-		bt_shell_printf("TargetLatency 0x%02x\n", qos->target_latency);
+		bt_shell_printf("TargetLatency 0x%02x\n", cfg->target_latency);
 		g_dbus_dict_append_entry(iter, "TargetLatency", DBUS_TYPE_BYTE,
-					&qos->target_latency);
+					&cfg->target_latency);
 	}
 
 	append_io_qos(iter, &qos->io_qos);
@@ -3765,6 +3765,7 @@ static void cmd_config_endpoint(int argc, char *argv[])
 		/* Copy capabilities */
 		util_iov_append(cfg->caps, preset->data.iov_base,
 				preset->data.iov_len);
+		cfg->target_latency = preset->target_latency;
 
 		/* Set QoS parameters */
 		cfg->qos = preset->qos;
@@ -3960,7 +3961,7 @@ static void custom_target_latency(const char *input, void *user_data)
 	else if (!strcasecmp(input, "Balance"))
 		p->target_latency = 0x02;
 	else if (!strcasecmp(input, "High"))
-		p->target_latency = 0x02;
+		p->target_latency = 0x03;
 	else {
 		char *endptr = NULL;
 

--- a/monitor/att.c
+++ b/monitor/att.c
@@ -4646,7 +4646,8 @@ static void print_notify(const struct l2cap_frame *frame, uint16_t handle,
 		frame = &clone;
 	}
 
-	handler->notify(frame);
+	if (handler->notify)
+		handler->notify(frame);
 }
 
 static void att_handle_value_notify(const struct l2cap_frame *frame)

--- a/profiles/audio/bap.c
+++ b/profiles/audio/bap.c
@@ -1523,6 +1523,10 @@ static void setup_config(void *data, void *user_data)
 		return;
 	}
 
+	if (setup->metadata && setup->metadata->iov_len)
+		bt_bap_stream_metadata(setup->stream, setup->metadata, NULL,
+								NULL);
+
 	bt_bap_stream_set_user_data(setup->stream, ep->path);
 }
 

--- a/src/shared/bap.c
+++ b/src/shared/bap.c
@@ -1971,8 +1971,17 @@ static unsigned int bap_ucast_metadata(struct bt_bap_stream *stream,
 		return 0;
 	}
 
-	return bap_stream_metadata(stream, BT_ASCS_METADATA, data, func,
-					user_data);
+	switch (bt_bap_stream_get_state(stream)) {
+	/* Valid only if ASE_State field = 0x03 (Enabling) */
+	case BT_BAP_STREAM_STATE_ENABLING:
+	 /* or 0x04 (Streaming) */
+	case BT_BAP_STREAM_STATE_STREAMING:
+		return bap_stream_metadata(stream, BT_ASCS_METADATA, data, func,
+						user_data);
+	}
+
+	stream_metadata(stream, data, NULL);
+	return 0;
 }
 
 static uint8_t stream_release(struct bt_bap_stream *stream, struct iovec *rsp)


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

This fixes not setting target_latency with endpoint.config command.
---
 client/player.c | 7 ++++---
 1 file changed, 4 insertions(+), 3 deletions(-)