### PR TITLE
[PW_SID:886341] tools/mpris-proxy: Add systemd user unit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/Makefile.am
+++ b/Makefile.am
@@ -49,6 +49,9 @@ if SYSTEMD
 systemdsystemunitdir = $(SYSTEMD_SYSTEMUNITDIR)
 systemdsystemunit_DATA = src/bluetooth.service
 
+systemduserunitdir = $(SYSTEMD_USERUNITDIR)
+systemduserunit_DATA =
+
 dbussystembusdir = $(DBUS_SYSTEMBUSDIR)
 dbussystembus_DATA = src/org.bluez.service
 endif

--- a/Makefile.obexd
+++ b/Makefile.obexd
@@ -2,8 +2,7 @@
 if OBEX
 
 if SYSTEMD
-systemduserunitdir = $(SYSTEMD_USERUNITDIR)
-systemduserunit_DATA = obexd/src/obex.service
+systemduserunit_DATA += obexd/src/obex.service
 
 dbussessionbusdir = $(DBUS_SESSIONBUSDIR)
 dbussessionbus_DATA = obexd/src/org.bluez.obex.service

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -332,6 +332,9 @@ tools_hex2hcd_SOURCES = tools/hex2hcd.c
 
 tools_mpris_proxy_SOURCES = tools/mpris-proxy.c
 tools_mpris_proxy_LDADD = gdbus/libgdbus-internal.la $(GLIB_LIBS) $(DBUS_LIBS)
+if SYSTEMD
+systemduserunit_DATA += tools/mpris-proxy.service
+endif
 
 tools_gatt_service_SOURCES = tools/gatt-service.c
 tools_gatt_service_LDADD = gdbus/libgdbus-internal.la \

--- a/configure.ac
+++ b/configure.ac
@@ -428,6 +428,14 @@ fi
 #
 # Otherwise we'll end up with literal references in the final binaries or
 # manuals, which is not something we really want.
+#
+pkgbindir="${bindir}"
+if (test "$bindir" = '${exec_prefix}/bin'); then
+	pkgbindir="${exec_prefix}/bin"
+else
+	pkgbindir="${bindir}"
+fi
+AC_SUBST(PKGBINDIR, "${pkgbindir}")
 
 if (test "$libexecdir" = '${exec_prefix}/libexec'); then
 	pkglibexecdir="${exec_prefix}/libexec/bluetooth"
@@ -496,5 +504,6 @@ AC_CONFIG_FILES(
 	src/bluetoothd.rst
 	src/bluetooth.service
 	tools/bluetooth-logger.service
+	tools/mpris-proxy.service
 )
 AC_OUTPUT

--- a/tools/mpris-proxy.service.in
+++ b/tools/mpris-proxy.service.in
@@ -1,0 +1,13 @@
+[Unit]
+Description=Bluetooth mpris proxy
+Documentation=man:mpris-proxy(1)
+
+Wants=dbus.socket
+After=dbus.socket
+
+[Service]
+Type=simple
+ExecStart=@PKGBINDIR@/mpris-proxy
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
That way it will be started automatically which is convenient on phones.
Distributions can then decide part of which install the unit should be.

Signed-off-by: Guido Günther <agx@sigxcpu.org>
---
 Makefile.am                  |  3 +++
 Makefile.obexd               |  3 +--
 Makefile.tools               |  3 +++
 configure.ac                 |  9 +++++++++
 tools/mpris-proxy.service.in | 13 +++++++++++++
 5 files changed, 29 insertions(+), 2 deletions(-)
 create mode 100644 tools/mpris-proxy.service.in