### PR TITLE
[PW_SID:922047] [BlueZ,v2] plugin: Order plugin init by priority

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -37,10 +37,10 @@ struct bluetooth_plugin {
 
 static int compare_priority(gconstpointer a, gconstpointer b)
 {
-	const struct bluetooth_plugin *plugin1 = a;
-	const struct bluetooth_plugin *plugin2 = b;
+	const struct bluetooth_plugin_desc *plugin1 = a;
+	const struct bluetooth_plugin_desc *plugin2 = b;
 
-	return plugin2->desc->priority - plugin1->desc->priority;
+	return plugin2->priority - plugin1->priority;
 }
 
 static int init_plugin(const struct bluetooth_plugin_desc *desc)
@@ -86,14 +86,15 @@ static gboolean add_external_plugin(void *handle,
 
 	__btd_enable_debug(desc->debug_start, desc->debug_stop);
 
-	plugins = g_slist_insert_sorted(plugins, plugin, compare_priority);
+	plugins = g_slist_append(plugins, plugin);
 	DBG("Plugin %s loaded", desc->name);
 
 	return TRUE;
 }
 
-static void add_plugin(const struct bluetooth_plugin_desc *desc)
+static void add_plugin(void *data, void *user_data)
 {
+	struct bluetooth_plugin_desc *desc = data;
 	struct bluetooth_plugin *plugin;
 
 	DBG("Loading %s plugin", desc->name);
@@ -109,7 +110,7 @@ static void add_plugin(const struct bluetooth_plugin_desc *desc)
 		return;
 	}
 
-	plugins = g_slist_insert_sorted(plugins, plugin, compare_priority);
+	plugins = g_slist_append(plugins, plugin);
 	DBG("Plugin %s loaded", desc->name);
 }
 
@@ -201,6 +202,7 @@ static void external_plugin_init(char **cli_disabled, char **cli_enabled)
 
 void plugin_init(const char *enable, const char *disable)
 {
+	GSList *builtins = NULL;
 	char **cli_disabled = NULL;
 	char **cli_enabled = NULL;
 	unsigned int i;
@@ -222,12 +224,16 @@ void plugin_init(const char *enable, const char *disable)
 								cli_disabled))
 			continue;
 
-		add_plugin(__bluetooth_builtin[i]);
+		builtins = g_slist_insert_sorted(builtins,
+			(void *) __bluetooth_builtin[i], compare_priority);
 	}
+
+	g_slist_foreach(builtins, add_plugin, NULL);
 
 	if IS_ENABLED(EXTERNAL_PLUGINS)
 		external_plugin_init(cli_enabled, cli_disabled);
 
+	g_slist_free(builtins);
 	g_strfreev(cli_enabled);
 	g_strfreev(cli_disabled);
 }


### PR DESCRIPTION
The init order matters for some plugins, e.g. wiimote
Add them to a sorted list before calling add_plugin
---
Cast has been removed and add_plugin is adjusted for g_slist_foreach

 src/plugin.c | 20 +++++++++++++-------
 1 file changed, 13 insertions(+), 7 deletions(-)