### PR TITLE
[PW_SID:890532] Replace the usage of non-standard GNU-basename with strrchr

### DIFF
--- a/mesh/mesh-config-json.c
+++ b/mesh/mesh-config-json.c
@@ -2708,7 +2708,9 @@ void mesh_config_destroy_nvm(struct mesh_config *cfg)
 	if (!hex2str(cfg->uuid, 16, uuid, sizeof(uuid)))
 		return;
 
-	node_name = basename(node_dir);
+	node_name = strrchr(node_dir, '/');
+	if (!node_name++)
+		node_name = node_dir;
 
 	/* Make sure path name of node follows expected guidelines */
 	if (strcmp(node_name, uuid))

--- a/mesh/rpl.c
+++ b/mesh/rpl.c
@@ -147,7 +147,9 @@ static void get_entries(const char *iv_path, struct l_queue *rpl_list)
 	if (!dir)
 		return;
 
-	iv_txt = basename(iv_path);
+	iv_txt = strrchr(iv_path);
+	if (!iv_txt++)
+		iv_txt = iv_path;
 	if (sscanf(iv_txt, "%08x", &iv_index) != 1) {
 		closedir(dir);
 		return;

--- a/tools/hex2hcd.c
+++ b/tools/hex2hcd.c
@@ -303,7 +303,10 @@ static void ver_parse_entry(const char *pathname)
 	}
 
 	if (S_ISREG(st.st_mode)) {
-		ver_parse_file(basename(pathname));
+		const char *bname = strrchr(pathname, '/');
+		if (!bname++)
+			bname = pathname;
+		ver_parse_file(bname);
 		goto done;
 	}
 


### PR DESCRIPTION
Fixes build against musl libc, since it doesn't provide a GNU-compatible
implementation of basename.

Signed-off-by: Ismael Luceno <ismael@iodev.co.uk>
---
 mesh/mesh-config-json.c | 4 +++-
 mesh/rpl.c              | 4 +++-
 tools/hex2hcd.c         | 5 ++++-
 3 files changed, 10 insertions(+), 3 deletions(-)