### PR TITLE
[PW_SID:920753] HID device connection issue fixed.

### DIFF
--- a/profiles/input/device.c
+++ b/profiles/input/device.c
@@ -89,7 +89,7 @@ struct input_device {
 };
 
 static int idle_timeout = 0;
-static uhid_state_t uhid_state = UHID_ENABLED;
+static uhid_state_t uhid_state = UHID_DISABLED;
 static bool classic_bonded_only = true;
 
 void input_set_idle_timeout(int timeout)


### PR DESCRIPTION
While connecting BT-HID device showing br-profile unavailable
and connection did not happen.
Steps followed:
	1. Pair Ref device
	2. Connect Ref device
With this patch HID device is able to connect and HID traffic
can be observed in btmon.
---
 profiles/input/device.c | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)