### PR TITLE
[PW_SID:919894] [v1] Doc: Obex Implement support for message listing format version 1.1

### DIFF
--- a/doc/org.bluez.obex.Message.rst
+++ b/doc/org.bluez.obex.Message.rst
@@ -137,3 +137,42 @@ boolean Protected [readonly]
 ````````````````````````````
 
 	Message protected flag
+
+string DeliveryStatus [readonly]
+````````````````````````````````
+
+	Message delivery status
+
+	Possible values:
+
+	:"delivered":
+	:"sent":
+	:"unknown":
+
+uint64 ConversationId [readonly]
+````````````````````````````````
+
+	Message conversation id
+	Identification of the conversation
+
+string ConversationName [readonly]
+````````````````````````````````
+
+	Human readable name of the conversation
+
+string Direction [readonly]
+````````````````````````````````
+
+	Indicate the direction of the message
+
+	Possible values:
+
+	:"incoming":
+	:"outgoing":
+	:"outgoingdraft":
+	:"outgoingpending":
+
+string AttachmentMimeTypes [readonly]
+````````````````````````````````
+
+	MIME type of the attachment


### PR DESCRIPTION
Add the documentation for the ‘Messages-Listing Format Version 1.1’
feature for MCE.

---
 doc/org.bluez.obex.Message.rst | 39 ++++++++++++++++++++++++++++++++++
 1 file changed, 39 insertions(+)