### PR TITLE
[PW_SID:905703] transport: don't disconnect A2DP if canceling Acquire() with Release()

### DIFF
--- a/profiles/audio/a2dp.c
+++ b/profiles/audio/a2dp.c
@@ -3132,6 +3132,9 @@ unsigned int a2dp_resume(struct avdtp *session, struct a2dp_sep *sep,
 	cb_data->resume_cb = cb;
 	cb_data->user_data = user_data;
 
+	if (setup->reconfigure)
+		goto failed;
+
 	setup->sep = sep;
 	setup->stream = sep->stream;
 
@@ -3189,6 +3192,9 @@ unsigned int a2dp_suspend(struct avdtp *session, struct a2dp_sep *sep,
 	cb_data = setup_cb_add(setup);
 	cb_data->suspend_cb = cb;
 	cb_data->user_data = user_data;
+
+	if (setup->reconfigure)
+		goto failed;
 
 	setup->sep = sep;
 	setup->stream = sep->stream;


### PR DESCRIPTION
User can cancel transport acquire by calling Release() while Acquire()
is in progress. This calls a2dp_cancel() which sends AVDTP_ABORT_CMD,
forcing AVDTP state transition to IDLE, and A2DP profile disconnects.

However, Release()/Acquire() should only result to transitions between
STREAMING/OPEN.  The expected behavior is that either these calls return
error, or they block until the target state is reached.

Fix by: Release() during pending Acquire() first sends error reply to
the Acquire. Then it waits for START to complete, then sends SUSPEND,
and after that completes, then it replies.

This also fixes SetConfiguration() after canceled Acquire(), which
previously did not work due to AVDTP disconnect. Now it does
START/SUSPEND -> CLOSE -> reconfigure.
---
 profiles/audio/transport.c | 179 ++++++++++++++++++++++++++++---------
 1 file changed, 137 insertions(+), 42 deletions(-)