### PR TITLE
[PW_SID:913009] [v2] BNEP: Fix the BNEP Unknown Control Message in PTS testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/profiles/network/bnep.c
+++ b/profiles/network/bnep.c
@@ -726,3 +726,9 @@ void bnep_server_delete(char *bridge, char *iface, const bdaddr_t *addr)
 	bnep_if_down(iface);
 	bnep_conndel(addr);
 }
+
+int bnep_send_unkown_rsp(int sk, uint16_t resp)
+{
+	return bnep_send_ctrl_rsp(sk, BNEP_CMD_NOT_UNDERSTOOD,
+							  resp);
+}

--- a/profiles/network/bnep.h
+++ b/profiles/network/bnep.h
@@ -27,3 +27,5 @@ void bnep_disconnect(struct bnep *session);
 int bnep_server_add(int sk, char *bridge, char *iface, const bdaddr_t *addr,
 						uint8_t *setup_data, int len);
 void bnep_server_delete(char *bridge, char *iface, const bdaddr_t *addr);
+int bnep_send_unkown_rsp(int sk, uint16_t resp);
+

--- a/profiles/network/server.c
+++ b/profiles/network/server.c
@@ -331,6 +331,17 @@ static gboolean bnep_setup(GIOChannel *chan,
 	 * 1 byte of BNEP Control Type + 1 byte of BNEP services UUID size.
 	 */
 	if (n < 3) {
+
+		/* Added a response to the error control command
+		 * This packet reply to any control message received,
+		 * which contains an unknown BNEP control type value.
+		 */
+		if (req->ctrl == BNEP_CONTROL) {
+			if (bnep_send_unkown_rsp(sk, req->ctrl) < 0)
+				error("send not understood ctrl rsp error: %s (%d)",
+								strerror(errno), errno);
+		}
+
 		error("To few setup connection request data received");
 		return FALSE;
 	}


### PR DESCRIPTION
This change is required for passing below PTS testcase:
1. BNEP/CTRL/BV-01-C

PTS sends an Unknown Control Message with only two bytes,
which is considered incorrect data. Therefore, add
responses to error control commands.

Signed-off-by: Shuai Zhang <quic_shuaz@quicinc.com>
---
 profiles/network/bnep.c   |  6 ++++++
 profiles/network/bnep.h   |  2 ++
 profiles/network/server.c | 11 +++++++++++
 3 files changed, 19 insertions(+)