### PR TITLE
[PW_SID:911278] [1/3] shared/ad: fix -std=c23 build failure

### DIFF
--- a/src/shared/ad.c
+++ b/src/shared/ad.c
@@ -1087,7 +1087,7 @@ bool bt_ad_add_name(struct bt_ad *ad, const char *name)
 const char *bt_ad_get_name(struct bt_ad *ad)
 {
 	if (!ad)
-		return false;
+		return NULL;
 
 	return ad->name;
 }

--- a/src/shared/gatt-helpers.c
+++ b/src/shared/gatt-helpers.c
@@ -1133,7 +1133,7 @@ struct bt_gatt_request *bt_gatt_discover_included_services(struct bt_att *att,
 	uint8_t pdu[6];
 
 	if (!att)
-		return false;
+		return NULL;
 
 	op = new0(struct bt_gatt_request, 1);
 	op->att = att;
@@ -1247,7 +1247,7 @@ struct bt_gatt_request *bt_gatt_discover_characteristics(struct bt_att *att,
 	uint8_t pdu[6];
 
 	if (!att)
-		return false;
+		return NULL;
 
 	op = new0(struct bt_gatt_request, 1);
 	op->att = att;
@@ -1475,7 +1475,7 @@ struct bt_gatt_request *bt_gatt_discover_descriptors(struct bt_att *att,
 	uint8_t pdu[4];
 
 	if (!att)
-		return false;
+		return NULL;
 
 	op = new0(struct bt_gatt_request, 1);
 	op->att = att;

--- a/src/shared/shell.c
+++ b/src/shared/shell.c
@@ -362,7 +362,7 @@ static struct input *input_new(int fd)
 
 	io = io_new(fd);
 	if (!io)
-		return false;
+		return NULL;
 
 	input = new0(struct input, 1);
 	input->io = io;


### PR DESCRIPTION
gcc-15 switched to -std=c23 by default:

    https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=55e3bd376b2214e200fa76d12b67ff259b06c212

As a result `bluez` fails the build as:

    src/shared/ad.c:1090:24: error: incompatible types when returning type '_Bool' but 'const char *' was expected
     1090 |                 return false;
          |                        ^~~~~

Signed-off-by: Rudi Heitbaum <rudi@heitbaum.com>
---
 src/shared/ad.c | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)