### PR TITLE
[PW_SID:909312] [BlueZ] rfkill: Do not log errors for missing device path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/src/rfkill.c
+++ b/src/rfkill.c
@@ -55,6 +55,7 @@ struct rfkill_event {
 	uint8_t  hard;
 };
 #define RFKILL_EVENT_SIZE_V1    8
+#define RFKILL_DEVICE_PATH      "/dev/rfkill"
 
 static int get_adapter_id_for_rfkill(uint32_t rfkill_id)
 {
@@ -88,7 +89,7 @@ int rfkill_get_blocked(uint16_t index)
 	int fd;
 	int blocked = -1;
 
-	fd = open("/dev/rfkill", O_RDWR);
+	fd = open(RFKILL_DEVICE_PATH, O_RDWR);
 	if (fd < 0) {
 		DBG("Failed to open RFKILL control device");
 		return -1;
@@ -178,9 +179,16 @@ void rfkill_init(void)
 	int fd;
 	GIOChannel *channel;
 
-	fd = open("/dev/rfkill", O_RDWR);
+	errno = 0;
+	fd = open(RFKILL_DEVICE_PATH, O_RDWR);
 	if (fd < 0) {
-		error("Failed to open RFKILL control device");
+		if (errno == ENOENT) {
+			DBG("No RFKILL device available at '%s'",
+				RFKILL_DEVICE_PATH);
+		} else {
+			error("Failed to open RFKILL control device: %s",
+				strerror(errno));
+		}
 		return;
 	}
 


### PR DESCRIPTION
In the case of our products, we lack a physical RFKILL switch and do
not have the rfkill module enabled in the kernel which resulted in an
error message each time bluetoothd was started.

This commit looks at the errno code after failing to open the RFKILL
device and only logs an error if it is something other than ENOENT
(No such file or directory).

Fixes: https://github.com/bluez/bluez/issues/792
---
 src/rfkill.c | 14 +++++++++++---
 1 file changed, 11 insertions(+), 3 deletions(-)