### PR TITLE
[PW_SID:893302] [v4] device: Remove device after all bearers are disconnected

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -3492,8 +3492,27 @@ void device_remove_connection(struct btd_device *device, uint8_t bdaddr_type,
 		DBusMessage *msg = device->disconnects->data;
 
 		if (dbus_message_is_method_call(msg, ADAPTER_INTERFACE,
-								"RemoveDevice"))
+							"RemoveDevice")) {
+
+			/* Don't handle the RemoveDevice msg if device is
+			 * connected. For a dual-mode remote, both BR/EDR
+			 * and BLE may be connected, RemoveDevice should
+			 * be handled after all bearers are disconnects.
+			 * Otherwise, if msg is removed, but not all
+			 * connection are dropped, this function returns
+			 * before *remove is updated, then after all
+			 * connections are dropped, but device->disconnects
+			 * is NULL, remove_device is not updated. Consequently
+			 * *remove is not set to true. The device is not removed
+			 * for adapter in adapter_remove_connection. Need
+			 * to wait for temporary device timeout to remove
+			 * the device.
+			 */
+			if (device->bredr_state.connected ||
+					device->le_state.connected)
+				break;
 			remove_device = true;
+		}
 
 		g_dbus_send_reply(dbus_conn, msg, DBUS_TYPE_INVALID);
 		device->disconnects = g_slist_remove(device->disconnects, msg);


### PR DESCRIPTION
For a combo mode remote, both BR/EDR and BLE may be connected.
RemoveDevice should be handled after all bearers are dropped,
otherwise, remove device is not performed in adapter_remove_connection.
---
 src/device.c | 21 ++++++++++++++++++++-
 1 file changed, 20 insertions(+), 1 deletion(-)