### PR TITLE
[PW_SID:884079] [BlueZ] mesh: Add provisioning algorithms config

### DIFF
--- a/mesh/mesh-main.conf
+++ b/mesh/mesh-main.conf
@@ -41,3 +41,8 @@
 # Setting this value to zero means there's no timeout.
 # Defaults to 60.
 #ProvTimeout = 60
+
+# Bitmask of supported provisioning security algorithms.
+# Valid range: 0-65535
+# Defaults to 1.
+#Algorithms = 1

--- a/mesh/mesh.c
+++ b/mesh/mesh.c
@@ -245,6 +245,10 @@ static void parse_settings(const char *mesh_conf_fname)
 	if (l_settings_get_uint(settings, "General", "ProvTimeout", &value))
 		mesh.prov_timeout = value;
 
+	if (l_settings_get_uint(settings, "General", "Algorithms", &value) &&
+								value <= 65535)
+		mesh.algorithms = value;
+
 done:
 	l_settings_free(settings);
 }
@@ -261,10 +265,6 @@ bool mesh_init(const char *config_dir, const char *mesh_conf_fname,
 
 	mesh_model_init();
 	mesh_agent_init();
-
-	/* TODO: read mesh.conf */
-	mesh.prov_timeout = DEFAULT_PROV_TIMEOUT;
-	mesh.algorithms = DEFAULT_ALGORITHMS;
 
 	storage_dir = config_dir ? config_dir : MESH_STORAGEDIR;
 


### PR DESCRIPTION
I added the Algorithms config to the conf file because there was a
`TODO` comment waiting to be added to the config file, and it was a
mutable config.
I also removed the duplicate initialization code for Provisioning
Timeout and Algorithms.

Signed-off-by: Junho Lee <tot0roprog@gmail.com>
---
 mesh/mesh-main.conf | 5 +++++
 mesh/mesh.c         | 8 ++++----
 2 files changed, 9 insertions(+), 4 deletions(-)