### PR TITLE
[PW_SID:891245] [BlueZ,v1] doc: Remove Pygments dependency from manpage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/doc/l2cap.rst
+++ b/doc/l2cap.rst
@@ -16,7 +16,7 @@ L2CAP protocol
 SYNOPSIS
 ========
 
-.. code-block:: c
+.. code-block::
 
     #include <sys/socket.h>
     #include <bluetooth/bluetooth.h>
@@ -40,7 +40,7 @@ connection, allowing for concurrent data transmission using different protocols.
 SOCKET ADDRESS
 ==============
 
-.. code-block:: c
+.. code-block::
 
     struct sockaddr_l2 {
         sa_family_t	l2_family;
@@ -52,7 +52,7 @@ SOCKET ADDRESS
 
 Example:
 
-.. code-block:: c
+.. code-block::
 
     struct sockaddr_l2 addr;
 
@@ -90,7 +90,7 @@ Channel security level, possible values:
 
 Example:
 
-.. code-block:: c
+.. code-block::
 
     int level = BT_SECURITY_HIGH;
     int err = setsockopt(l2cap_socket, SOL_BLUETOOTH, BT_SECURITY, &level,
@@ -116,7 +116,7 @@ authorization at profile level, possible values:
 
 Example:
 
-.. code-block:: c
+.. code-block::
 
     int defer_setup = 1;
     int err = setsockopt(l2cap_socket, SOL_BLUETOOTH, BT_DEFER_SETUP,

--- a/doc/rfcomm.rst
+++ b/doc/rfcomm.rst
@@ -16,7 +16,7 @@ RFCOMM protocol
 SYNOPSIS
 ========
 
-.. code-block:: c
+.. code-block::
 
     #include <sys/socket.h>
     #include <bluetooth/bluetooth.h>
@@ -36,7 +36,7 @@ the 9 circuits of RS-232 (EIATIA-232-E) serial ports.
 SOCKET ADDRESS
 ==============
 
-.. code-block:: c
+.. code-block::
 
     struct sockaddr_rc {
         sa_family_t rc_family;
@@ -46,7 +46,7 @@ SOCKET ADDRESS
 
 Example:
 
-.. code-block:: c
+.. code-block::
 
     struct sockaddr_rc addr;
 
@@ -78,7 +78,7 @@ Channel security level, possible values:
 
 Example:
 
-.. code-block:: c
+.. code-block::
 
     int level = BT_SECURITY_HIGH;
     int err = setsockopt(rfcomm_socket, SOL_BLUETOOTH, BT_SECURITY, &level,
@@ -104,7 +104,7 @@ authorization at profile level, possible values:
 
 Example:
 
-.. code-block:: c
+.. code-block::
 
     int defer_setup = 1;
     int err = setsockopt(rfcomm_socket, SOL_BLUETOOTH, BT_DEFER_SETUP,


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

This patch removes the Pygments dependency from l2cap/rfcomm.rst file.
When the code-block type is specified, the rst2man throws a warning
asking for Pygments package.

Fixes: https://github.com/bluez/bluez/issues/950
---
 doc/l2cap.rst  | 10 +++++-----
 doc/rfcomm.rst | 10 +++++-----
 2 files changed, 10 insertions(+), 10 deletions(-)