### PR TITLE
[PW_SID:903299] [BlueZ,1/2] sink: clean up outstanding AVDTP requests if the stream goes away.

### DIFF
--- a/profiles/audio/sink.c
+++ b/profiles/audio/sink.c
@@ -137,6 +137,11 @@ static void stream_state_changed(struct avdtp_stream *stream,
 	case AVDTP_STATE_IDLE:
 		btd_service_disconnecting_complete(sink->service, 0);
 
+		if (sink->connect_id > 0) {
+			a2dp_cancel(sink->connect_id);
+			sink->connect_id = 0;
+		}
+
 		if (sink->disconnect_id > 0) {
 			a2dp_cancel(sink->disconnect_id);
 			sink->disconnect_id = 0;

--- a/profiles/audio/source.c
+++ b/profiles/audio/source.c
@@ -134,6 +134,11 @@ static void stream_state_changed(struct avdtp_stream *stream,
 	case AVDTP_STATE_IDLE:
 		btd_service_disconnecting_complete(source->service, 0);
 
+		if (source->connect_id > 0) {
+			a2dp_cancel(source->connect_id);
+			source->connect_id = 0;
+		}
+
 		if (source->disconnect_id > 0) {
 			a2dp_cancel(source->disconnect_id);
 			source->disconnect_id = 0;


### PR DESCRIPTION
If the stream goes IDLE while we have an outstanding request, connect_id
stays non-zero and is never cleared via a completion callback. As a
consequence, the profile on this device will never be connected
successfully again until BlueZ restarts.
---
 profiles/audio/sink.c | 5 +++++
 1 file changed, 5 insertions(+)