### PR TITLE
[PW_SID:908094] [BlueZ] transport: fix AVRCP volume in reconfigured transports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/profiles/audio/transport.c
+++ b/profiles/audio/transport.c
@@ -2598,10 +2598,9 @@ void media_transport_update_device_volume(struct btd_device *dev,
 		/* Volume is A2DP only */
 		if (media_endpoint_get_sep(transport->endpoint)) {
 			media_transport_update_volume(transport, volume);
-			return;
+			break;
 		}
 	}
 
-	/* If transport volume doesn't exists add to device_volume */
 	btd_device_set_volume(dev, volume);
 }


### PR DESCRIPTION
We no longer reconnect AVRCP session on AVDTP transport reconfiguration.
This breaks AVRCP volume after reconfiguration, since there's no volume
update event incoming.

Fix by keeping track of the latest volume in btd_device volume.  It was
introduced to track volume changes that arrive when there are no
transports/players, but we should track all volume changes otherwise the
value can be out of date when we want to use it.

Fixes: 469a75ae182a ("sink: Fix transitioning to BTD_SERVICE_STATE_DISCONNECTED on idle")
---
 profiles/audio/transport.c | 3 +--
 1 file changed, 1 insertion(+), 2 deletions(-)