### PR TITLE
[PW_SID:908365] [v1] obex: Fix the PBAP GET request in PTS testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/obexd/plugins/pbap.c
+++ b/obexd/plugins/pbap.c
@@ -438,10 +438,6 @@ static struct apparam_field *parse_aparam(const uint8_t *buffer, uint32_t hlen)
 	GObexApparam *apparam;
 	struct apparam_field *param;
 
-	apparam = g_obex_apparam_decode(buffer, hlen);
-	if (apparam == NULL)
-		return NULL;
-
 	param = g_new0(struct apparam_field, 1);
 
 	/*
@@ -449,24 +445,27 @@ static struct apparam_field *parse_aparam(const uint8_t *buffer, uint32_t hlen)
 	 * should be assume as Maximum value in vcardlisting 65535
 	 */
 	param->maxlistcount = UINT16_MAX;
-
-	g_obex_apparam_get_uint8(apparam, ORDER_TAG, &param->order);
-	g_obex_apparam_get_uint8(apparam, SEARCHATTRIB_TAG,
+	apparam = g_obex_apparam_decode(buffer, hlen);
+	if (apparam) {
+		g_obex_apparam_get_uint8(apparam, ORDER_TAG, &param->order);
+		g_obex_apparam_get_uint8(apparam, SEARCHATTRIB_TAG,
 						&param->searchattrib);
-	g_obex_apparam_get_uint8(apparam, FORMAT_TAG, &param->format);
-	g_obex_apparam_get_uint16(apparam, MAXLISTCOUNT_TAG,
+		g_obex_apparam_get_uint8(apparam, FORMAT_TAG, &param->format);
+		g_obex_apparam_get_uint16(apparam, MAXLISTCOUNT_TAG,
 						&param->maxlistcount);
-	g_obex_apparam_get_uint16(apparam, LISTSTARTOFFSET_TAG,
+		g_obex_apparam_get_uint16(apparam, LISTSTARTOFFSET_TAG,
 						&param->liststartoffset);
-	g_obex_apparam_get_uint64(apparam, FILTER_TAG, &param->filter);
-	param->searchval = g_obex_apparam_get_string(apparam, SEARCHVALUE_TAG);
+		g_obex_apparam_get_uint64(apparam, FILTER_TAG, &param->filter);
+		param->searchval = g_obex_apparam_get_string(apparam,
+						SEARCHVALUE_TAG);
+
+		g_obex_apparam_free(apparam);
+	}
 
 	DBG("o %x sa %x sv %s fil %" G_GINT64_MODIFIER "x for %x max %x off %x",
 			param->order, param->searchattrib, param->searchval,
 			param->filter, param->format, param->maxlistcount,
 			param->liststartoffset);
-
-	g_obex_apparam_free(apparam);
 
 	return param;
 }


### PR DESCRIPTION
This change is required for passing below PTS testcases:
1. PBAP/PSE/PBD/BV-02-C
2. PBAP/PSE/PBD/BV-03-C
3. PBAP/PSE/PBD/BI-01-C
4. PBAP/PSE/PBD/BV-13-C
5. PBAP/PSE/PBD/BV-14-C
6. PBAP/PSE/PBD/BV-17-C

PTS sends all the GET phonebook requests without extra params.
Therefore, the PBAP server is rejecting the requests with a
'Bad Request' response.
So append 'maxlistcount' as default param in GET request to
avoid testcase failure.

---
 obexd/plugins/pbap.c | 27 +++++++++++++--------------
 1 file changed, 13 insertions(+), 14 deletions(-)