### PR TITLE
[PW_SID:899479] [BlueZ,v1] avdtp: Fix triggering disconnect_timeout while discovering capabilities

### DIFF
--- a/profiles/audio/avdtp.c
+++ b/profiles/audio/avdtp.c
@@ -2037,6 +2037,14 @@ failed:
 static gboolean avdtp_parse_cmd(struct avdtp *session, uint8_t transaction,
 				uint8_t signal_id, void *buf, int size)
 {
+	/* Reset disconnect timer if command is received */
+	if (session->dc_timer) {
+		timeout_remove(session->dc_timer);
+		session->dc_timer = timeout_add_seconds(session->dc_timeout,
+						disconnect_timeout,
+						session, NULL);
+	}
+
 	switch (signal_id) {
 	case AVDTP_DISCOVER:
 		DBG("Received DISCOVER_CMD");


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

If there are many endpoint registered it may delay the discovering of
the capabilities long enough to trigger diconnect_timeout which may
cause unexpected collisions/disconnections.

Fixes: https://github.com/bluez/bluez/issues/981
---
 profiles/audio/avdtp.c | 8 ++++++++
 1 file changed, 8 insertions(+)