### PR TITLE
[PW_SID:901706] [v1] obex: Resolve SRM issue for PTS testcases

### DIFF
--- a/gobex/gobex.c
+++ b/gobex/gobex.c
@@ -317,6 +317,9 @@ static void set_srm(GObex *obex, guint8 op, guint8 srm)
 	struct srm_config *config = obex->srm;
 	gboolean enable;
 
+	if(srm != G_OBEX_SRM_DISABLE && srm != G_OBEX_SRM_ENABLE && srm != G_OBEX_SRM_INDICATE)
+	      return; //unknown srm value
+
 	if (config == NULL) {
 		if (srm == G_OBEX_SRM_DISABLE)
 			return;


### PR DESCRIPTION
Add check for unknown/undefined srm value.

This fix is required to pass the below the PTS testcases :
1. OPP/SR/GOEP/SRM/BI-02-C
2. FTP/SR/GOEP/SRM/BI-02-C
3. PBAP/PSE/GOEP/SRM/BI-05-C

Description - Verify that the Server ignores a SRM header with an invalid
value in the PUT/GET request and carries on with the PUT/GET operation with SRM disabled.

Current Behaviour - Server is sending SRM enable in the response even
though recieving the unknown SRM value.

To fix this, I have added the check to verify the valid SRM values
before continuing with SRM enable.

Change-Id: I399b1daacdcfa118137dc9798529514d36fd78ed
---
 gobex/gobex.c | 3 +++
 1 file changed, 3 insertions(+)