### PR TITLE
[PW_SID:908391] [v1] obex: Check for supported features bit value for legacy server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/obexd/client/pbap.c
+++ b/obexd/client/pbap.c
@@ -1219,6 +1219,7 @@ static void *pbap_supported_features(struct obc_session *session)
 {
 	const void *data;
 	uint16_t version;
+	uint32_t features;
 
 	/* Version */
 	data = obc_session_get_attribute(session, SDP_ATTR_PFILE_DESC_LIST);
@@ -1233,7 +1234,9 @@ static void *pbap_supported_features(struct obc_session *session)
 	/* Supported Feature Bits */
 	data = obc_session_get_attribute(session,
 					SDP_ATTR_PBAP_SUPPORTED_FEATURES);
-	if (!data)
+
+	features = *(uint32_t *) data;
+	if (!features)
 		return NULL;
 
 	return g_obex_apparam_set_uint32(NULL, SUPPORTED_FEATURES_TAG,


### PR DESCRIPTION
This fix is required for below PTS testcase:

1. PBAP/PCE/SSM/BV-10-C
Description - Verify that the PCE does not share its
PbapSupportedFeatures bits with a legacy server.

Incase of legacy server, check for 'supported features bit'
uint_32_t value instead of directly checking the pointer
holding the attribute.
As pointer 'data' won't be null as PbapSupportedFeatures
attribute is present in SDP record but it's value is zero.

---
 obexd/client/pbap.c | 5 ++++-
 1 file changed, 4 insertions(+), 1 deletion(-)