### PR TITLE
[PW_SID:907010] [BlueZ,v1,1/3] sink: Fix transitioning to BTD_SERVICE_STATE_DISCONNECTED on idle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/profiles/audio/a2dp.c
+++ b/profiles/audio/a2dp.c
@@ -58,7 +58,6 @@
 /* The duration that streams without users are allowed to stay in
  * STREAMING state. */
 #define SUSPEND_TIMEOUT 5
-#define RECONFIGURE_TIMEOUT 500
 
 #define AVDTP_PSM 25
 
@@ -1398,7 +1397,7 @@ static bool setup_reconfigure(struct a2dp_setup *setup)
 
 	DBG("%p", setup);
 
-	setup->id = g_timeout_add(RECONFIGURE_TIMEOUT, a2dp_reconfigure, setup);
+	setup->id = g_idle_add(a2dp_reconfigure, setup);
 
 	setup->reconfigure = FALSE;
 

--- a/profiles/audio/sink.c
+++ b/profiles/audio/sink.c
@@ -110,6 +110,7 @@ static void avdtp_state_callback(struct btd_device *dev,
 	switch (new_state) {
 	case AVDTP_SESSION_STATE_DISCONNECTED:
 		sink_set_state(sink, SINK_STATE_DISCONNECTED);
+		btd_service_disconnecting_complete(sink->service, 0);
 		break;
 	case AVDTP_SESSION_STATE_CONNECTING:
 		sink_set_state(sink, SINK_STATE_CONNECTING);
@@ -135,8 +136,6 @@ static void stream_state_changed(struct avdtp_stream *stream,
 
 	switch (new_state) {
 	case AVDTP_STATE_IDLE:
-		btd_service_disconnecting_complete(sink->service, 0);
-
 		if (sink->connect_id > 0) {
 			a2dp_cancel(sink->connect_id);
 			sink->connect_id = 0;

--- a/profiles/audio/source.c
+++ b/profiles/audio/source.c
@@ -107,6 +107,7 @@ static void avdtp_state_callback(struct btd_device *dev, struct avdtp *session,
 	switch (new_state) {
 	case AVDTP_SESSION_STATE_DISCONNECTED:
 		source_set_state(source, SOURCE_STATE_DISCONNECTED);
+		btd_service_disconnecting_complete(source->service, 0);
 		break;
 	case AVDTP_SESSION_STATE_CONNECTING:
 		source_set_state(source, SOURCE_STATE_CONNECTING);
@@ -132,8 +133,6 @@ static void stream_state_changed(struct avdtp_stream *stream,
 
 	switch (new_state) {
 	case AVDTP_STATE_IDLE:
-		btd_service_disconnecting_complete(source->service, 0);
-
 		if (source->connect_id > 0) {
 			a2dp_cancel(source->connect_id);
 			source->connect_id = 0;


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

If the stream transition to AVDTP_STATE_IDLE it means the stream has
been disconnected, not the session, therefore
btd_service_disconnecting_complete shall not be called otherwise it may
trigger the policy plugin to disconnect AVRCP in cases like codec
reconfiguration.

Fixes: https://github.com/bluez/bluez/issues/1003
---
 profiles/audio/sink.c | 3 +--
 1 file changed, 1 insertion(+), 2 deletions(-)