### PR TITLE
[PW_SID:903281] [BlueZ,v1] input: Add support for UserspaceHID=persist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/profiles/input/device.h
+++ b/profiles/input/device.h
@@ -11,11 +11,18 @@
 #define L2CAP_PSM_HIDP_CTRL	0x11
 #define L2CAP_PSM_HIDP_INTR	0x13
 
+typedef enum {
+	UHID_DISABLED = 0,
+	UHID_ENABLED,
+	UHID_PERSIST
+} uhid_state_t;
+
 struct input_device;
 struct input_conn;
 
 void input_set_idle_timeout(int timeout);
-void input_enable_userspace_hid(bool state);
+void input_set_userspace_hid(char *state);
+uint8_t input_get_userspace_hid(void);
 void input_set_classic_bonded_only(bool state);
 bool input_get_classic_bonded_only(void);
 void input_set_auto_sec(bool state);

--- a/profiles/input/hog.c
+++ b/profiles/input/hog.c
@@ -208,7 +208,10 @@ static int hog_disconnect(struct btd_service *service)
 {
 	struct hog_device *dev = btd_service_get_user_data(service);
 
-	bt_hog_detach(dev->hog, false);
+	if (input_get_userspace_hid() == UHID_PERSIST)
+		bt_hog_detach(dev->hog, false);
+	else
+		bt_hog_detach(dev->hog, true);
 
 	btd_service_disconnecting_complete(service, 0);
 

--- a/profiles/input/input.conf
+++ b/profiles/input/input.conf
@@ -10,7 +10,11 @@
 #IdleTimeout=0
 
 # Enable HID protocol handling in userspace input profile
-# Defaults to true (Use UHID instead of kernel HIDP)
+# Possible values:
+#  - persist: Use UHID in persistent mode (keyboard only)
+#  - true: Use UHID instead
+#  - false: User kernel HIDP
+# Defaults to true
 #UserspaceHID=true
 
 # Limit HID connections to bonded devices

--- a/profiles/input/manager.c
+++ b/profiles/input/manager.c
@@ -83,7 +83,8 @@ static int input_init(void)
 	config = load_config_file(CONFIGDIR "/input.conf");
 	if (config) {
 		int idle_timeout;
-		gboolean uhid_enabled, classic_bonded_only, auto_sec;
+		gboolean classic_bonded_only, auto_sec;
+		char *uhid_enabled;
 
 		idle_timeout = g_key_file_get_integer(config, "General",
 							"IdleTimeout", &err);
@@ -93,12 +94,12 @@ static int input_init(void)
 		} else
 			g_clear_error(&err);
 
-		uhid_enabled = g_key_file_get_boolean(config, "General",
+		uhid_enabled = g_key_file_get_string(config, "General",
 							"UserspaceHID", &err);
 		if (!err) {
-			DBG("input.conf: UserspaceHID=%s", uhid_enabled ?
-							"true" : "false");
-			input_enable_userspace_hid(uhid_enabled);
+			DBG("input.conf: UserspaceHID=%s", uhid_enabled);
+			input_set_userspace_hid(uhid_enabled);
+			free(uhid_enabled);
 		} else
 			g_clear_error(&err);
 


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

This adds support supportfor persist mode via input.conf:UserspaceHID
but don't default to it since this appears to create more problems than
it solves.

Fixes: https://github.com/bluez/bluez/issues/983
Fixes: https://github.com/bluez/bluez/issues/977
Fixes: https://github.com/bluez/bluez/issues/949
---
 profiles/input/device.c   | 27 ++++++++++++++++++++++-----
 profiles/input/device.h   |  9 ++++++++-
 profiles/input/hog.c      |  5 ++++-
 profiles/input/input.conf |  6 +++++-
 profiles/input/manager.c  | 11 ++++++-----
 5 files changed, 45 insertions(+), 13 deletions(-)