### PR TITLE
[PW_SID:928111] [BlueZ] avrcp: Fix crash on remote player changed

### DIFF
--- a/profiles/audio/avrcp.c
+++ b/profiles/audio/avrcp.c
@@ -2661,6 +2661,11 @@ static gboolean avrcp_list_items_rsp(struct avctp *conn, uint8_t *operands,
 	size_t i;
 	int err = 0;
 
+	if (player->p == NULL) {
+		media_player_list_complete(player->user_data, NULL, -EINVAL);
+		return FALSE;
+	}
+
 	if (pdu == NULL) {
 		err = -ETIMEDOUT;
 		goto done;


### PR DESCRIPTION
bluetoothd crashes when the remote player changes while bluetoothd
is waiting for avrcp_list_items reply.

profiles/audio/player.c:1597:9: runtime error: member access within null pointer of type 'struct media_folder'
AddressSanitizer:DEADLYSIGNAL
=================================================================
==825871==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000020 (pc 0x602bb0fffabc bp 0x000000000020 sp 0x7ffef88216d0 T0)
==825871==The signal is caused by a READ memory access.
==825871==Hint: address points to the zero page.
    #0 0x602bb0fffabc in media_folder_find_item profiles/audio/player.c:1597
    #1 0x602bb100cd3b in media_folder_create_item profiles/audio/player.c:1877
    #2 0x602bb100cd3b in media_player_create_item profiles/audio/player.c:1928
    #3 0x602bb107eae6 in parse_media_element profiles/audio/avrcp.c:2605
    #4 0x602bb107eae6 in avrcp_list_items_rsp profiles/audio/avrcp.c:2706
    #5 0x602bb106892f in browsing_response profiles/audio/avctp.c:987
    #6 0x602bb106892f in session_browsing_cb profiles/audio/avctp.c:1028
    #7 0x73de85b1448d  (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x5d48d) (BuildId: 461eff2b4df472ba9c32b2358ae9ba018a59a8c5)
    #8 0x73de85b73716  (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0xbc716) (BuildId: 461eff2b4df472ba9c32b2358ae9ba018a59a8c5)
    #9 0x73de85b14f76 in g_main_loop_run (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x5df76) (BuildId: 461eff2b4df472ba9c32b2358ae9ba018a59a8c5)
    #10 0x602bb13a22a8 in mainloop_run src/shared/mainloop-glib.c:66
    #11 0x602bb13a2bb6 in mainloop_run_with_signal src/shared/mainloop-notify.c:189
    #12 0x602bb0fd0257 in main src/main.c:1544
    #13 0x73de84e2a1c9 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #14 0x73de84e2a28a in __libc_start_main_impl ../csu/libc-start.c:360
    #15 0x602bb0fd3124 in _start (/home/fdanis/src/bluez/src/bluetoothd+0x5c8124) (BuildId: 367892bd0501d74713dd7341977abfac1b2c5d6a)

This can be reproduced using bluetoothctl and doing "player.list-items"
just before switching music player on the remote device.

This commit discards the item list parsing if the current player has
not created a pending_list_items, i.e. it doesn't start this request.
---
 profiles/audio/avrcp.c | 5 +++++
 1 file changed, 5 insertions(+)