### PR TITLE
[PW_SID:876731] Fix a number of static analysis issues #6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/lib/sdp.c
+++ b/lib/sdp.c
@@ -1678,13 +1678,13 @@ sdp_data_t *sdp_data_get(const sdp_record_t *rec, uint16_t attrId)
 	return NULL;
 }
 
-static int sdp_send_req(sdp_session_t *session, uint8_t *buf, uint32_t size)
+static int sdp_send_req(sdp_session_t *session, uint8_t *buf, size_t size)
 {
-	uint32_t sent = 0;
+	size_t sent = 0;
 
 	while (sent < size) {
 		int n = send(session->sock, buf + sent, size - sent, 0);
-		if (n < 0)
+		if (n < 0 || sent > SIZE_MAX - n)
 			return -1;
 		sent += n;
 	}

--- a/mesh/net.c
+++ b/mesh/net.c
@@ -3149,13 +3149,22 @@ static bool send_seg(struct mesh_net *net, uint8_t cnt, uint16_t interval,
 	uint32_t seq_num;
 
 	if (msg->segmented) {
+		if (msg->len < seg_off) {
+			l_error("Failed to build packet");
+			return false;
+		}
 		/* Send each segment on unique seq_num */
 		seq_num = mesh_net_next_seq_num(net);
 
-		if (msg->len - seg_off > SEG_OFF(1))
+		if (msg->len - seg_off > SEG_OFF(1)) {
 			seg_len = SEG_OFF(1);
-		else
+		} else {
+			if (msg->len - seg_off > UINT8_MAX) {
+				l_error("Failed to build packet");
+				return false;
+			}
 			seg_len = msg->len - seg_off;
+		}
 	} else {
 		/* Send on same seq_num used for Access Layer */
 		seq_num = msg->seqAuth;

--- a/monitor/control.c
+++ b/monitor/control.c
@@ -18,6 +18,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <errno.h>
+#include <limits.h>
 #include <unistd.h>
 #include <stdlib.h>
 #include <string.h>
@@ -1091,9 +1092,14 @@ static void client_callback(int fd, uint32_t events, void *user_data)
 		return;
 	}
 
+	if (sizeof(data->buf) <= data->offset)
+		return;
+
 	len = recv(data->fd, data->buf + data->offset,
 			sizeof(data->buf) - data->offset, MSG_DONTWAIT);
-	if (len < 0)
+	if (len < 0 ||
+	    len > UINT16_MAX ||
+	    UINT16_MAX - data->offset > len)
 		return;
 
 	data->offset += len;

--- a/profiles/health/mcap.c
+++ b/profiles/health/mcap.c
@@ -389,7 +389,7 @@ int mcap_send_data(int sock, const void *buf, uint32_t size)
 
 	while (sent < size) {
 		int n = write(sock, buf_b + sent, size - sent);
-		if (n < 0)
+		if (n < 0 || n > SSIZE_MAX - sent)
 			return -1;
 		sent += n;
 	}

--- a/src/shared/btsnoop.c
+++ b/src/shared/btsnoop.c
@@ -530,7 +530,7 @@ bool btsnoop_read_hci(struct btsnoop *btsnoop, struct timeval *tv,
 	}
 
 	toread = be32toh(pkt.len);
-	if (toread > BTSNOOP_MAX_PACKET_SIZE) {
+	if (toread > BTSNOOP_MAX_PACKET_SIZE || toread < 1) {
 		btsnoop->aborted = true;
 		return false;
 	}
@@ -565,6 +565,11 @@ bool btsnoop_read_hci(struct btsnoop *btsnoop, struct timeval *tv,
 		break;
 
 	default:
+		btsnoop->aborted = true;
+		return false;
+	}
+
+	if (toread == 0) {
 		btsnoop->aborted = true;
 		return false;
 	}

--- a/src/shared/gatt-db.c
+++ b/src/shared/gatt-db.c
@@ -560,9 +560,14 @@ static int uuid_to_le(const bt_uuid_t *uuid, uint8_t *dst)
 		return bt_uuid_len(uuid);
 	}
 
-	bt_uuid_to_uuid128(uuid, &uuid128);
-	bswap_128(&uuid128.value.u128, dst);
-	return bt_uuid_len(&uuid128);
+	if (uuid->type == BT_UUID32 ||
+	    uuid->type == BT_UUID128) {
+		bt_uuid_to_uuid128(uuid, &uuid128);
+		bswap_128(&uuid128.value.u128, dst);
+		return bt_uuid_len(&uuid128);
+	}
+
+	return 0;
 }
 
 static bool le_to_uuid(const uint8_t *src, size_t len, bt_uuid_t *uuid)

--- a/src/shared/tester.c
+++ b/src/shared/tester.c
@@ -945,6 +945,8 @@ static bool test_io_send(struct io *io, void *user_data)
 
 	len = io_send(io, iov, 1);
 
+	g_assert(len > 0);
+
 	tester_monitor('<', 0x0004, 0x0000, iov->iov_base, len);
 
 	g_assert_cmpint(len, ==, iov->iov_len);

--- a/tools/isotest.c
+++ b/tools/isotest.c
@@ -779,6 +779,8 @@ static int read_stream(int fd, ssize_t count)
 		len = read(fd, buf + ret, count - ret);
 		if (len < 0)
 			return -errno;
+		if (len > SSIZE_MAX - ret)
+			return -EOVERFLOW;
 
 		ret += len;
 		usleep(1000);


### PR DESCRIPTION
Error: INTEGER_OVERFLOW (CWE-190): [#def1] [important]
bluez-5.77/lib/sdp.c:1685:2: tainted_data_argument: The check "sent < size" contains the tainted expression "sent" which causes "size" to be considered tainted.
bluez-5.77/lib/sdp.c:1686:3: overflow: The expression "size - sent" is deemed overflowed because at least one of its arguments has overflowed.
bluez-5.77/lib/sdp.c:1686:3: overflow_sink: "size - sent", which might have underflowed, is passed to "send(session->sock, buf + sent, size - sent, 0)".
1684|
1685|		while (sent < size) {
1686|->			int n = send(session->sock, buf + sent, size - sent, 0);
1687|			if (n < 0)
1688|				return -1;
---
 lib/sdp.c | 6 +++---
 1 file changed, 3 insertions(+), 3 deletions(-)