### PR TITLE
[PW_SID:924316] [BlueZ,v1] build: Fix --disable-asha

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -234,6 +234,9 @@ AM_CONDITIONAL(CSIP, test "${enable_csip}" != "no")
 AC_ARG_ENABLE(asha, AS_HELP_STRING([--disable-asha],
 		[disable ASHA support]), [enable_asha=${enableval}])
 AM_CONDITIONAL(ASHA, test "${enable_asha}" != "no")
+if test "${enable_asha}" != "no"; then
+	AC_DEFINE(HAVE_ASHA, 1, [Define to 1 if you have ASHA support.])
+fi
 
 AC_ARG_ENABLE(tools, AS_HELP_STRING([--disable-tools],
 		[disable Bluetooth tools]), [enable_tools=${enableval}])

--- a/profiles/audio/transport.c
+++ b/profiles/audio/transport.c
@@ -48,7 +48,10 @@
 #endif
 #endif
 
+#ifdef HAVE_ASHA
 #include "asha.h"
+#endif
+
 #include "media.h"
 #include "transport.h"
 #include "bass.h"
@@ -1555,6 +1558,7 @@ static const GDBusPropertyTable transport_bap_bc_properties[] = {
 	{ }
 };
 
+#ifdef HAVE_ASHA
 static gboolean get_asha_delay(const GDBusPropertyTable *property,
 					DBusMessageIter *iter, void *data)
 {
@@ -1580,6 +1584,7 @@ static const GDBusPropertyTable transport_asha_properties[] = {
 	{ "Volume", "q", get_volume, set_volume, volume_exists },
 	{ }
 };
+#endif /* HAVE_ASHA */
 
 #ifdef HAVE_A2DP
 static void transport_a2dp_destroy(void *data)
@@ -2210,6 +2215,7 @@ static void *transport_bap_init(struct media_transport *transport, void *stream)
 	return bap;
 }
 
+#ifdef HAVE_ASHA
 static void asha_transport_sync_state(struct media_transport *transport,
 						struct bt_asha_device *asha_dev)
 {
@@ -2367,6 +2373,7 @@ static void *transport_asha_init(struct media_transport *transport, void *data)
 	/* We just store the struct asha_device on the transport */
 	return data;
 }
+#endif /* HAVE_ASHA */
 
 #define TRANSPORT_OPS(_uuid, _props, _set_owner, _remove_owner, _init, \
 		      _resume, _suspend, _cancel, _set_state, _get_stream, \
@@ -2447,7 +2454,9 @@ static const struct media_transport_ops transport_ops[] = {
 	BAP_UC_OPS(PAC_SINK_UUID),
 	BAP_BC_OPS(BCAA_SERVICE_UUID),
 	BAP_BC_OPS(BAA_SERVICE_UUID),
+#ifdef HAVE_ASHA
 	ASHA_OPS(ASHA_PROFILE_UUID),
+#endif /* HAVE_ASHA */
 };
 
 static const struct media_transport_ops *


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

This fixes --disable-asha causing build errors:

/usr/bin/ld: profiles/audio/bluetoothd-transport.o: in function `transport_asha_set_volume':
/bluez/profiles/audio/transport.c:2362:(.text.transport_asha_set_volume+0x2f): undefined reference to `bt_asha_device_set_volume'
/usr/bin/ld: profiles/audio/bluetoothd-transport.o: in function `transport_asha_get_volume':
/bluez/profiles/audio/transport.c:2345:(.text.transport_asha_get_volume+0x9): undefined reference to `bt_asha_device_get_volume'
/usr/bin/ld: profiles/audio/bluetoothd-transport.o: in function `get_asha_delay':
/bluez/profiles/audio/transport.c:1566:(.text.get_asha_delay+0xd): undefined reference to `bt_asha_device_get_render_delay'
/usr/bin/ld: profiles/audio/bluetoothd-transport.o: in function `asha_transport_sync_state':
/bluez/profiles/audio/transport.c:2216:(.text.asha_transport_sync_state+0x8): undefined reference to `bt_asha_device_get_state'
/usr/bin/ld: profiles/audio/bluetoothd-transport.o: in function `asha_transport_state_cb':
/bluez/profiles/audio/transport.c:2245:(.text.asha_transport_state_cb+0x1d): undefined reference to `bt_asha_device_get_state'
/usr/bin/ld: /bluez/profiles/audio/transport.c:2252:(.text.asha_transport_state_cb+0x94): undefined reference to `bt_asha_device_get_fd'
/usr/bin/ld: /bluez/profiles/audio/transport.c:2253:(.text.asha_transport_state_cb+0xa0): undefined reference to `bt_asha_device_get_imtu'
/usr/bin/ld: /bluez/profiles/audio/transport.c:2254:(.text.asha_transport_state_cb+0xad): undefined reference to `bt_asha_device_get_omtu'
/usr/bin/ld: profiles/audio/bluetoothd-transport.o: in function `transport_asha_resume':
/bluez/profiles/audio/transport.c:2290:(.text.transport_asha_resume+0x19): undefined reference to `bt_asha_device_start'
/usr/bin/ld: profiles/audio/bluetoothd-transport.o: in function `transport_asha_suspend':
/bluez/profiles/audio/transport.c:2303:(.text.transport_asha_suspend+0x1e): undefined reference to `bt_asha_device_stop'
/usr/bin/ld: /bluez/profiles/audio/transport.c:2307:(.text.transport_asha_suspend+0x48): undefined reference to `bt_asha_device_stop'
/usr/bin/ld: profiles/audio/bluetoothd-transport.o: in function `transport_asha_cancel':
/bluez/profiles/audio/transport.c:2318:(.text.transport_asha_cancel+0x17): undefined reference to `bt_asha_device_get_state'
/usr/bin/ld: /bluez/profiles/audio/transport.c:2320:(.text.transport_asha_cancel+0x22): undefined reference to `bt_asha_device_device_get_resume_id'
/usr/bin/ld: /bluez/profiles/audio/transport.c:2334:(.text.transport_asha_cancel+0x61): undefined reference to `bt_asha_device_state_reset'
/usr/bin/ld: /bluez/profiles/audio/transport.c:2328:(.text.transport_asha_cancel+0x81): undefined reference to `bt_asha_device_stop'
collect2: error: ld returned 1 exit status
make[1]: *** [Makefile:6378: src/bluetoothd] Error 1
make: *** [Makefile:4696: all] Error 2
---
 configure.ac               | 3 +++
 profiles/audio/transport.c | 9 +++++++++
 2 files changed, 12 insertions(+)