### PR TITLE
[PW_SID:906986] [BlueZ,v1] lib: Add IPC bus type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/doc/mgmt-api.txt
+++ b/doc/mgmt-api.txt
@@ -2500,6 +2500,7 @@ Read Extended Controller Index List Command
 		0x08	I2C
 		0x09	SMD
 		0x0A	VIRTIO
+		0x0B	IPC
 
 	Controllers marked as RAW only operation are currently not listed
 	by this command.

--- a/lib/hci.c
+++ b/lib/hci.c
@@ -152,6 +152,8 @@ const char *hci_bustostr(int bus)
 		return "SMD";
 	case HCI_VIRTIO:
 		return "VIRTIO";
+	case HCI_IPC:
+		return "IPC";
 	default:
 		return "Unknown";
 	}

--- a/lib/hci.h
+++ b/lib/hci.h
@@ -47,6 +47,7 @@ extern "C" {
 #define HCI_I2C		8
 #define HCI_SMD		9
 #define HCI_VIRTIO	10
+#define HCI_IPC		11
 
 /* HCI controller types */
 #define HCI_PRIMARY	0x00

--- a/src/shared/btsnoop.h
+++ b/src/shared/btsnoop.h
@@ -58,6 +58,8 @@
 #define BTSNOOP_BUS_SPI		7
 #define BTSNOOP_BUS_I2C		8
 #define BTSNOOP_BUS_SMD		9
+#define BTSNOOP_BUS_VIRTIO	10
+#define BTSNOOP_BUS_IPC		11
 
 struct btsnoop_opcode_new_index {
 	uint8_t  type;


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

Zephyr(1) has been using the same bus defines as Linux so tools likes of
btmon, etc, are able to decode the bus under HCI, so this attempts to
synchronize the definitions by adding the missing bus type IPC(11) and its
decoding string.

[1] https://github.com/zephyrproject-rtos/zephyr/pull/80808
---
 doc/mgmt-api.txt     | 1 +
 lib/hci.c            | 2 ++
 lib/hci.h            | 1 +
 src/shared/btsnoop.h | 2 ++
 4 files changed, 6 insertions(+)