### PR TITLE
[PW_SID:916123] [BlueZ,v1,1/3] shared/gatt-db: Fix possible crash on gatt_db_clone

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/monitor/att.c
+++ b/monitor/att.c
@@ -63,6 +63,13 @@ struct att_conn_data {
 	uint16_t mtu;
 };
 
+struct gatt_cache {
+	bdaddr_t id;
+	struct gatt_db *db;
+};
+
+static struct queue *cache_list;
+
 static void print_uuid(const char *label, const void *data, uint16_t size)
 {
 	const char *str;
@@ -397,9 +404,41 @@ static const struct bitfield_data chrc_prop_table[] = {
 	{ }
 };
 
-static void att_conn_data_free(void *data)
+static bool match_cache_id(const void *data, const void *match_data)
+{
+	const struct gatt_cache *cache = data;
+	const bdaddr_t *id = match_data;
+
+	return !bacmp(&cache->id, id);
+}
+
+static void gatt_cache_add(struct packet_conn_data *conn, struct gatt_db *db)
+{
+	struct gatt_cache *cache;
+	bdaddr_t id;
+	uint8_t id_type;
+
+	if (!keys_resolve_identity(conn->dst, id.b, &id_type))
+		bacpy(&id, (bdaddr_t *)conn->dst);
+
+	if (queue_find(cache_list, match_cache_id, &id))
+		return;
+
+	if (!cache_list)
+		cache_list = queue_new();
+
+	cache = new0(struct gatt_cache, 1);
+	bacpy(&cache->id, &id);
+	cache->db = gatt_db_ref(db);
+	queue_push_tail(cache_list, cache);
+}
+
+static void att_conn_data_free(struct packet_conn_data *conn, void *data)
 {
 	struct att_conn_data *att_data = data;
+
+	if (!gatt_db_isempty(att_data->rdb))
+		gatt_cache_add(conn, att_data->rdb);
 
 	gatt_db_unref(att_data->rdb);
 	gatt_db_unref(att_data->ldb);
@@ -456,20 +495,32 @@ static void load_gatt_db(struct packet_conn_data *conn)
 	char filename[PATH_MAX];
 	char local[18];
 	char peer[18];
-	uint8_t id[6], id_type;
+	bdaddr_t id;
+	uint8_t id_type;
 
 	ba2str((bdaddr_t *)conn->src, local);
 
-	if (keys_resolve_identity(conn->dst, id, &id_type))
-		ba2str((bdaddr_t *)id, peer);
-	else
+	if (keys_resolve_identity(conn->dst, id.b, &id_type)) {
+		ba2str(&id, peer);
+	} else {
+		bacpy(&id, (bdaddr_t *)conn->dst);
 		ba2str((bdaddr_t *)conn->dst, peer);
+	}
 
 	create_filename(filename, PATH_MAX, "/%s/attributes", local);
 	gatt_load_db(data->ldb, filename, &data->ldb_mtim);
 
 	create_filename(filename, PATH_MAX, "/%s/cache/%s", local, peer);
 	gatt_load_db(data->rdb, filename, &data->rdb_mtim);
+
+	/* If rdb cannot be loaded from file try local cache */
+	if (gatt_db_isempty(data->rdb)) {
+		struct gatt_cache *cache;
+
+		cache = queue_find(cache_list, match_cache_id, &id);
+		if (cache)
+			data->rdb = cache->db;
+	}
 }
 
 static struct gatt_db *get_db(const struct l2cap_frame *frame, bool rsp)

--- a/monitor/packet.c
+++ b/monitor/packet.c
@@ -199,7 +199,7 @@ static struct packet_conn_data *release_handle(uint16_t handle)
 
 		if (conn->handle == handle) {
 			if (conn->destroy)
-				conn->destroy(conn->data);
+				conn->destroy(conn, conn->data);
 
 			queue_destroy(conn->tx_q, free);
 			queue_destroy(conn->chan_q, free);

--- a/monitor/packet.h
+++ b/monitor/packet.h
@@ -50,7 +50,7 @@ struct packet_conn_data {
 	struct queue *chan_q;
 	struct packet_latency tx_l;
 	void     *data;
-	void     (*destroy)(void *data);
+	void     (*destroy)(struct packet_conn_data *conn, void *data);
 };
 
 struct packet_conn_data *packet_get_conn_data(uint16_t handle);

--- a/profiles/battery/battery.c
+++ b/profiles/battery/battery.c
@@ -327,7 +327,6 @@ static struct btd_profile batt_profile = {
 	.device_remove	= batt_remove,
 	.accept		= batt_accept,
 	.disconnect	= batt_disconnect,
-	.external	= true,
 };
 
 static int batt_init(void)

--- a/profiles/deviceinfo/deviceinfo.c
+++ b/profiles/deviceinfo/deviceinfo.c
@@ -138,7 +138,6 @@ static int deviceinfo_disconnect(struct btd_service *service)
 static struct btd_profile deviceinfo_profile = {
 	.name		= "deviceinfo",
 	.remote_uuid	= DEVICE_INFORMATION_UUID,
-	.external	= true,
 	.device_probe	= deviceinfo_probe,
 	.device_remove	= deviceinfo_remove,
 	.accept		= deviceinfo_accept,

--- a/src/btd.h
+++ b/src/btd.h
@@ -42,6 +42,12 @@ enum sc_mode_t {
 	SC_ONLY,
 };
 
+enum bt_gatt_export_t {
+	BT_GATT_EXPORT_OFF,
+	BT_GATT_EXPORT_READ_ONLY,
+	BT_GATT_EXPORT_READ_WRITE,
+};
+
 struct btd_br_defaults {
 	uint16_t	page_scan_type;
 	uint16_t	page_scan_interval;
@@ -147,6 +153,7 @@ struct btd_opts {
 	uint16_t	gatt_mtu;
 	uint8_t		gatt_channels;
 	bool		gatt_client;
+	enum bt_gatt_export_t gatt_export;
 	enum mps_mode_t	mps;
 
 	struct btd_avdtp_opts avdtp;

--- a/src/main.c
+++ b/src/main.c
@@ -148,6 +148,7 @@ static const char *gatt_options[] = {
 	"ExchangeMTU",
 	"Channels",
 	"Client",
+	"ExportClaimedServices",
 	NULL
 };
 
@@ -1066,6 +1067,33 @@ static void parse_gatt_cache(GKeyFile *config)
 	g_free(str);
 }
 
+static enum bt_gatt_export_t parse_gatt_export_str(const char *str)
+{
+	if (!strcmp(str, "no") || !strcmp(str, "false") ||
+				!strcmp(str, "off")) {
+		return BT_GATT_EXPORT_OFF;
+	} else if (!strcmp(str, "read-only")) {
+		return BT_GATT_EXPORT_READ_ONLY;
+	} else if (!strcmp(str, "read-write")) {
+		return BT_GATT_EXPORT_READ_WRITE;
+	}
+
+	DBG("Invalid value for ExportClaimedServices=%s", str);
+	return BT_GATT_EXPORT_READ_ONLY;
+}
+
+static void parse_gatt_export(GKeyFile *config)
+{
+	char *str = NULL;
+
+	parse_config_string(config, "GATT", "ExportClaimedServices", &str);
+	if (!str)
+		return;
+
+	btd_opts.gatt_export = parse_gatt_export_str(str);
+	g_free(str);
+}
+
 static void parse_gatt(GKeyFile *config)
 {
 	parse_gatt_cache(config);
@@ -1075,6 +1103,7 @@ static void parse_gatt(GKeyFile *config)
 	parse_config_u8(config, "GATT", "Channels", &btd_opts.gatt_channels,
 				1, 5);
 	parse_config_bool(config, "GATT", "Client", &btd_opts.gatt_client);
+	parse_gatt_export(config);
 }
 
 static void parse_csis_sirk(GKeyFile *config)
@@ -1219,6 +1248,7 @@ static void init_defaults(void)
 	btd_opts.gatt_mtu = BT_ATT_MAX_LE_MTU;
 	btd_opts.gatt_channels = 1;
 	btd_opts.gatt_client = true;
+	btd_opts.gatt_export = BT_GATT_EXPORT_READ_ONLY;
 
 	btd_opts.avdtp.session_mode = BT_IO_MODE_BASIC;
 	btd_opts.avdtp.stream_mode = BT_IO_MODE_BASIC;

--- a/src/main.conf
+++ b/src/main.conf
@@ -262,6 +262,11 @@
 # Default to 1
 #Channels = 1
 
+# Export claimed services by plugins
+# Possible values: no, read-only, read-write
+# Default: read-only
+#ExportClaimedServices = read-only
+
 [CSIS]
 # SIRK - Set Identification Resolution Key which is common for all the
 # sets. They SIRK key is used to identify its sets. This can be any

--- a/src/shared/gatt-db.c
+++ b/src/shared/gatt-db.c
@@ -278,6 +278,9 @@ static void service_clone(void *data, void *user_data)
 	for (i = 0; i < service->num_handles; i++) {
 		struct gatt_db_attribute *attr = service->attributes[i];
 
+		if (!attr)
+			continue;
+
 		/* Only clone values for characteristics declaration since that
 		 * is considered when calculating the db hash.
 		 */


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

The following crash can happen if the original gatt_db has incomplete
service definitions since the attribute might still be discovering:

 Invalid read of size 4
    at 0x1E5A39: bt_uuid_len (uuid.h:289)
    by 0x1E5A39: service_clone (gatt-db.c:284)
    by 0x1D5EBB: queue_foreach (queue.c:207)
    by 0x1E61CD: gatt_db_clone (gatt-db.c:329)
    by 0x1C18F0: btd_device_set_gatt_db (device.c:7110)
    by 0x1C9F96: foreach_rsi (set.c:295)
    by 0x1D5EBB: queue_foreach (queue.c:207)
    by 0x48EA91F: g_slist_foreach (in /usr/lib64/libglib-2.0.so.0.8000.3)
    by 0x1CA2C8: btd_set_add_device (set.c:357)
    by 0x1BB9AB: btd_device_add_set (device.c:2049)
    by 0x17FF76: csip_ready (csip.c:243)
    by 0x1FD5CC: csip_notify_ready (csip.c:546)
    by 0x1FD5CC: csip_idle (csip.c:630)
    by 0x1DE20C: idle_notify (gatt-client.c:171)
  Address 0xc is not stack'd, malloc'd or (recently) free'd
---
 src/shared/gatt-db.c | 3 +++
 1 file changed, 3 insertions(+)