### PR TITLE
[PW_SID:918257] [v2] obexctl: Enable Map folderlisting operation from obexctl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/tools/obexctl.c
+++ b/tools/obexctl.c
@@ -1873,7 +1873,7 @@ static const struct bt_shell_menu main_menu = {
 	{ "pull",	  "<file>",   cmd_pull,
 					"Pull Vobject & stores in file" },
 	{ "cd",           "<path>",   cmd_cd, "Change current folder" },
-	{ "ls",           "<options>", cmd_ls, "List current folder" },
+	{ "ls",           "[options]", cmd_ls, "List current folder" },
 	{ "cp",          "<source file> <destination file>",   cmd_cp,
 				"Copy source file to destination file" },
 	{ "mv",          "<source file> <destination file>",   cmd_mv,


### PR DESCRIPTION
This change is required for passing below PTS testcase -

1) MAP/MCE/MMB/BV-01-C
Verify that the MCE can retrieve a Folders Listing on the MSE.

As of now, user is able to initiate only map messagelisting
operation with command 'ls <folder_name>' and there is no way to initiate
folder listing with 'ls' command as second argument <options> is
set as compulsary.
In the obexctl code, map folderlisting gets triggered only when there is no
arguments followed by 'ls' command.
Therefore in 'ls' command, make the second argument as optional.

This change will also enable pbap vcard listing operation which also
gets triggered with 'ls' command with no args.

---
 tools/obexctl.c | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)