### PR TITLE
[PW_SID:884360] [BlueZ,v1,1/2] adapter: Fix up address type when loading keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/src/adapter.c
+++ b/src/adapter.c
@@ -5017,12 +5017,28 @@ static void load_devices(struct btd_adapter *adapter)
 			goto free;
 		}
 
-		if (key_info)
+		if (key_info) {
+			/* Fix up address type if it was stored with the wrong
+			 * address type since Load Link Keys are only meant to
+			 * work with BR/EDR addresses as per MGMT documentation.
+			 */
+			if (key_info->bdaddr_type != BDADDR_BREDR)
+				key_info->bdaddr_type = BDADDR_BREDR;
+
 			adapter->load_keys = g_slist_append(adapter->load_keys,
 								key_info);
+		}
 
-		if (ltk_info)
+		if (ltk_info) {
+			/* Fix up address type if it was stored with the wrong
+			 * address type since Load Long Term Keys are only meant
+			 * to work with LE addresses as per MGMT documentation.
+			 */
+			if (ltk_info->bdaddr_type == BDADDR_BREDR)
+				ltk_info->bdaddr_type = BDADDR_LE_PUBLIC;
+
 			ltks = g_slist_append(ltks, ltk_info);
+		}
 
 		if (peripheral_ltk_info)
 			ltks = g_slist_append(ltks, peripheral_ltk_info);


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

Due to kernel change 59b047bc9808
("Bluetooth: MGMT/SMP: Fix address type when using SMP over BREDR/LE")
some keys maybe store using the wrong/invalid address type as per MGMT
API, so this attempts to fix them up.

Fixes: https://github.com/bluez/bluez/issues/875
---
 src/adapter.c | 20 ++++++++++++++++++--
 1 file changed, 18 insertions(+), 2 deletions(-)