### PR TITLE
[PW_SID:882708] [BlueZ,v1] test-uhid: Fix attempting to run when bt_uhid is NULL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/unit/test-uhid.c
+++ b/unit/test-uhid.c
@@ -201,6 +201,11 @@ static struct context *create_context(gconstpointer data)
 	 */
 	if (test_data->test_device && !uid) {
 		context->uhid = bt_uhid_new_default();
+		if (!context->uhid) {
+			tester_test_abort();
+			context_quit(context);
+			return NULL;
+		}
 		return context;
 	}
 
@@ -255,9 +260,13 @@ static const struct uhid_event ev_feature = {
 static void test_client(gconstpointer data)
 {
 	struct context *context = create_context(data);
-	struct test_device *device = context->data->test_device;
+	struct test_device *device;
 	int err;
 
+	if (!context)
+		return;
+
+	device = context->data->test_device;
 	if (device)
 		err = bt_uhid_create(context->uhid, device->name,
 					BDADDR_ANY, BDADDR_ANY,


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

When running under root there is a possibility the bt_uhid_new_default
doesn't work (e.g. fakeroot) in which case the test shall be aborted
since it is likely a device specific test case which would require
proper permissions to run.
---
 unit/test-uhid.c | 11 ++++++++++-
 1 file changed, 10 insertions(+), 1 deletion(-)