### PR TITLE
[PW_SID:882131] [BlueZ] gatt-client: allow AcquireNotify when characteristic has indicate flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/src/gatt-client.c
+++ b/src/gatt-client.c
@@ -1556,7 +1556,8 @@ static DBusMessage *characteristic_acquire_notify(DBusConnection *conn,
 	if (!queue_isempty(chrc->notify_clients))
 		return btd_error_in_progress(msg);
 
-	if (!(chrc->props & BT_GATT_CHRC_PROP_NOTIFY))
+	if (!(chrc->props & (BT_GATT_CHRC_PROP_NOTIFY |
+			BT_GATT_CHRC_PROP_INDICATE)))
 		return btd_error_not_supported(msg);
 
 	client = notify_client_create(chrc, sender);
@@ -1601,8 +1602,8 @@ static DBusMessage *characteristic_start_notify(DBusConnection *conn,
 	if (chrc->notify_io)
 		return btd_error_not_permitted(msg, "Notify acquired");
 
-	if (!(chrc->props & BT_GATT_CHRC_PROP_NOTIFY ||
-				chrc->props & BT_GATT_CHRC_PROP_INDICATE))
+	if (!(chrc->props & (BT_GATT_CHRC_PROP_NOTIFY |
+				BT_GATT_CHRC_PROP_INDICATE)))
 		return btd_error_not_supported(msg);
 
 	/* Each client can only have one active notify session. */


### PR DESCRIPTION
From: Benedek Kupper <benedek.kupper@epitome.inc>

StartNotify / StopNotify already correctly allows usage when the
characteristic indicate is present (simplify this check though),
apply the same to AcquireNotify.
---
 src/gatt-client.c | 7 ++++---
 1 file changed, 4 insertions(+), 3 deletions(-)