### PR TITLE
[PW_SID:912795] [BlueZ,1/2] profiles/audio: Quiet plug-in warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/profiles/audio/media.c
+++ b/profiles/audio/media.c
@@ -1249,7 +1249,7 @@ static bool endpoint_init_pac(struct media_endpoint *endpoint, uint8_t type,
 	char *name;
 
 	if (!(g_dbus_get_flags() & G_DBUS_FLAG_ENABLE_EXPERIMENTAL)) {
-		warn("D-Bus experimental not enabled");
+		DBG("D-Bus experimental not enabled");
 		*err = -ENOTSUP;
 		return false;
 	}

--- a/profiles/audio/micp.c
+++ b/profiles/audio/micp.c
@@ -318,7 +318,7 @@ static unsigned int micp_id;
 static int micp_init(void)
 {
 	if (!(g_dbus_get_flags() & G_DBUS_FLAG_ENABLE_EXPERIMENTAL)) {
-		warn("D-Bus experimental not enabled");
+		DBG("D-Bus experimental not enabled");
 		return -ENOTSUP;
 	}
 

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -50,7 +50,7 @@ static int init_plugin(const struct bluetooth_plugin_desc *desc)
 	err = desc->init();
 	if (err < 0) {
 		if (err == -ENOSYS || err == -ENOTSUP)
-			warn("System does not support %s plugin",
+			DBG("System does not support %s plugin",
 						desc->name);
 		else
 			error("Failed to init %s plugin",


### PR DESCRIPTION
A normal daemon start should not throw warnings on a system in the
default configuration. Quiet the plug-in warnings that require
experimental features to be enabled. They will still appear in the debug
output.

bluetoothd[896]: profiles/audio/micp.c:micp_init() D-Bus experimental not enabled
---
 profiles/audio/media.c | 2 +-
 profiles/audio/micp.c  | 2 +-
 2 files changed, 2 insertions(+), 2 deletions(-)