### PR TITLE
[PW_SID:922893] [v1] obexctl: Implement support for message listing format version 1.1 for MCE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/tools/obexctl.c
+++ b/tools/obexctl.c
@@ -477,6 +477,11 @@ static void message_info(GDBusProxy *proxy, int argc, char *argv[])
 	print_property(proxy, "Deleted");
 	print_property(proxy, "Sent");
 	print_property(proxy, "Protected");
+	print_property(proxy, "DeliveryStatus");
+	print_property(proxy, "ConversationId");
+	print_property(proxy, "ConversationName");
+	print_property(proxy, "Direction");
+	print_property(proxy, "AttachmentMimeTypes");
 }
 
 static void cmd_info(int argc, char *argv[])


### PR DESCRIPTION
This change is corresponding to obexd changes done for implementing
‘Messages-Listing Format Version 1.1’ .
This change will emit the newly added properties values in obexctl
which are sent by server.

---
 tools/obexctl.c | 5 +++++
 1 file changed, 5 insertions(+)