### PR TITLE
[PW_SID:879259] [BlueZ,v3,1/2] shared/uhid: Fix registering UHID_START multiple times

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/src/shared/uhid.c
+++ b/src/shared/uhid.c
@@ -46,6 +46,7 @@ struct bt_uhid {
 	struct queue *input;
 	uint8_t type;
 	bool created;
+	unsigned int start_id;
 	bool started;
 	struct uhid_replay *replay;
 };
@@ -246,7 +247,7 @@ unsigned int bt_uhid_register(struct bt_uhid *uhid, uint32_t event,
 		return 0;
 
 	notify = new0(struct uhid_notify, 1);
-	notify->id = uhid->notify_id++;
+	notify->id = ++uhid->notify_id ? uhid->notify_id : ++uhid->notify_id;
 	notify->event = event;
 	notify->func = func;
 	notify->user_data = user_data;
@@ -351,6 +352,14 @@ int bt_uhid_create(struct bt_uhid *uhid, const char *name, bdaddr_t *src,
 	if (uhid->created)
 		return 0;
 
+	/* Register callback for UHID_START if not registered yet */
+	if (!uhid->start_id) {
+		uhid->start_id = bt_uhid_register(uhid, UHID_START, uhid_start,
+									uhid);
+		if (!uhid->start_id)
+			return -ENOMEM;
+	}
+
 	memset(&ev, 0, sizeof(ev));
 	ev.type = UHID_CREATE2;
 	strncpy((char *) ev.u.create2.name, name,
@@ -377,8 +386,6 @@ int bt_uhid_create(struct bt_uhid *uhid, const char *name, bdaddr_t *src,
 	err = bt_uhid_send(uhid, &ev);
 	if (err)
 		return err;
-
-	bt_uhid_register(uhid, UHID_START, uhid_start, uhid);
 
 	uhid->created = true;
 	uhid->started = false;

--- a/src/shared/uhid.c
+++ b/src/shared/uhid.c
@@ -504,6 +504,10 @@ int bt_uhid_destroy(struct bt_uhid *uhid, bool force)
 	if (!uhid)
 		return -EINVAL;
 
+	/* Cleanup input queue */
+	queue_destroy(uhid->input, free);
+	uhid->input = NULL;
+
 	/* Force destroy for non-keyboard devices - keyboards are not destroyed
 	 * on disconnect since they can glitch on reconnection losing
 	 * keypresses.

--- a/unit/test-uhid.c
+++ b/unit/test-uhid.c
@@ -233,8 +233,10 @@ static void test_client(gconstpointer data)
 
 	err = bt_uhid_create(context->uhid, "", NULL, NULL, 0, 0, 0, 0,
 				BT_UHID_NONE, NULL, 0);
-	if (err < 0)
+	if (err < 0) {
+		tester_debug("create failed: %s\n", strerror(-err));
 		tester_test_failed();
+	}
 
 	if (g_str_equal(context->data->test_name, "/uhid/command/destroy")) {
 		err = bt_uhid_destroy(context->uhid, true);


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

UHID_START callback shall only be registered once otherwise there is a
risk of processing input queue multiple times.
---
 src/shared/uhid.c | 13 ++++++++++---
 unit/test-uhid.c  |  4 +++-
 2 files changed, 13 insertions(+), 4 deletions(-)