### PR TITLE
[PW_SID:894842] shared/bap: Fix load of misaligned address error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/src/shared/bap.c
+++ b/src/shared/bap.c
@@ -6484,8 +6484,8 @@ static void check_pac_caps_ltv(size_t i, uint8_t l, uint8_t t, uint8_t *v,
 
 	switch (t) {
 	case BAP_FREQ_LTV_TYPE:
-		mask = *((uint16_t *)v);
-		mask = le16_to_cpu(mask);
+		mask = get_le16(v);
+
 		if (mask & (1 << (bis_v[0] - 1)))
 			compare_data->data32 |= 1<<t;
 		break;
@@ -6494,12 +6494,10 @@ static void check_pac_caps_ltv(size_t i, uint8_t l, uint8_t t, uint8_t *v,
 			compare_data->data32 |= 1<<t;
 		break;
 	case BAP_FRAME_LEN_LTV_TYPE:
-		min = *((uint16_t *)v);
-		max = *((uint16_t *)(&v[2]));
-		frame_len = *((uint16_t *)bis_v);
-		min = le16_to_cpu(min);
-		max = le16_to_cpu(max);
-		frame_len = le16_to_cpu(frame_len);
+		min = get_le16(v);
+		max = get_le16(v + 2);
+		frame_len = get_le16(bis_v);
+
 		if ((frame_len >= min) &&
 				(frame_len <= max))
 			compare_data->data32 |= 1<<t;


### PR DESCRIPTION
This fixes the "load of misaligned address" error that appears when
parsing PAC caps:

src/shared/bap.c:6497:7: runtime error: load of misaligned address
0x502000063639 for type 'uint16_t', which requires 2 byte alignment

0x502000063639: note: pointer points here
 02 03 05  04 1a 00 f0 00 02 03 01  02 11 00 00 08 00 00 00  a3 00 00
              ^                        00 00 00 00 00  01 00 00 00 01

src/shared/bap.c:6498:7: runtime error: load of misaligned address
0x502000063639 for type 'uint16_t', which requires 2 byte alignment

0x502000063639: note: pointer points here
 02 03 05  04 1a 00 f0 00 02 03 01  02 11 00 00 08 00 00 00  a3 00 00
              ^                        00 00 00 00 00  01 00 00 00 01
---
 src/shared/bap.c | 14 ++++++--------
 1 file changed, 6 insertions(+), 8 deletions(-)