### PR TITLE
[PW_SID:878946] [BlueZ,v1,1/2] shared/uhid: Fix registering UHID_START multiple times

### DIFF
--- a/src/shared/uhid.c
+++ b/src/shared/uhid.c
@@ -504,6 +504,10 @@ int bt_uhid_destroy(struct bt_uhid *uhid, bool force)
 	if (!uhid)
 		return -EINVAL;
 
+	/* Cleanup input queue */
+	queue_destroy(uhid->input, free);
+	uhid->input = NULL;
+
 	/* Force destroy for non-keyboard devices - keyboards are not destroyed
 	 * on disconnect since they can glitch on reconnection losing
 	 * keypresses.


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

UHID_START callback shall only be registered once otherwise there is a
risk of processing input queue multiple times.
---
 src/shared/uhid.c | 11 +++++++++--
 1 file changed, 9 insertions(+), 2 deletions(-)