### PR TITLE
[PW_SID:927510] device: Better "Connect" debug

### DIFF
--- a/Makefile.tools
+++ b/Makefile.tools
@@ -10,6 +10,8 @@ client_bluetoothctl_SOURCES = client/main.c \
 					client/advertising.c \
 					client/adv_monitor.h \
 					client/adv_monitor.c \
+					client/error.h \
+					client/error.c \
 					client/gatt.h client/gatt.c \
 					client/admin.h client/admin.c \
 					client/player.h client/player.c \

--- a/client/error.c
+++ b/client/error.c
@@ -1,0 +1,36 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ *
+ *  BlueZ - Bluetooth protocol stack for Linux
+ *
+ *  Copyright (C) 2025 Bastien Nocera <hadess@hadess.net>
+ *
+ *
+ */
+
+#include <stddef.h>
+#include <glib.h>
+#include "error.h"
+
+struct {
+	const char *error_code;
+	const char *str;
+} error_codes[] = {
+	{ "br-connection-profile-unavailable", "Exhausted the list of BR/EDR profiles to connect to" },
+	{ "br-connection-busy", "Cannot connect, connection busy" },
+	{ "br-connection-adapter-not-powered", "Cannot connect, adapter is not powered" },
+};
+
+const char *error_code_to_str(const char *error_code)
+{
+	unsigned int i;
+
+	if (error_code == NULL)
+		return NULL;
+
+	for (i = 0; i < G_N_ELEMENTS(error_codes); i++) {
+		if (g_str_equal(error_codes[i].error_code, error_code))
+			return error_codes[i].str;
+	}
+	return error_code;
+}

--- a/client/error.c
+++ b/client/error.c
@@ -19,6 +19,7 @@ struct {
 	{ "br-connection-profile-unavailable", "Exhausted the list of BR/EDR profiles to connect to" },
 	{ "br-connection-busy", "Cannot connect, connection busy" },
 	{ "br-connection-adapter-not-powered", "Cannot connect, adapter is not powered" },
+	{ "br-connection-page-timeout", "Device is unpowered or not in range" },
 };
 
 const char *error_code_to_str(const char *error_code)

--- a/client/error.h
+++ b/client/error.h
@@ -1,0 +1,11 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ *
+ *  BlueZ - Bluetooth protocol stack for Linux
+ *
+ *  Copyright (C) 2025 Bastien Nocera <hadess@hadess.net>
+ *
+ *
+ */
+
+const char *error_code_to_str(const char *error_code);

--- a/client/main.c
+++ b/client/main.c
@@ -30,6 +30,7 @@
 #include "gdbus/gdbus.h"
 #include "print.h"
 #include "agent.h"
+#include "error.h"
 #include "gatt.h"
 #include "advertising.h"
 #include "adv_monitor.h"
@@ -1977,8 +1978,8 @@ static void connect_reply(DBusMessage *message, void *user_data)
 	dbus_error_init(&error);
 
 	if (dbus_set_error_from_message(&error, message) == TRUE) {
-		bt_shell_printf("Failed to connect: %s %s\n", error.name,
-				error.message);
+		bt_shell_printf("Failed to connect: %s: %s\n", error.name,
+				error_code_to_str(error.message));
 		dbus_error_free(&error);
 		return bt_shell_noninteractive_quit(EXIT_FAILURE);
 	}

--- a/src/device.c
+++ b/src/device.c
@@ -2477,8 +2477,9 @@ static DBusMessage *connect_profiles(struct btd_device *dev, uint8_t bdaddr_type
 	DBG("%s %s, client %s", dev->path, uuid ? uuid : "(all)",
 						dbus_message_get_sender(msg));
 
-	if (dev->pending || dev->connect || dev->browse)
+	if (dev->pending || dev->connect || dev->browse) {
 		return btd_error_in_progress_str(msg, ERR_BREDR_CONN_BUSY);
+	}
 
 	if (!btd_adapter_get_powered(dev->adapter)) {
 		return btd_error_not_ready_str(msg,
@@ -2497,6 +2498,7 @@ static DBusMessage *connect_profiles(struct btd_device *dev, uint8_t bdaddr_type
 							"Connect") &&
 				find_service_with_state(dev->services,
 						BTD_SERVICE_STATE_CONNECTED)) {
+				DBG("Already connected to services");
 				return dbus_message_new_method_return(msg);
 			} else {
 				return btd_error_not_available_str(msg,
@@ -2509,8 +2511,10 @@ static DBusMessage *connect_profiles(struct btd_device *dev, uint8_t bdaddr_type
 
 	err = connect_next(dev);
 	if (err < 0) {
-		if (err == -EALREADY)
+		if (err == -EALREADY) {
+			DBG("Already connected");
 			return dbus_message_new_method_return(msg);
+		}
 		return btd_error_failed(msg,
 					btd_error_bredr_conn_from_errno(err));
 	}
@@ -2583,11 +2587,19 @@ static uint8_t select_conn_bearer(struct btd_device *dev)
 	return dev->bdaddr_type;
 }
 
+static const char *bdaddr_type_strs[] = {
+	"BR/EDR",
+	"LE public",
+	"LE random"
+};
+
 static DBusMessage *dev_connect(DBusConnection *conn, DBusMessage *msg,
 							void *user_data)
 {
 	struct btd_device *dev = user_data;
 	uint8_t bdaddr_type;
+
+	DBG("Calling \"Connect\" for device %s", dev->path);
 
 	if (dev->bredr_state.connected) {
 		/*
@@ -2596,20 +2608,30 @@ static DBusMessage *dev_connect(DBusConnection *conn, DBusMessage *msg,
 		 */
 		if (dev->bredr_state.svc_resolved &&
 			find_service_with_state(dev->services,
-						BTD_SERVICE_STATE_CONNECTED))
+						BTD_SERVICE_STATE_CONNECTED)) {
 			bdaddr_type = dev->bdaddr_type;
-		else
+			DBG("Selecting address type %s, as BR/EDR services are resolved "
+			    " and connected", bdaddr_type_strs[dev->bdaddr_type]);
+		} else {
 			bdaddr_type = BDADDR_BREDR;
-	} else if (dev->le_state.connected && dev->bredr)
+			DBG("Selecting address type BR/EDR, as services not resolved "
+			    "or not connected");
+		}
+	} else if (dev->le_state.connected && dev->bredr) {
 		bdaddr_type = BDADDR_BREDR;
-	else
+		DBG("Selecting address type BR/EDR, as LE already connected");
+	} else {
 		bdaddr_type = select_conn_bearer(dev);
+		DBG("Selecting address type %s", bdaddr_type_strs[dev->bdaddr_type]);
+	}
 
 	if (bdaddr_type != BDADDR_BREDR) {
 		int err;
 
-		if (dev->le_state.connected)
+		if (dev->le_state.connected) {
+			DBG("Device already connected through LE");
 			return dbus_message_new_method_return(msg);
+		}
 
 		btd_device_set_temporary(dev, false);
 


### PR DESCRIPTION
The D-Bus errors returned in a number of cases aren't in human-readable
form, but instead exist as "codes" (listed in src/error.h).

This new function will allow us to convert those to human-readable form.
---
 Makefile.tools |  2 ++
 client/error.c | 36 ++++++++++++++++++++++++++++++++++++
 client/error.h | 11 +++++++++++
 3 files changed, 49 insertions(+)
 create mode 100644 client/error.c
 create mode 100644 client/error.h