### PR TITLE
[PW_SID:910561] [v1] hog: Check security level before setting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/profiles/input/hog.c
+++ b/profiles/input/hog.c
@@ -191,8 +191,10 @@ static int hog_accept(struct btd_service *service)
 			return -ECONNREFUSED;
 
 		client = btd_device_get_gatt_client(device);
-		if (!bt_gatt_client_set_security(client,
-						BT_ATT_SECURITY_MEDIUM))
+		if (BT_ATT_SECURITY_MEDIUM !=
+			bt_gatt_client_get_security(client) &&
+		    !bt_gatt_client_set_security(client,
+						 BT_ATT_SECURITY_MEDIUM))
 			return -ECONNREFUSED;
 	}
 


### PR DESCRIPTION
bt_gatt_client_set_security could fail if the security level is
already BT_ATT_SECURITY_MEDIUM. So, get and check the security
level before setting it.

Signed-off-by: Jiayang Mao <quic_jiaymao@quicinc.com>
---
 profiles/input/hog.c | 6 ++++--
 1 file changed, 4 insertions(+), 2 deletions(-)