### PR TITLE
[PW_SID:896570] Add Scan Delegator support for Set Broadcast Code op

### DIFF
--- a/client/player.c
+++ b/client/player.c
@@ -5150,15 +5150,23 @@ static void set_bcode_cb(const DBusError *error, void *user_data)
 static void set_bcode(const char *input, void *user_data)
 {
 	GDBusProxy *proxy = user_data;
-	char *bcode = g_strdup(input);
+	char *bcode;
+
+	if (!strcasecmp(input, "n") || !strcasecmp(input, "no"))
+		bcode = g_new0(char, 16);
+	else
+		bcode = g_strdup(input);
 
 	if (g_dbus_proxy_set_property_dict(proxy, "QoS",
 				set_bcode_cb, user_data,
 				NULL, "BCode", DBUS_TYPE_ARRAY, DBUS_TYPE_BYTE,
 				strlen(bcode), bcode, NULL) == FALSE) {
 		bt_shell_printf("Setting broadcast code failed\n");
+		g_free(bcode);
 		return bt_shell_noninteractive_quit(EXIT_FAILURE);
 	}
+
+	g_free(bcode);
 }
 
 static void transport_select(GDBusProxy *proxy, bool prompt)
@@ -5183,7 +5191,8 @@ static void transport_select(GDBusProxy *proxy, bool prompt)
 			dbus_message_iter_get_basic(&value, &encryption);
 			if (encryption == 1) {
 				bt_shell_prompt_input("",
-				"Enter broadcast code:", set_bcode, proxy);
+					"Enter brocast code[value/no]:",
+					set_bcode, proxy);
 				return;
 			}
 			break;

--- a/client/scripts/broadcast-assistant.bt
+++ b/client/scripts/broadcast-assistant.bt
@@ -25,10 +25,13 @@ scan on
 # using the "push" command from the assistant submenu. When asked
 # to enter stream metadata, the "auto" option will keep the LTV
 # values advertised by the Broadcast Source. By entering new LTV
-# values, the default metadata will be overwritten.
+# values, the default metadata will be overwritten. If the stream
+# is encrypted, a prompt will be displayed to enter the Broadcast
+# Code for decrypting.
 #
 # assistant.push /org/bluez/hci0/src_yy_yy_yy_yy_yy_yy/dev_xx_xx_xx_xx_xx_xx/bis_n
 # [Assistant] Enter Metadata (auto/value): a
+# [Assistant] Enter Broadcast Code (auto/value): Borne House
 #
 #
 # Wait for the MediaAssistant object to transition to "active"

--- a/client/scripts/scan-delegator.bt
+++ b/client/scripts/scan-delegator.bt
@@ -18,7 +18,22 @@ advertise on
 # After the connection has been established, transports will
 # be created for streams added by the Bradcast Assistant that
 # match the audio capabilities chosen at endpoint register.
-# Acquire the desired transport to start receiving audio.
+# Select the desired transport. If the stream is encrypted,
+# a prompt will be displayed to enter the Broadacast Code for
+# decrypting. If the code is unknown, the "no" option will
+# request the code from the Broadcast Assistant.
+#
+# transport.select /org/bluez/hci0/dev_xx_xx_xx_xx_xx_xx/bis_n/fd_m
+# [] Enter brocast code[value/no]: no
+#
+#
+# If the Broadcast Assistant provided the Broadcast Code, the
+# transport will transition to "broadcasting" state.
+#
+# [CHG] Transport /org/bluez/hci0/dev_xx_xx_xx_xx_xx_xx/bis_n/fd_m State: broadcasting
+#
+#
+# Acquire the transport to start receiving audio.
 #
 # transport.acquire /org/bluez/hci0/dev_xx_xx_xx_xx_xx_xx/bis_n/fd_m
 #

--- a/profiles/audio/bass.h
+++ b/profiles/audio/bass.h
@@ -16,3 +16,9 @@ bool bass_bcast_probe(struct btd_device *device, struct bt_bap *bap);
 bool bass_bcast_remove(struct btd_device *device);
 
 bool bass_check_bis(struct btd_device *device, uint8_t bis);
+
+typedef void (*bt_bass_bcode_func_t)(void *user_data, int err);
+
+void bass_req_bcode(struct bt_bap_stream *stream,
+				bt_bass_bcode_func_t cb,
+				void *user_data);

--- a/src/shared/bass.c
+++ b/src/shared/bass.c
@@ -1832,3 +1832,27 @@ bool bt_bass_check_bis(struct bt_bcast_src *bcast_src, uint8_t bis)
 
 	return false;
 }
+
+int bt_bass_set_enc(struct bt_bcast_src *bcast_src, uint8_t enc)
+{
+	struct iovec *iov;
+
+	if (!bcast_src)
+		return -EINVAL;
+
+	if (bcast_src->enc == enc)
+		return 0;
+
+	bcast_src->enc = enc;
+
+	iov = bass_parse_bcast_src(bcast_src);
+	if (!iov)
+		return -ENOMEM;
+
+	bt_bass_notify_all(bcast_src->attr, iov);
+
+	free(iov->iov_base);
+	free(iov);
+
+	return 0;
+}

--- a/src/shared/bass.c
+++ b/src/shared/bass.c
@@ -1793,6 +1793,9 @@ int bt_bass_set_bis_sync(struct bt_bcast_src *bcast_src, uint8_t bis)
 		if (sgrp->pending_bis_sync & bitmask) {
 			sgrp->bis_sync |= bitmask;
 
+			if (bcast_src->enc == BT_BASS_BIG_ENC_STATE_BCODE_REQ)
+				bcast_src->enc = BT_BASS_BIG_ENC_STATE_DEC;
+
 			iov = bass_parse_bcast_src(bcast_src);
 			if (!iov)
 				return -ENOMEM;

--- a/src/shared/bass.h
+++ b/src/shared/bass.h
@@ -133,3 +133,4 @@ int bt_bass_set_pa_sync(struct bt_bcast_src *bcast_src, uint8_t sync_state);
 int bt_bass_set_bis_sync(struct bt_bcast_src *bcast_src, uint8_t bis);
 int bt_bass_clear_bis_sync(struct bt_bcast_src *bcast_src, uint8_t bis);
 bool bt_bass_check_bis(struct bt_bcast_src *bcast_src, uint8_t bis);
+int bt_bass_set_enc(struct bt_bcast_src *bcast_src, uint8_t enc);


### PR DESCRIPTION
A Broadcast Sink might scan encrypted streams, and the user might not
know the Broadcast Code to decrypt them.

This commit adds the option to set an empty Broadcast Code when prompted
for it after transport.select, if the Code is unknown. In this case, if
the Broadcast Sink is acting as a Scan Delegator, it can ask its peer
Broadcast Assistants to provide the Code through BASS.
---
 client/player.c | 13 +++++++++++--
 1 file changed, 11 insertions(+), 2 deletions(-)