### PR TITLE
[PW_SID:908402] [v1] obex: Add Newmissedcalls tag in PBAP GET response

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/obexd/plugins/pbap.c
+++ b/obexd/plugins/pbap.c
@@ -184,12 +184,11 @@ static void phonebook_size_result(const char *buffer, size_t bufsize,
 
 	if (missed > 0)	{
 		DBG("missed %d", missed);
+	}
 
-		pbap->obj->apparam = g_obex_apparam_set_uint16(
-							pbap->obj->apparam,
+	pbap->obj->apparam = g_obex_apparam_set_uint16(pbap->obj->apparam,
 							NEWMISSEDCALLS_TAG,
 							missed);
-	}
 
 	obex_object_set_io_flags(pbap->obj, G_IO_IN, 0);
 }
@@ -223,12 +222,11 @@ static void query_result(const char *buffer, size_t bufsize, int vcards,
 		DBG("missed %d", missed);
 
 		pbap->obj->firstpacket = TRUE;
+	}
 
-		pbap->obj->apparam = g_obex_apparam_set_uint16(
-							pbap->obj->apparam,
+	pbap->obj->apparam = g_obex_apparam_set_uint16(pbap->obj->apparam,
 							NEWMISSEDCALLS_TAG,
 							missed);
-	}
 
 	obex_object_set_io_flags(pbap->obj, G_IO_IN, 0);
 }


### PR DESCRIPTION
This fix is required for passing below PTS testcases:

1. PBAP/PSE/PBD/BV-05-C
2. PBAP/PSE/PBD/BV-17-C
3. PBAP/PSE/PBB/BV-11-C

Even if the new missed calls value is zero, send it in GET response.
As per the PBAP spec, it is mandatory to include Newmissedcalls
tag in response incase of object name is 'mch.vcf' or 'cch.vcf'.
It will be better to include it in all GET response.

---
 obexd/plugins/pbap.c | 10 ++++------
 1 file changed, 4 insertions(+), 6 deletions(-)