### PR TITLE
[PW_SID:881045] [BlueZ,v1,1/2] hog-lib: Fix calling bt_uhid_destroy with invalid instance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/profiles/input/hog-lib.c
+++ b/profiles/input/hog-lib.c
@@ -830,14 +830,16 @@ static void uhid_destroy(struct bt_hog *hog, bool force)
 {
 	int err;
 
+	if (!hog->uhid)
+		return;
+
+	bt_uhid_unregister_all(hog->uhid);
+
 	err = bt_uhid_destroy(hog->uhid, force);
 	if (err < 0) {
 		error("bt_uhid_destroy: %s", strerror(-err));
 		return;
 	}
-
-	if (bt_uhid_created(hog->uhid))
-		bt_uhid_unregister_all(hog->uhid);
 }
 
 static void set_report(struct uhid_event *ev, void *user_data)

--- a/profiles/input/hog-lib.c
+++ b/profiles/input/hog-lib.c
@@ -1421,7 +1421,18 @@ static struct bt_hog *hog_new(int fd, const char *name, uint16_t vendor,
 					uint8_t type,
 					struct gatt_db_attribute *attr)
 {
+	struct bt_uhid *uhid;
 	struct bt_hog *hog;
+
+	if (fd < 0)
+		uhid = bt_uhid_new_default();
+	else
+		uhid = bt_uhid_new(fd);
+
+	if (!uhid) {
+		DBG("Unable to create UHID");
+		return NULL;
+	}
 
 	hog = g_try_new0(struct bt_hog, 1);
 	if (!hog)
@@ -1429,15 +1440,10 @@ static struct bt_hog *hog_new(int fd, const char *name, uint16_t vendor,
 
 	hog->gatt_op = queue_new();
 	hog->bas = queue_new();
-
-	if (fd < 0)
-		hog->uhid = bt_uhid_new_default();
-	else
-		hog->uhid = bt_uhid_new(fd);
-
 	hog->uhid_fd = fd;
+	hog->uhid = uhid;
 
-	if (!hog->gatt_op || !hog->bas || !hog->uhid) {
+	if (!hog->gatt_op || !hog->bas) {
 		hog_free(hog);
 		return NULL;
 	}


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

If the hog->uhid cannot be created then it is pointless to call
bt_uhid_destroy as it will likely just produce bogus output as in:

https://github.com/bluez/bluez/issues/529#issuecomment-2297350805
---
 profiles/input/hog-lib.c | 8 +++++---
 1 file changed, 5 insertions(+), 3 deletions(-)