### PR TITLE
[PW_SID:883075] [v2] Add pattern matching for service UUIDs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/src/shared/ad.c
+++ b/src/shared/ad.c
@@ -1362,6 +1362,46 @@ static bool match_manufacturer(const void *data, const void *user_data)
 	return false;
 }
 
+static bool match_uuid(const void *data, const void *user_data)
+{
+	const bt_uuid_t *uuid = data;
+	const struct pattern_match_info *info = user_data;
+	const struct bt_ad_pattern *pattern;
+
+	if (!uuid || !info)
+		return false;
+
+	if (info->matched_pattern)
+		return false;
+
+	pattern = info->current_pattern;
+
+	if (!pattern)
+		return false;
+
+	switch (pattern->type) {
+	case BT_AD_UUID16_ALL:
+	case BT_AD_UUID16_SOME:
+		if (pattern->offset != 0 || pattern->len != sizeof(uint16_t))
+			return false;
+		break;
+	case BT_AD_UUID32_ALL:
+	case BT_AD_UUID32_SOME:
+		if (pattern->offset != 0 || pattern->len != sizeof(uint32_t))
+			return false;
+		break;
+	case BT_AD_UUID128_ALL:
+	case BT_AD_UUID128_SOME:
+		if (pattern->offset != 0 || pattern->len != sizeof(uint128_t))
+			return false;
+		break;
+	default:
+		return false;
+	}
+
+	return !memcmp(&uuid->value, pattern->data, pattern->len);
+}
+
 static bool match_service(const void *data, const void *user_data)
 {
 	const struct bt_ad_service_data *service_data = data;
@@ -1450,6 +1490,14 @@ static void pattern_match(void *data, void *user_data)
 	case BT_AD_MANUFACTURER_DATA:
 		matched = queue_find(ad->manufacturer_data, match_manufacturer,
 				user_data);
+		break;
+	case BT_AD_UUID16_ALL:
+	case BT_AD_UUID16_SOME:
+	case BT_AD_UUID32_ALL:
+	case BT_AD_UUID32_SOME:
+	case BT_AD_UUID128_ALL:
+	case BT_AD_UUID128_SOME:
+		matched = queue_find(ad->service_uuids, match_uuid, user_data);
 		break;
 	case BT_AD_SERVICE_DATA16:
 	case BT_AD_SERVICE_DATA32:


### PR DESCRIPTION
This commit extends the pattern matching capabilities of advertisement
monitors with matching for service UUIDs. This functionality was lost
with bc2ab4b (see #652) and not added with b0656c2.
---
 src/shared/ad.c | 48 ++++++++++++++++++++++++++++++++++++++++++++++++
 1 file changed, 48 insertions(+)