### PR TITLE
[PW_SID:902259] [BlueZ,v1] shared/bap: Fix crash on bt_bap_stream_disable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/Makefile.am
+++ b/Makefile.am
@@ -386,7 +386,7 @@ man_MANS += doc/org.bluez.obex.Client.5 doc/org.bluez.obex.Session.5 \
 		doc/org.bluez.obex.Image.5
 endif
 manual_pages += src/bluetoothd.8
-manual_pages += doct/hci.7 doc/l2cap.7 doc/rfcomm.7
+manual_pages += doc/hci.7 doc/l2cap.7 doc/rfcomm.7
 manual_pages += doc/org.bluez.Adapter.5 doc/org.bluez.Device.5 \
 		doc/org.bluez.DeviceSet.5 doc/org.bluez.AgentManager.5 \
 		doc/org.bluez.Agent.5 doc/org.bluez.ProfileManager.5 \

--- a/doc/mgmt-api.txt
+++ b/doc/mgmt-api.txt
@@ -3991,6 +3991,36 @@ Cancel Transmit Mesh Packet Command
 	Possible errors:	Failed
 				Invalid Parameters
 
+Send HCI command and wait for event Command
+===========================================
+
+	Command Code:		0x005B
+	Controller Index:	<controller id>
+	Command Parameters:	Opcode (2 Octets)
+				Event (1 Octet)
+				Timeout (1 Octet)
+				Parameter Length (2 Octets)
+				Parameter (variable)
+	Return Parameters:	Response (1-variable Octets)
+
+	This command may be used to send a HCI command and wait for an
+	(optional) event.
+
+	The HCI command is specified by the Opcode, any arbitrary is supported
+	including vendor commands, but contrary to the like of
+	Raw/User channel it is run as an HCI command send by the kernel
+	since it uses its command synchronization thus it is possible to wait
+	for a specific event as a response.
+
+	Seeting event to 0x00 will cause the command to wait for either
+	HCI Command Status or HCI Command Complete.
+
+	Timeout is specified in seconds, setting it to 0 will cause the
+	default timeout to be used.
+
+	Possible errors:	Failed
+				Invalid Parameters
+
 Command Complete Event
 ======================
 

--- a/src/btd.h
+++ b/src/btd.h
@@ -106,6 +106,7 @@ struct btd_avdtp_opts {
 
 struct btd_avrcp_opts {
 	bool		volume_without_target;
+	bool		volume_category;
 };
 
 struct btd_advmon_opts {

--- a/src/main.c
+++ b/src/main.c
@@ -167,6 +167,7 @@ static const char *avdtp_options[] = {
 
 static const char *avrcp_options[] = {
 	"VolumeWithoutTarget",
+	"VolumeCategory",
 	NULL
 };
 
@@ -1151,6 +1152,9 @@ static void parse_avrcp(GKeyFile *config)
 	parse_config_bool(config, "AVRCP",
 		"VolumeWithoutTarget",
 		&btd_opts.avrcp.volume_without_target);
+	parse_config_bool(config, "AVRCP",
+		"VolumeCategory",
+		&btd_opts.avrcp.volume_category);
 }
 
 static void parse_advmon(GKeyFile *config)
@@ -1220,6 +1224,7 @@ static void init_defaults(void)
 	btd_opts.avdtp.stream_mode = BT_IO_MODE_BASIC;
 
 	btd_opts.avrcp.volume_without_target = false;
+	btd_opts.avrcp.volume_category = true;
 
 	btd_opts.advmon.rssi_sampling_period = 0xFF;
 	btd_opts.csis.encrypt = true;

--- a/src/main.conf
+++ b/src/main.conf
@@ -311,6 +311,11 @@
 # version is ignored.
 #VolumeWithoutTarget = false
 
+# Validate that remote AVRCP profiles advertise the category-2 bit before
+# allowing SetAbsoluteVolume calls or registering for EVENT_VOLUME_CHANGED
+# notifications.
+#VolumeCategory = true
+
 [Policy]
 #
 # The ReconnectUUIDs defines the set of remote services that should try


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

Calls to bt_bap_stream_disable with unicast stream shall result in
stream_disable if when acting as a server (!stream->client) otherwise it
may lead to the following trace:

bluetoothd[104990]: src/shared/bap.c:bap_queue_req() req 0x555555732470 (op 0x05) queue 0x55555571e850
bluetoothd[104990]: src/gatt-database.c:send_notification_to_device() GATT server sending notification
bluetoothd[104990]: src/shared/bap.c:stream_notify_state() stream 0x55555571b7f0
bluetoothd[104990]: src/shared/bap.c:stream_notify_qos() stream 0x55555571b7f0
bluetoothd[104990]: src/gatt-database.c:send_notification_to_device() GATT server sending notification
bluetoothd[104990]: src/shared/bap.c:bap_process_queue()
bluetoothd[104990]: src/shared/bap.c:bap_send() req 0x555555732470 len 3

Program received signal SIGSEGV, Segmentation fault.
bap_send (bap=bap@entry=0x555555730c50, req=req@entry=0x555555732470) at src/shared/bap.c:1490

Fixes: https://github.com/bluez/bluez/issues/991
---
 src/shared/bap.c | 45 ++++++++++++++++++++++++---------------------
 1 file changed, 24 insertions(+), 21 deletions(-)