### PR TITLE
[PW_SID:890531] Fix missing inclusion of <limits.h>

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/android/ipc-tester.c
+++ b/android/ipc-tester.c
@@ -17,6 +17,7 @@
 #include <unistd.h>
 #include <errno.h>
 #include <poll.h>
+#include <limits.h>
 
 #include <sys/socket.h>
 #include <sys/types.h>

--- a/android/system-emulator.c
+++ b/android/system-emulator.c
@@ -19,6 +19,7 @@
 #include <stdlib.h>
 #include <signal.h>
 #include <string.h>
+#include <limits.h>
 #include <libgen.h>
 #include <poll.h>
 #include <sys/wait.h>

--- a/android/tester-main.c
+++ b/android/tester-main.c
@@ -7,6 +7,7 @@
 #define _GNU_SOURCE
 #include <stdbool.h>
 #include <unistd.h>
+#include <limits.h>
 #include <libgen.h>
 
 #include <sys/un.h>

--- a/client/mgmt.c
+++ b/client/mgmt.c
@@ -17,6 +17,7 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <string.h>
+#include <limits.h>
 #include <sys/types.h>
 #include <sys/param.h>
 #include <sys/socket.h>

--- a/emulator/serial.c
+++ b/emulator/serial.c
@@ -21,6 +21,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <sys/param.h>
 #include <sys/epoll.h>
 #include <sys/uio.h>

--- a/emulator/vhci.c
+++ b/emulator/vhci.c
@@ -23,6 +23,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <dirent.h>
+#include <limits.h>
 
 #include "lib/bluetooth.h"
 #include "lib/hci.h"

--- a/monitor/att.c
+++ b/monitor/att.c
@@ -22,7 +22,7 @@
 #include <inttypes.h>
 #include <stdbool.h>
 #include <errno.h>
-#include <linux/limits.h>
+#include <limits.h>
 #include <sys/stat.h>
 
 #include <glib.h>

--- a/peripheral/efivars.c
+++ b/peripheral/efivars.c
@@ -20,6 +20,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdint.h>
+#include <limits.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/param.h>

--- a/profiles/audio/a2dp.c
+++ b/profiles/audio/a2dp.c
@@ -19,6 +19,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <errno.h>
+#include <limits.h>
 
 #include <dbus/dbus.h>
 #include <glib.h>

--- a/src/adapter.c
+++ b/src/adapter.c
@@ -24,6 +24,7 @@
 #include <sys/file.h>
 #include <sys/stat.h>
 #include <dirent.h>
+#include <limits.h>
 
 #include <glib.h>
 #include <dbus/dbus.h>

--- a/src/device.c
+++ b/src/device.c
@@ -22,6 +22,7 @@
 #include <errno.h>
 #include <dirent.h>
 #include <time.h>
+#include <limits.h>
 #include <sys/stat.h>
 
 #include <glib.h>

--- a/src/gatt-database.c
+++ b/src/gatt-database.c
@@ -16,6 +16,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <unistd.h>
+#include <limits.h>
 
 #include "lib/bluetooth.h"
 #include "lib/sdp.h"

--- a/src/main.c
+++ b/src/main.c
@@ -22,6 +22,7 @@
 #include <string.h>
 #include <signal.h>
 #include <stdbool.h>
+#include <limits.h>
 #include <sys/signalfd.h>
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/src/rfkill.c
+++ b/src/rfkill.c
@@ -20,6 +20,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <limits.h>
 
 #include <glib.h>
 

--- a/src/storage.c
+++ b/src/storage.c
@@ -21,6 +21,7 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <time.h>
+#include <limits.h>
 #include <sys/file.h>
 #include <sys/stat.h>
 

--- a/src/textfile.c
+++ b/src/textfile.c
@@ -21,6 +21,7 @@
 #include <stdlib.h>
 #include <stdarg.h>
 #include <string.h>
+#include <limits.h>
 #include <sys/file.h>
 #include <sys/stat.h>
 #include <sys/mman.h>

--- a/tools/bluemoon.c
+++ b/tools/bluemoon.c
@@ -18,6 +18,7 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <string.h>
+#include <limits.h>
 #include <getopt.h>
 #include <sys/stat.h>
 #include <sys/param.h>

--- a/tools/hciattach.c
+++ b/tools/hciattach.c
@@ -26,6 +26,7 @@
 #include <termios.h>
 #include <time.h>
 #include <poll.h>
+#include <limits.h>
 #include <sys/time.h>
 #include <sys/param.h>
 #include <sys/ioctl.h>

--- a/tools/hciattach_ath3k.c
+++ b/tools/hciattach_ath3k.c
@@ -16,6 +16,7 @@
 #include <string.h>
 #include <ctype.h>
 #include <time.h>
+#include <limits.h>
 #include <sys/stat.h>
 #include <sys/time.h>
 #include <sys/types.h>

--- a/tools/hciattach_intel.c
+++ b/tools/hciattach_intel.c
@@ -19,6 +19,7 @@
 #include <string.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <sys/param.h>
 #include <sys/ioctl.h>
 #include <time.h>

--- a/tools/hciattach_st.c
+++ b/tools/hciattach_st.c
@@ -12,6 +12,7 @@
 #include <config.h>
 #endif
 
+#include <limits.h>
 #include <stdio.h>
 #include <errno.h>
 #include <fcntl.h>

--- a/tools/hciattach_ti.c
+++ b/tools/hciattach_ti.c
@@ -14,6 +14,7 @@
 #endif
 
 #define _GNU_SOURCE
+#include <limits.h>
 #include <stdio.h>
 #include <errno.h>
 #include <unistd.h>

--- a/tools/test-runner.c
+++ b/tools/test-runner.c
@@ -23,6 +23,7 @@
 #include <string.h>
 #include <getopt.h>
 #include <poll.h>
+#include <limits.h>
 #include <sys/wait.h>
 #include <sys/stat.h>
 #include <sys/types.h>


### PR DESCRIPTION
Needed for PATH_MAX.

Signed-off-by: Ismael Luceno <ismael@iodev.co.uk>
---
 android/ipc-tester.c      | 1 +
 android/system-emulator.c | 1 +
 android/tester-main.c     | 1 +
 client/mgmt.c             | 1 +
 emulator/serial.c         | 1 +
 emulator/vhci.c           | 1 +
 monitor/att.c             | 2 +-
 peripheral/efivars.c      | 1 +
 profiles/audio/a2dp.c     | 1 +
 src/adapter.c             | 1 +
 src/device.c              | 1 +
 src/gatt-database.c       | 1 +
 src/main.c                | 1 +
 src/rfkill.c              | 1 +
 src/storage.c             | 1 +
 src/textfile.c            | 1 +
 tools/bluemoon.c          | 1 +
 tools/hciattach.c         | 1 +
 tools/hciattach_ath3k.c   | 1 +
 tools/hciattach_intel.c   | 1 +
 tools/hciattach_st.c      | 1 +
 tools/hciattach_ti.c      | 1 +
 tools/test-runner.c       | 1 +
 23 files changed, 23 insertions(+), 1 deletion(-)