### PR TITLE
[PW_SID:919893] [v1] obexctl: Implement support for message listing format version 1.1 for MCE

### DIFF
--- a/tools/obexctl.c
+++ b/tools/obexctl.c
@@ -477,6 +477,11 @@ static void message_info(GDBusProxy *proxy, int argc, char *argv[])
 	print_property(proxy, "Deleted");
 	print_property(proxy, "Sent");
 	print_property(proxy, "Protected");
+	print_property(proxy, "DeliveryStatus");
+	print_property(proxy, "ConversationId");
+	print_property(proxy, "ConversationName");
+	print_property(proxy, "Direction");
+	print_property(proxy, "AttachmentMimeTypes");
 }
 
 static void cmd_info(int argc, char *argv[])


### PR DESCRIPTION
This change is corresponding to obexd changes done for implementing
‘Messages-Listing Format Version 1.1’ .
This change will emit the newly added properties values in obexctl
which are sent by server.

---
 tools/obexctl.c | 5 +++++
 1 file changed, 5 insertions(+)