### PR TITLE
[PW_SID:917564] [v1] obexctl: Enable Map folderlisting operation from obexctl

### DIFF
--- a/tools/obexctl.c
+++ b/tools/obexctl.c
@@ -1265,7 +1265,7 @@ static void map_ls_messages(GDBusProxy *proxy, int argc, char *argv[])
 
 static void map_ls(GDBusProxy *proxy, int argc, char *argv[])
 {
-	if (argc > 1) {
+	if (argc > 1 && strcmp(".", argv[1]) != 0) {
 		map_ls_messages(proxy, argc, argv);
 		return;
 	}


### PR DESCRIPTION
This change is required for passing below PTS testcase -

1) MAP/MCE/MMB/BV-01-C
Verify that the MCE can retrieve a Folders Listing on the MSE.

As of now, user is able to initiate only map messagelisting
operation with command 'ls' and there is no way to initiate
folder listing from obexctl.
Adding a way to initiate it with command "ls ."

---
 tools/obexctl.c | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)