### PR TITLE
[PW_SID:914938] [BlueZ] Leave config files writable for owner

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -32,7 +32,7 @@ confdir = $(sysconfdir)/bluetooth
 statedir = $(localstatedir)/lib/bluetooth
 
 bluetoothd-fix-permissions:
-	install -dm555 $(DESTDIR)$(confdir)
+	install -dm755 $(DESTDIR)$(confdir)
 	install -dm700 $(DESTDIR)$(statedir)
 
 if DATAFILES


### PR DESCRIPTION
This is needed both so the owner can adjust config as needed, and for
distribution builds to be able to move/delete files as part of the
build without adjusting permissions themselves. Limiting writes from
the running service needs to be done in the systemd unit (already the
case) or init script.

See also: https://lore.kernel.org/linux-bluetooth/4d1206df-598b-4a68-8655-74981b62ecca@gmx.de/T/
---
 Makefile.am | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)