### PR TITLE
[PW_SID:911300] [BlueZ] Fix for broadcast mode, not to add any AD flags in advertise Data

### DIFF
--- a/src/advertising.c
+++ b/src/advertising.c
@@ -759,10 +759,15 @@ static bool parse_discoverable(DBusMessageIter *iter,
 
 	dbus_message_iter_get_basic(iter, &discoverable);
 
+	/* For broadcast mode, need not add any flags
+	 * just return true without adding flags.
+	 */
 	if (discoverable)
 		flags = BT_AD_FLAG_GENERAL;
-	else
+	else if (client->type != AD_TYPE_BROADCAST)
 		flags = 0x00;
+	else
+		return true;
 
 	if (!set_flags(client , flags))
 		goto fail;


### PR DESCRIPTION
From: Prathibha Madugonde <quic_prathm@quicinc.com>

src/advertising.c
Include check for broadcast mode:
Need not set flags in AD flags of Advertise Data

Test steps:
From DUT, bluetoothctl go to menu advertise
secondary 1M/2M
name on
back
advertise broadcast

---
 src/advertising.c | 7 ++++++-
 1 file changed, 6 insertions(+), 1 deletion(-)