### PR TITLE
[PW_SID:896868] [BlueZ] transport: Delay existence based on delay reporting capability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/profiles/audio/avdtp.c
+++ b/profiles/audio/avdtp.c
@@ -3203,6 +3203,10 @@ gboolean avdtp_stream_has_capabilities(struct avdtp_stream *stream,
 	return TRUE;
 }
 
+gboolean avdtp_stream_has_delay_reporting(struct avdtp_stream *stream) {
+	return stream->delay_reporting;
+}
+
 struct avdtp_remote_sep *avdtp_stream_get_remote_sep(
 						struct avdtp_stream *stream)
 {

--- a/profiles/audio/avdtp.h
+++ b/profiles/audio/avdtp.h
@@ -252,6 +252,7 @@ struct avdtp_service_capability *avdtp_stream_get_codec(
 						struct avdtp_stream *stream);
 gboolean avdtp_stream_has_capabilities(struct avdtp_stream *stream,
 					GSList *caps);
+gboolean avdtp_stream_has_delay_reporting(struct avdtp_stream *stream);
 struct avdtp_remote_sep *avdtp_stream_get_remote_sep(
 						struct avdtp_stream *stream);
 


### PR DESCRIPTION
In case when the existence of the delay property is based on its value
not being zero it is not possible to read the delay if sink sets it to
zero on purpose (or it was not updated by the sink at all). However,
client might expect it to be readable, if SEP reports delay reporting
as available.

Instead of checking the value, we should check the capabilities of
the AVDTP stream. Also, by doing that we can allow this property to
be writable in the future - the exists() callback is used in the
properties_set() function as well.
---
 profiles/audio/avdtp.c     |  4 ++++
 profiles/audio/avdtp.h     |  1 +
 profiles/audio/transport.c | 23 ++++++++++++++++++-----
 3 files changed, 23 insertions(+), 5 deletions(-)