### PR TITLE
[PW_SID:928379] [BlueZ] shared/gatt-db: fix crash on bad attribute index

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/src/shared/gatt-db.c
+++ b/src/shared/gatt-db.c
@@ -1660,6 +1660,8 @@ gatt_db_attribute_get_value(struct gatt_db_attribute *attrib)
 
 	if (!bt_uuid_cmp(&characteristic_uuid, &attrib->uuid))
 		return service->attributes[index + 1];
+	else if (service->attributes[index - 1] == NULL)
+		return NULL;
 	else if (!bt_uuid_cmp(&characteristic_uuid,
 				&service->attributes[index - 1]->uuid))
 		return service->attributes[index];


### PR DESCRIPTION
In gatt_db_attribute_get_value(), avoid NULL pointer deref if attribute
or db is in unexpected state and attrib at index-1 is missing.

Fixes btmon -r crash, on a packet capture obtained with btmon -w after
clearing BlueZ attributes & cache for the device:

==208213==ERROR: AddressSanitizer: SEGV on unknown address 0x00000000000c
==208213==The signal is caused by a READ memory access.
==208213==Hint: address points to the zero page.
    #0 0x5af4a6 in bt_uuid_to_uuid128 lib/uuid.c:65
    #1 0x5afd54 in bt_uuid_cmp lib/uuid.c:118
    #2 0x5d0dd2 in gatt_db_attribute_get_value src/shared/gatt-db.c:1663
    #3 0x56aeab in print_value monitor/att.c:158
    #4 0x56b80f in print_attribute monitor/att.c:207
    #5 0x5982f7 in print_handle monitor/att.c:4417
    #6 0x59b1b8 in print_write monitor/att.c:4598
    #7 0x59b796 in att_write_req monitor/att.c:4627
    #8 0x59e91e in att_packet monitor/att.c:4918
    #9 0x4f4847 in l2cap_frame monitor/l2cap.c:2567
    #10 0x4f6022 in l2cap_packet monitor/l2cap.c:2708
    #11 0x4a48f6 in packet_hci_acldata monitor/packet.c:12606
    #12 0x43952a in packet_monitor monitor/packet.c:4247
    #13 0x4170c9 in control_reader monitor/control.c:1517
    #14 0x402f76 in main monitor/main.c:277
---
 src/shared/gatt-db.c | 2 ++
 1 file changed, 2 insertions(+)