### PR TITLE
[PW_SID:904104] [v2] device: only use the address type selection algorithm when remote device is a dual-mode device when pair device

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+


### PR DESCRIPTION
For a BLE-only device, if the device is already paired and the upper
layer attempts to pair it again, the bdaddr_type will be set to
BDADDR_BREDR since the LE connection is already bonded. This causes the
device to use the BR/EDR bearer, which stalls the pairing procedure and
requires waiting for the pairing timeout.

The bluetoothctl log below shows the error result:

[bluetooth]# pair ED:8E:0E:B3:85:C1
Attempting to pair with ED:8E:0E:B3:85:C1
Pairing successful
[RAPOO BleMouse]# disconnect ED:8E:0E:B3:85:C1
Attempting to disconnect from ED:8E:0E:B3:85:C1
[RAPOO BleMouse]#
[bluetooth]# devices Paired
Device ED:8E:0E:B3:85:C1 RAPOO BleMouse
[bluetooth]# scan le
SetDiscoveryFilter success
Discovery started
[CHG] Controller 8C:FD:F0:21:84:17 Discovering: yes
[CHG] Device ED:8E:0E:B3:85:C1 RSSI: -38
[bluetooth]# scan off
Discovery stopped
[bluetooth]# pair ED:8E:0E:B3:85:C1
Attempting to pair with ED:8E:0E:B3:85:C1
[bluetooth]#
Failed to pair: org.freedesktop.DBus.Error.NoReply
---
 src/device.c | 23 ++++++++++++++++++-----
 1 file changed, 18 insertions(+), 5 deletions(-)