### PR TITLE
[PW_SID:919917] bass: Handle Modify Source opcode

### DIFF
--- a/src/shared/bass.c
+++ b/src/shared/bass.c
@@ -1819,7 +1819,7 @@ int bt_bass_clear_bis_sync(struct bt_bcast_src *bcast_src, uint8_t bis)
 				&bcast_src->subgroup_data[i];
 		uint32_t bitmask = 1 << (bis - 1);
 
-		if (sgrp->pending_bis_sync & bitmask) {
+		if (sgrp->bis_sync & bitmask) {
 			sgrp->bis_sync &= ~bitmask;
 
 			iov = bass_parse_bcast_src(bcast_src);

--- a/src/shared/bass.c
+++ b/src/shared/bass.c
@@ -1781,6 +1781,16 @@ int bt_bass_set_pa_sync(struct bt_bcast_src *bcast_src, uint8_t sync_state)
 	return 0;
 }
 
+int bt_bass_get_pa_sync(struct bt_bcast_src *bcast_src, uint8_t *sync_state)
+{
+	if (!bcast_src)
+		return -EINVAL;
+
+	*sync_state = bcast_src->sync_state;
+
+	return 0;
+}
+
 int bt_bass_set_bis_sync(struct bt_bcast_src *bcast_src, uint8_t bis)
 {
 	struct iovec *iov;

--- a/src/shared/bass.h
+++ b/src/shared/bass.h
@@ -130,6 +130,7 @@ unsigned int bt_bass_cp_handler_register(struct bt_bass *bass,
 bool bt_bass_cp_handler_unregister(struct bt_bass *bass,
 				unsigned int id);
 int bt_bass_set_pa_sync(struct bt_bcast_src *bcast_src, uint8_t sync_state);
+int bt_bass_get_pa_sync(struct bt_bcast_src *bcast_src, uint8_t *sync_state);
 int bt_bass_set_bis_sync(struct bt_bcast_src *bcast_src, uint8_t bis);
 int bt_bass_clear_bis_sync(struct bt_bcast_src *bcast_src, uint8_t bis);
 bool bt_bass_check_bis(struct bt_bcast_src *bcast_src, uint8_t bis);


### PR DESCRIPTION
This fixes bt_bass_clear_bis_sync by checking the bitmask which contains
synced BIS indeces, instead of the mask holding pending BISes.
---
 src/shared/bass.c | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)