### PR TITLE
[PW_SID:927943] [BlueZ,v2,1/2] org.bluez.MediaTransport: Allow Volume property to follow profile range

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/doc/org.bluez.MediaTransport.rst
+++ b/doc/org.bluez.MediaTransport.rst
@@ -128,7 +128,8 @@ uint16 Volume [readwrite, optional]
 	Indicates volume level of the transport, this property is only writeable
 	when the transport was acquired by the sender.
 
-	Possible Values: 0-127
+	Possible Values: 0-127 (A2DP)
+			 0-255 (BAP)
 
 object Endpoint [readonly, optional, experimental]
 ``````````````````````````````````````````````````

--- a/profiles/audio/transport.c
+++ b/profiles/audio/transport.c
@@ -126,8 +126,8 @@ struct media_transport_ops {
 	void (*set_state)(struct media_transport *transport,
 				transport_state_t state);
 	void *(*get_stream)(struct media_transport *transport);
-	int8_t (*get_volume)(struct media_transport *transport);
-	int (*set_volume)(struct media_transport *transport, int8_t level);
+	uint8_t (*get_volume)(struct media_transport *transport);
+	int (*set_volume)(struct media_transport *transport, uint8_t level);
 	int (*set_delay)(struct media_transport *transport, uint16_t delay);
 	void (*update_links)(const struct media_transport *transport);
 	GDestroyNotify destroy;
@@ -616,7 +616,7 @@ static void transport_a2dp_remove_owner(struct media_transport *transport,
 	a2dp->cancel_resume = FALSE;
 }
 
-static int8_t transport_a2dp_get_volume(struct media_transport *transport)
+static uint8_t transport_a2dp_get_volume(struct media_transport *transport)
 {
 	struct a2dp_transport *a2dp = transport->data;
 	return a2dp->volume;
@@ -624,7 +624,7 @@ static int8_t transport_a2dp_get_volume(struct media_transport *transport)
 
 #ifdef HAVE_AVRCP
 static int transport_a2dp_src_set_volume(struct media_transport *transport,
-					int8_t level)
+					uint8_t level)
 {
 	struct a2dp_transport *a2dp = transport->data;
 
@@ -635,7 +635,7 @@ static int transport_a2dp_src_set_volume(struct media_transport *transport,
 }
 
 static int transport_a2dp_snk_set_volume(struct media_transport *transport,
-					int8_t level)
+					uint8_t level)
 {
 	struct a2dp_transport *a2dp = transport->data;
 	bool notify;
@@ -2190,13 +2190,13 @@ static void bap_connecting(struct bt_bap_stream *stream, bool state, int fd,
 	bap_update_links(transport);
 }
 
-static int8_t transport_bap_get_volume(struct media_transport *transport)
+static uint8_t transport_bap_get_volume(struct media_transport *transport)
 {
 	return bt_audio_vcp_get_volume(transport->device);
 }
 
 static int transport_bap_set_volume(struct media_transport *transport,
-								int8_t volume)
+								uint8_t volume)
 {
 	return bt_audio_vcp_set_volume(transport->device, volume) ? 0 : -EIO;
 }
@@ -2355,7 +2355,7 @@ static void transport_asha_cancel(struct media_transport *transport, guint id)
 	}
 }
 
-static int8_t transport_asha_get_volume(struct media_transport *transport)
+static uint8_t transport_asha_get_volume(struct media_transport *transport)
 {
 	struct bt_asha_device *asha_dev = transport->data;
 	int8_t volume;
@@ -2370,7 +2370,7 @@ static int8_t transport_asha_get_volume(struct media_transport *transport)
 }
 
 static int transport_asha_set_volume(struct media_transport *transport,
-								int8_t volume)
+							uint8_t volume)
 {
 	struct bt_asha_device *asha_dev = transport->data;
 	int scaled_volume;

--- a/profiles/audio/vcp.c
+++ b/profiles/audio/vcp.c
@@ -103,25 +103,12 @@ static bool match_data(const void *data, const void *match_data)
 	return vdata->vcp == vcp;
 }
 
-static int8_t scale_volume(uint8_t volume)
-{
-	/* Convert 0-255 to 0-127. */
-	return volume / 2;
-}
-
-static uint8_t unscale_volume(int8_t volume)
-{
-	/* Convert 0-127 to 0-255. */
-	return volume * 2;
-}
-
 static void vcp_volume_changed(struct bt_vcp *vcp, uint8_t volume)
 {
 	struct vcp_data *data = queue_find(sessions, match_data, vcp);
 
 	if (data)
-		media_transport_update_device_volume(data->device,
-						      scale_volume(volume));
+		media_transport_update_device_volume(data->device, volume);
 }
 
 static void vcp_data_add(struct vcp_data *data)
@@ -179,22 +166,22 @@ static void vcp_data_remove(struct vcp_data *data)
 	}
 }
 
-int8_t bt_audio_vcp_get_volume(struct btd_device *device)
+uint8_t bt_audio_vcp_get_volume(struct btd_device *device)
 {
 	struct vcp_data *data = queue_find(sessions, match_device, device);
 
 	if (data)
-		return scale_volume(bt_vcp_get_volume(data->vcp));
+		return bt_vcp_get_volume(data->vcp);
 
 	return 0;
 }
 
-bool bt_audio_vcp_set_volume(struct btd_device *device, int8_t volume)
+bool bt_audio_vcp_set_volume(struct btd_device *device, uint8_t volume)
 {
 	struct vcp_data *data = queue_find(sessions, match_device, device);
 
 	if (data)
-		return bt_vcp_set_volume(data->vcp, unscale_volume(volume));
+		return bt_vcp_set_volume(data->vcp, volume);
 
 	return FALSE;
 }

--- a/profiles/audio/vcp.h
+++ b/profiles/audio/vcp.h
@@ -8,5 +8,5 @@
  *
  */
 
-int8_t bt_audio_vcp_get_volume(struct btd_device *device);
-bool bt_audio_vcp_set_volume(struct btd_device *device, int8_t volume);
+uint8_t bt_audio_vcp_get_volume(struct btd_device *device);
+bool bt_audio_vcp_set_volume(struct btd_device *device, uint8_t volume);


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

This makes the Volume property to follow the profile defined range.
---
 doc/org.bluez.MediaTransport.rst | 3 ++-
 1 file changed, 2 insertions(+), 1 deletion(-)