### PR TITLE
[PW_SID:884060] [v5,BlueZ] Provide GNU basename compatible implementation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -70,7 +70,16 @@ AC_CHECK_LIB(pthread, pthread_create, dummy=yes,
 AC_CHECK_LIB(dl, dlopen, dummy=yes,
 			AC_MSG_ERROR(dynamic linking loader is required))
 
-AC_CHECK_HEADERS(linux/types.h linux/if_alg.h linux/uinput.h linux/uhid.h sys/random.h)
+AC_CHECK_HEADERS(string.h linux/types.h linux/if_alg.h linux/uinput.h linux/uhid.h sys/random.h)
+
+# basename may be only available in libgen.h with the POSIX behavior,
+# not desired here
+AC_CHECK_DECLS([basename], [],
+				AC_MSG_WARN([GNU basename extension not found]),
+				[#define _GNU_SOURCE 1
+				 #include <string.h>
+				 ])
+
 
 PKG_CHECK_MODULES(GLIB, glib-2.0 >= 2.28)
 

--- a/mesh/mesh-config-json.c
+++ b/mesh/mesh-config-json.c
@@ -28,6 +28,7 @@
 #include <ell/ell.h>
 #include <json-c/json.h>
 
+#include "mesh/missing.h"
 #include "mesh/mesh-defs.h"
 #include "mesh/util.h"
 #include "mesh/mesh-config.h"
@@ -2694,7 +2695,8 @@ bool mesh_config_load_nodes(const char *cfgdir_name, mesh_config_node_func_t cb,
 
 void mesh_config_destroy_nvm(struct mesh_config *cfg)
 {
-	char *node_dir, *node_name;
+	char *node_dir;
+	const char* node_name;
 	char uuid[33];
 
 	if (!cfg)

--- a/mesh/missing.h
+++ b/mesh/missing.h
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ *
+ *  BlueZ - Bluetooth protocol stack for Linux
+ *
+ *  Copyright (C) 2024  Khem Raj <raj.khem@gmail.com>
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+#if !HAVE_DECL_BASENAME
+#include <string.h>
+static inline const char *basename(const char *path)
+{
+  const char *base = strrchr(path, '/');
+
+  return base ? base + 1 : path;
+}
+#endif

--- a/mesh/rpl.c
+++ b/mesh/rpl.c
@@ -24,6 +24,7 @@
 
 #include <ell/ell.h>
 
+#include "mesh/missing.h"
 #include "mesh/mesh-defs.h"
 
 #include "mesh/node.h"

--- a/tools/hex2hcd.c
+++ b/tools/hex2hcd.c
@@ -24,6 +24,7 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include <sys/stat.h>
+#include "tools/missing.h"
 
 static ssize_t process_record(int fd, const char *line, uint16_t *upper_addr)
 {

--- a/tools/missing.h
+++ b/tools/missing.h
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ *
+ *  BlueZ - Bluetooth protocol stack for Linux
+ *
+ *  Copyright (C) 2024  Khem Raj <raj.khem@gmail.com>
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+#if !HAVE_DECL_BASENAME
+#include <string.h>
+static inline const char *basename(const char *path)
+{
+  const char *base = strrchr(path, '/');
+
+  return base ? base + 1 : path;
+}
+#endif


### PR DESCRIPTION
Call to basename() relies on a GNU extension
to take a const char * vs a char *. Let's define
a trivial helper function to ensure compatibility
with musl.

Fixes Issue: https://github.com/bluez/bluez/issues/843
---
v2: Fix code formatter reported errors
v3: Make just node_name as const and keep node_dir as such
v4: Fix code formatting errors
v5: Redo the patch to address textrels seen on ppc32/arm

 configure.ac            | 11 ++++++++++-
 mesh/mesh-config-json.c |  4 +++-
 mesh/missing.h          | 21 +++++++++++++++++++++
 mesh/rpl.c              |  1 +
 tools/hex2hcd.c         |  1 +
 tools/missing.h         | 21 +++++++++++++++++++++
 6 files changed, 57 insertions(+), 2 deletions(-)
 create mode 100644 mesh/missing.h
 create mode 100644 tools/missing.h