### PR TITLE
[PW_SID:903164] transport: Fix select/unselect reply missing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/client/player.c
+++ b/client/player.c
@@ -4870,7 +4870,7 @@ static void select_reply(DBusMessage *message, void *user_data)
 		return bt_shell_noninteractive_quit(EXIT_FAILURE);
 	}
 
-	bt_shell_printf("Select successful");
+	bt_shell_printf("Select successful\n");
 
 	return bt_shell_noninteractive_quit(EXIT_SUCCESS);
 }
@@ -4887,7 +4887,7 @@ static void unselect_reply(DBusMessage *message, void *user_data)
 		return bt_shell_noninteractive_quit(EXIT_FAILURE);
 	}
 
-	bt_shell_printf("Select successful");
+	bt_shell_printf("Unselect successful\n");
 
 	return bt_shell_noninteractive_quit(EXIT_SUCCESS);
 }

--- a/profiles/audio/transport.c
+++ b/profiles/audio/transport.c
@@ -1423,7 +1423,7 @@ static DBusMessage *select_transport(DBusConnection *conn, DBusMessage *msg,
 		transport_update_playing(transport, TRUE);
 	}
 
-	return NULL;
+	return dbus_message_new_method_return(msg);
 }
 
 static DBusMessage *unselect_transport(DBusConnection *conn, DBusMessage *msg,
@@ -1436,7 +1436,7 @@ static DBusMessage *unselect_transport(DBusConnection *conn, DBusMessage *msg,
 		transport_update_playing(transport, FALSE);
 	}
 
-	return NULL;
+	return dbus_message_new_method_return(msg);
 }
 
 static void sink_state_changed(struct btd_service *service,


### PR DESCRIPTION
When a transport is selected from bluetoothctl, a reply is expected.
Currently, if the method call is successful, no reply is sent, causing
the following error message in bluetoothctl:

transport.Failed to select: org.freedesktop.DBus.Error.NoReply

The same error can be reproduced for the unselect method.

This commit updates the select and unselect methods to send reply
messages.
---
 profiles/audio/transport.c | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)