### PR TITLE
[PW_SID:891253] [BlueZ,v1] client/print: Add decoding for UUID properties

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/client/main.c
+++ b/client/main.c
@@ -221,33 +221,6 @@ done:
 					address, name);
 }
 
-static void print_uuid(const char *label, const char *uuid)
-{
-	const char *text;
-
-	text = bt_uuidstr_to_str(uuid);
-	if (text) {
-		char str[26];
-		unsigned int n;
-
-		str[sizeof(str) - 1] = '\0';
-
-		n = snprintf(str, sizeof(str), "%s", text);
-		if (n > sizeof(str) - 1) {
-			str[sizeof(str) - 2] = '.';
-			str[sizeof(str) - 3] = '.';
-			if (str[sizeof(str) - 4] == ' ')
-				str[sizeof(str) - 4] = '.';
-
-			n = sizeof(str) - 1;
-		}
-
-		bt_shell_printf("\t%s: %s%*c(%s)\n", label, str, 26 - n, ' ',
-									uuid);
-	} else
-		bt_shell_printf("\t%s: %*c(%s)\n", label, 26, ' ', uuid);
-}
-
 static void print_uuids(GDBusProxy *proxy)
 {
 	DBusMessageIter iter, value;
@@ -262,7 +235,7 @@ static void print_uuids(GDBusProxy *proxy)
 
 		dbus_message_iter_get_basic(&value, &uuid);
 
-		print_uuid("UUID", uuid);
+		print_uuid("\t", "UUID", uuid);
 
 		dbus_message_iter_next(&value);
 	}
@@ -283,7 +256,7 @@ static void print_experimental(GDBusProxy *proxy)
 
 		dbus_message_iter_get_basic(&value, &uuid);
 
-		print_uuid("ExperimentalFeatures", uuid);
+		print_uuid("\t", "ExperimentalFeatures", uuid);
 
 		dbus_message_iter_next(&value);
 	}
@@ -1376,7 +1349,7 @@ static void cmd_scan_filter_uuids(int argc, char *argv[])
 		char **uuid;
 
 		for (uuid = filter.uuids; uuid && *uuid; uuid++)
-			print_uuid("UUID", *uuid);
+			print_uuid("\t", "UUID", *uuid);
 
 		return bt_shell_noninteractive_quit(EXIT_SUCCESS);
 	}

--- a/client/print.c
+++ b/client/print.c
@@ -116,6 +116,12 @@ void print_iter(const char *label, const char *name, DBusMessageIter *iter)
 		bt_shell_printf("%s%s is invalid\n", label, name);
 		break;
 	case DBUS_TYPE_STRING:
+		if (!strcasecmp(name, "UUID")) {
+			dbus_message_iter_get_basic(iter, &valstr);
+			print_uuid(label, name, valstr);
+			break;
+		}
+		/* fall through */
 	case DBUS_TYPE_OBJECT_PATH:
 		dbus_message_iter_get_basic(iter, &valstr);
 		bt_shell_printf("%s%s: %s\n", label, name, valstr);
@@ -202,4 +208,31 @@ void print_property_with_label(GDBusProxy *proxy, const char *name,
 void print_property(GDBusProxy *proxy, const char *name)
 {
 	print_property_with_label(proxy, name, NULL);
+}
+
+void print_uuid(const char *label, const char *name, const char *uuid)
+{
+	const char *text;
+
+	text = bt_uuidstr_to_str(uuid);
+	if (text) {
+		char str[26];
+		unsigned int n;
+
+		str[sizeof(str) - 1] = '\0';
+
+		n = snprintf(str, sizeof(str), "%s", text);
+		if (n > sizeof(str) - 1) {
+			str[sizeof(str) - 2] = '.';
+			str[sizeof(str) - 3] = '.';
+			if (str[sizeof(str) - 4] == ' ')
+				str[sizeof(str) - 4] = '.';
+
+			n = sizeof(str) - 1;
+		}
+
+		bt_shell_printf("%s%s: %s%*c(%s)\n", label, name, str, 26 - n,
+								' ', uuid);
+	} else
+		bt_shell_printf("%s%s: %*c(%s)\n", label, name, 26, ' ', uuid);
 }

--- a/client/print.h
+++ b/client/print.h
@@ -12,3 +12,4 @@ void print_property(GDBusProxy *proxy, const char *name);
 void print_property_with_label(GDBusProxy *proxy, const char *name,
 					const char *label);
 void print_iter(const char *label, const char *name, DBusMessageIter *iter);
+void print_uuid(const char *label, const char *name, const char *uuid);


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

This adds proper decoding for UUID properties with usage of
bt_uuidstr_to_str so it can print the 'friendly' name as bellow:

bluetoothctl# transport.show /org/bluez/hci0/dev_94_DB_56_F7_F2_88/sep4/fd0
Transport /org/bluez/hci0/dev_94_DB_56_F7_F2_88/sep4/fd0
	UUID: Audio Source              (0000110a-0000-1000-8000-00805f9b34fb)
...
---
 client/main.c  | 33 +++------------------------------
 client/print.c | 33 +++++++++++++++++++++++++++++++++
 client/print.h |  1 +
 3 files changed, 37 insertions(+), 30 deletions(-)