### PR TITLE
[PW_SID:927176] [BlueZ,bluez] gatt: expand the max GATT Channels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/src/main.c
+++ b/src/main.c
@@ -1119,7 +1119,7 @@ static void parse_gatt(GKeyFile *config)
 	parse_config_u16(config, "GATT", "ExchangeMTU", &btd_opts.gatt_mtu,
 				BT_ATT_DEFAULT_LE_MTU, BT_ATT_MAX_LE_MTU);
 	parse_config_u8(config, "GATT", "Channels", &btd_opts.gatt_channels,
-				1, 5);
+				1, 10);
 	parse_config_bool(config, "GATT", "Client", &btd_opts.gatt_client);
 	parse_gatt_export(config);
 }

--- a/src/main.conf
+++ b/src/main.conf
@@ -264,7 +264,7 @@
 #ExchangeMTU = 517
 
 # Number of ATT channels
-# Possible values: 1-5 (1 disables EATT)
+# Possible values: 1-10 (1 disables EATT)
 # Default to 1
 #Channels = 1
 


### PR DESCRIPTION
From: Yang Li <yang.li@amlogic.com>

Fixed the problem that Xiaomi K70 mobile phone takes too long to
connect to CIS.

L2CAP CB Connection (PSM=0x0027, MTU=517 bytes, MPS=251 bytes,
 Credits=255, Src=0x0056 › All Connections Refused –
 Insufficient Authorization)

Ref https://github.com/bluez/bluez/issues/1033

Signed-off-by: Yang Li <yang.li@amlogic.com>
---
 src/main.c    | 2 +-
 src/main.conf | 2 +-
 2 files changed, 2 insertions(+), 2 deletions(-)


---
base-commit: 2ee08ffd4d469781dc627fa50b4a015d9ad68007
change-id: 20250121-upstream-fab070351ad3

Best regards,