### PR TITLE
[PW_SID:928598] [BlueZ,v1,1/3] org.bluez.LEAdvertisement: Add dedicated Scan Response field

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/client/advertising.c
+++ b/client/advertising.c
@@ -59,11 +59,13 @@ static struct ad {
 	uint16_t duration;
 	uint16_t timeout;
 	uint16_t discoverable_to;
-	char **uuids;
-	size_t uuids_len;
-	struct service_data service;
-	struct manufacturer_data manufacturer;
-	struct data data;
+	char **uuids[AD_TYPE_COUNT];
+	size_t uuids_len[AD_TYPE_COUNT];
+	char **solicit[AD_TYPE_COUNT];
+	size_t solicit_len[AD_TYPE_COUNT];
+	struct service_data service[AD_TYPE_COUNT];
+	struct manufacturer_data manufacturer[AD_TYPE_COUNT];
+	struct data data[AD_TYPE_COUNT];
 	bool discoverable;
 	bool tx_power;
 	bool name;
@@ -111,7 +113,7 @@ static void register_setup(DBusMessageIter *iter, void *user_data)
 	dbus_message_iter_close_container(iter, &dict);
 }
 
-static void print_uuid(const char *uuid)
+static void print_uuid(const char *prefix, const char *uuid)
 {
 	const char *text;
 
@@ -130,37 +132,70 @@ static void print_uuid(const char *uuid)
 				str[sizeof(str) - 4] = '.';
 		}
 
-		bt_shell_printf("UUID: %s(%s)\n", str, uuid);
+		bt_shell_printf("%s: %s(%s)\n", prefix, str, uuid);
 	} else
-		bt_shell_printf("UUID: (%s)\n", uuid ? uuid : "");
+		bt_shell_printf("%s: (%s)\n", prefix, uuid ? uuid : "");
 }
 
-static void print_ad_uuids(void)
+static const struct {
+	const char *uuid[AD_TYPE_COUNT];
+	const char *solicit[AD_TYPE_COUNT];
+	const char *service[AD_TYPE_COUNT];
+	const char *manufacturer[AD_TYPE_COUNT];
+	const char *data[AD_TYPE_COUNT];
+} ad_names = {
+	.uuid = { "UUID", "Scan Response UUID" },
+	.solicit = { "Solicit UUID", "Scan Response Solicit UUID" },
+	.service = { "UUID", "Scan Response UUID" },
+	.manufacturer = { "Manufacturer", "Scan Response Manufacturer" },
+	.data = { "Data", "Scan Response Data" }
+};
+
+static void print_ad_uuids(int type)
 {
 	char **uuid;
 
-	for (uuid = ad.uuids; uuid && *uuid; uuid++)
-		print_uuid(*uuid);
+	for (uuid = ad.uuids[type]; uuid && *uuid; uuid++)
+		print_uuid(ad_names.uuid[type], *uuid);
+}
+
+static void print_ad_solicit(int type)
+{
+	char **uuid;
+
+	for (uuid = ad.solicit[type]; uuid && *uuid; uuid++)
+		print_uuid(ad_names.solicit[type], *uuid);
 }
 
 static void print_ad(void)
 {
-	print_ad_uuids();
+	int type;
 
-	if (ad.service.uuid) {
-		print_uuid(ad.service.uuid);
-		bt_shell_hexdump(ad.service.data.data, ad.service.data.len);
-	}
+	for (type = AD_TYPE_AD; type <= AD_TYPE_SRD; type++) {
+		print_ad_uuids(type);
+		print_ad_solicit(type);
 
-	if (ad.manufacturer.data.len) {
-		bt_shell_printf("Manufacturer: %u\n", ad.manufacturer.id);
-		bt_shell_hexdump(ad.manufacturer.data.data,
-						ad.manufacturer.data.len);
-	}
+		if (ad.service[type].uuid) {
+			print_uuid(ad_names.service[type],
+					ad.service[type].uuid);
+			bt_shell_hexdump(ad.service[type].data.data,
+						ad.service[type].data.len);
+		}
 
-	if (ad.data.valid) {
-		bt_shell_printf("Data Type: 0x%02x\n", ad.data.type);
-		bt_shell_hexdump(ad.data.data.data, ad.data.data.len);
+		if (ad.manufacturer[type].data.len) {
+			bt_shell_printf("%s: %u\n", ad_names.manufacturer[type],
+						ad.manufacturer[type].id);
+			bt_shell_hexdump(ad.manufacturer[type].data.data,
+						ad.manufacturer[type].data.len);
+		}
+
+		if (ad.data[type].valid) {
+			bt_shell_printf("%s Type: 0x%02x\n",
+						ad_names.data[type],
+						ad.data[type].type);
+			bt_shell_hexdump(ad.data[type].data.data,
+						ad.data[type].data.len);
+		}
 	}
 
 	bt_shell_printf("Tx Power: %s\n", ad.tx_power ? "on" : "off");
@@ -228,12 +263,13 @@ static gboolean get_type(const GDBusPropertyTable *property,
 	return TRUE;
 }
 
-static gboolean uuids_exists(const GDBusPropertyTable *property, void *data)
+static gboolean uuids_exists(int type, const GDBusPropertyTable *property,
+								void *data)
 {
-	return ad.uuids_len != 0;
+	return ad.uuids_len[type] != 0;
 }
 
-static gboolean get_uuids(const GDBusPropertyTable *property,
+static gboolean get_uuids(int type, const GDBusPropertyTable *property,
 				DBusMessageIter *iter, void *user_data)
 {
 	DBusMessageIter array;
@@ -241,60 +277,178 @@ static gboolean get_uuids(const GDBusPropertyTable *property,
 
 	dbus_message_iter_open_container(iter, DBUS_TYPE_ARRAY, "as", &array);
 
-	for (i = 0; i < ad.uuids_len; i++)
+	for (i = 0; i < ad.uuids_len[type]; i++)
 		dbus_message_iter_append_basic(&array, DBUS_TYPE_STRING,
-							&ad.uuids[i]);
+						&ad.uuids[type][i]);
 
 	dbus_message_iter_close_container(iter, &array);
 
 	return TRUE;
 }
 
-static gboolean service_data_exists(const GDBusPropertyTable *property,
-								void *data)
+static gboolean ad_uuids_exists(const GDBusPropertyTable *property, void *data)
 {
-	return ad.service.uuid != NULL;
+	return uuids_exists(AD_TYPE_AD, property, data);
 }
 
-static gboolean get_service_data(const GDBusPropertyTable *property,
+static gboolean get_ad_uuids(const GDBusPropertyTable *property,
+				DBusMessageIter *iter, void *user_data)
+{
+	return get_uuids(AD_TYPE_AD, property, iter, user_data);
+}
+
+static gboolean sr_uuids_exists(const GDBusPropertyTable *property, void *data)
+{
+	return uuids_exists(AD_TYPE_SRD, property, data);
+}
+
+static gboolean get_sr_uuids(const GDBusPropertyTable *property,
+				DBusMessageIter *iter, void *user_data)
+{
+	return get_uuids(AD_TYPE_SRD, property, iter, user_data);
+}
+
+static gboolean solicit_uuids_exists(int type,
+				const GDBusPropertyTable *property, void *data)
+{
+	return ad.solicit_len[type] != 0;
+}
+
+static gboolean get_solicit_uuids(int type, const GDBusPropertyTable *property,
+				DBusMessageIter *iter, void *user_data)
+{
+	DBusMessageIter array;
+	size_t i;
+
+	dbus_message_iter_open_container(iter, DBUS_TYPE_ARRAY, "as", &array);
+
+	for (i = 0; i < ad.solicit_len[type]; i++)
+		dbus_message_iter_append_basic(&array, DBUS_TYPE_STRING,
+						&ad.solicit[type][i]);
+
+	dbus_message_iter_close_container(iter, &array);
+
+	return TRUE;
+}
+
+static gboolean ad_solicit_uuids_exists(const GDBusPropertyTable *property,
+								void *data)
+{
+	return solicit_uuids_exists(AD_TYPE_AD, property, data);
+}
+
+static gboolean get_ad_solicit_uuids(const GDBusPropertyTable *property,
+				DBusMessageIter *iter, void *user_data)
+{
+	return get_solicit_uuids(AD_TYPE_AD, property, iter, user_data);
+}
+
+static gboolean sr_solicit_uuids_exists(const GDBusPropertyTable *property,
+								void *data)
+{
+	return solicit_uuids_exists(AD_TYPE_SRD, property, data);
+}
+
+static gboolean get_sr_solicit_uuids(const GDBusPropertyTable *property,
+				DBusMessageIter *iter, void *user_data)
+{
+	return get_solicit_uuids(AD_TYPE_SRD, property, iter, user_data);
+}
+
+static gboolean service_data_exists(int type,
+				const GDBusPropertyTable *property, void *data)
+{
+	return ad.service[type].uuid != NULL;
+}
+
+static gboolean get_service_data(int type, const GDBusPropertyTable *property,
 				DBusMessageIter *iter, void *user_data)
 {
 	DBusMessageIter dict;
-	struct ad_data *data = &ad.service.data;
+	struct ad_data *data = &ad.service[type].data;
 	uint8_t *val = data->data;
 
 	dbus_message_iter_open_container(iter, DBUS_TYPE_ARRAY, "{sv}", &dict);
 
-	g_dbus_dict_append_array(&dict, ad.service.uuid, DBUS_TYPE_BYTE, &val,
-								data->len);
+	g_dbus_dict_append_array(&dict, ad.service[type].uuid, DBUS_TYPE_BYTE,
+							&val, data->len);
 
 	dbus_message_iter_close_container(iter, &dict);
 
 	return TRUE;
 }
 
-static gboolean manufacturer_data_exists(const GDBusPropertyTable *property,
+static gboolean ad_service_data_exists(const GDBusPropertyTable *property,
 								void *data)
 {
-	return ad.manufacturer.id != 0;
+	return service_data_exists(AD_TYPE_AD, property, data);
 }
 
-static gboolean get_manufacturer_data(const GDBusPropertyTable *property,
-					DBusMessageIter *iter, void *user_data)
+static gboolean get_ad_service_data(const GDBusPropertyTable *property,
+				DBusMessageIter *iter, void *user_data)
+{
+	return get_service_data(AD_TYPE_AD, property, iter, user_data);
+}
+
+static gboolean sr_service_data_exists(const GDBusPropertyTable *property,
+								void *data)
+{
+	return service_data_exists(AD_TYPE_SRD, property, data);
+}
+
+static gboolean get_sr_service_data(const GDBusPropertyTable *property,
+				DBusMessageIter *iter, void *user_data)
+{
+	return get_service_data(AD_TYPE_SRD, property, iter, user_data);
+}
+
+static gboolean manufacturer_data_exists(int type,
+				const GDBusPropertyTable *property, void *data)
+{
+	return ad.manufacturer[type].id != 0;
+}
+
+static gboolean get_manufacturer_data(int type,
+				const GDBusPropertyTable *property,
+				DBusMessageIter *iter, void *user_data)
 {
 	DBusMessageIter dict;
-	struct ad_data *data = &ad.manufacturer.data;
+	struct ad_data *data = &ad.manufacturer[type].data;
 	uint8_t *val = data->data;
 
 	dbus_message_iter_open_container(iter, DBUS_TYPE_ARRAY, "{qv}", &dict);
 
 	g_dbus_dict_append_basic_array(&dict, DBUS_TYPE_UINT16,
-					&ad.manufacturer.id,
+					&ad.manufacturer[type].id,
 					DBUS_TYPE_BYTE, &val, data->len);
 
 	dbus_message_iter_close_container(iter, &dict);
 
 	return TRUE;
+}
+
+static gboolean ad_manufacturer_data_exists(const GDBusPropertyTable *property,
+								void *data)
+{
+	return manufacturer_data_exists(AD_TYPE_AD, property, data);
+}
+
+static gboolean get_ad_manufacturer_data(const GDBusPropertyTable *property,
+					DBusMessageIter *iter, void *user_data)
+{
+	return get_manufacturer_data(AD_TYPE_AD, property, iter, user_data);
+}
+
+static gboolean sr_manufacturer_data_exists(const GDBusPropertyTable *property,
+								void *data)
+{
+	return manufacturer_data_exists(AD_TYPE_SRD, property, data);
+}
+
+static gboolean get_sr_manufacturer_data(const GDBusPropertyTable *property,
+					DBusMessageIter *iter, void *user_data)
+{
+	return get_manufacturer_data(AD_TYPE_SRD, property, iter, user_data);
 }
 
 static gboolean includes_exists(const GDBusPropertyTable *property, void *data)
@@ -394,26 +548,49 @@ static gboolean get_timeout(const GDBusPropertyTable *property,
 	return TRUE;
 }
 
-static gboolean data_exists(const GDBusPropertyTable *property, void *data)
+static gboolean data_exists(int type, const GDBusPropertyTable *property,
+								void *data)
 {
-	return ad.data.valid;
+	return ad.data[type].valid;
 }
 
-static gboolean get_data(const GDBusPropertyTable *property,
+static gboolean get_data(int type, const GDBusPropertyTable *property,
 					DBusMessageIter *iter, void *user_data)
 {
 	DBusMessageIter dict;
-	struct ad_data *data = &ad.data.data;
+	struct ad_data *data = &ad.data[type].data;
 	uint8_t *val = data->data;
 
 	dbus_message_iter_open_container(iter, DBUS_TYPE_ARRAY, "{yv}", &dict);
 
-	g_dbus_dict_append_basic_array(&dict, DBUS_TYPE_BYTE, &ad.data.type,
-					DBUS_TYPE_BYTE, &val, data->len);
+	g_dbus_dict_append_basic_array(&dict, DBUS_TYPE_BYTE,
+			&ad.data[type].type, DBUS_TYPE_BYTE, &val, data->len);
 
 	dbus_message_iter_close_container(iter, &dict);
 
 	return TRUE;
+}
+
+static gboolean ad_data_exists(const GDBusPropertyTable *property, void *data)
+{
+	return data_exists(AD_TYPE_AD, property, data);
+}
+
+static gboolean get_ad_data(const GDBusPropertyTable *property,
+					DBusMessageIter *iter, void *user_data)
+{
+	return get_data(AD_TYPE_AD, property, iter, user_data);
+}
+
+static gboolean sr_data_exists(const GDBusPropertyTable *property, void *data)
+{
+	return data_exists(AD_TYPE_SRD, property, data);
+}
+
+static gboolean get_sr_data(const GDBusPropertyTable *property,
+					DBusMessageIter *iter, void *user_data)
+{
+	return get_data(AD_TYPE_SRD, property, iter, user_data);
 }
 
 static gboolean get_discoverable(const GDBusPropertyTable *property,
@@ -487,11 +664,23 @@ static gboolean get_max_interval(const GDBusPropertyTable *property,
 
 static const GDBusPropertyTable ad_props[] = {
 	{ "Type", "s", get_type },
-	{ "ServiceUUIDs", "as", get_uuids, NULL, uuids_exists },
-	{ "ServiceData", "a{sv}", get_service_data, NULL, service_data_exists },
-	{ "ManufacturerData", "a{qv}", get_manufacturer_data, NULL,
-						manufacturer_data_exists },
-	{ "Data", "a{yv}", get_data, NULL, data_exists },
+	{ "ServiceUUIDs", "as", get_ad_uuids, NULL, ad_uuids_exists },
+	{ "SolicitUUIDs", "as", get_ad_solicit_uuids, NULL,
+						ad_solicit_uuids_exists },
+	{ "ServiceData", "a{sv}", get_ad_service_data, NULL,
+						ad_service_data_exists },
+	{ "ManufacturerData", "a{qv}", get_ad_manufacturer_data, NULL,
+						ad_manufacturer_data_exists },
+	{ "Data", "a{yv}", get_ad_data, NULL, ad_data_exists },
+	{ "ScanResponseServiceUUIDs", "as", get_sr_uuids, NULL,
+						sr_uuids_exists },
+	{ "ScanResponseSolicitUUIDs", "as", get_sr_solicit_uuids, NULL,
+						sr_solicit_uuids_exists },
+	{ "ScanResponseServiceData", "a{sv}", get_sr_service_data, NULL,
+						sr_service_data_exists },
+	{ "ScanResponseManufacturerData", "a{qv}", get_sr_manufacturer_data,
+					NULL, sr_manufacturer_data_exists },
+	{ "ScanResponseData", "a{yv}", get_sr_data, NULL, sr_data_exists },
 	{ "Discoverable", "b", get_discoverable, NULL, NULL },
 	{ "DiscoverableTimeout", "q", get_discoverable_timeout, NULL,
 						discoverable_timeout_exists },
@@ -582,50 +771,109 @@ void ad_unregister(DBusConnection *conn, GDBusProxy *manager)
 	}
 }
 
-static void ad_clear_uuids(void)
+static const struct {
+	const char *uuid[AD_TYPE_COUNT];
+	const char *solicit[AD_TYPE_COUNT];
+	const char *service[AD_TYPE_COUNT];
+	const char *manufacturer[AD_TYPE_COUNT];
+	const char *data[AD_TYPE_COUNT];
+} prop_names = {
+	.uuid = { "ServiceUUIDs", "ScanResponseServiceUUIDs" },
+	.solicit = { "SolicitUUIDs", "ScanResponseSolicitUUIDs" },
+	.service = { "ServiceData", "ScanResponseServiceData" },
+	.manufacturer = { "ManufacturerData", "ScanResponseManufacturerData" },
+	.data = { "Data", "ScanResponseData" }
+};
+
+static void ad_clear_uuids(int type)
 {
-	g_strfreev(ad.uuids);
-	ad.uuids = NULL;
-	ad.uuids_len = 0;
+	g_strfreev(ad.uuids[type]);
+	ad.uuids[type] = NULL;
+	ad.uuids_len[type] = 0;
 }
 
-void ad_advertise_uuids(DBusConnection *conn, int argc, char *argv[])
+void ad_advertise_uuids(DBusConnection *conn, int type, int argc, char *argv[])
 {
 	if (argc < 2 || !strlen(argv[1])) {
-		print_ad_uuids();
+		print_ad_uuids(type);
 		return bt_shell_noninteractive_quit(EXIT_SUCCESS);
 	}
 
-	ad_clear_uuids();
+	ad_clear_uuids(type);
 
-	ad.uuids = g_strdupv(&argv[1]);
-	if (!ad.uuids) {
+	ad.uuids[type] = g_strdupv(&argv[1]);
+	if (!ad.uuids[type]) {
 		bt_shell_printf("Failed to parse input\n");
 		return bt_shell_noninteractive_quit(EXIT_FAILURE);
 	}
 
-	ad.uuids_len = g_strv_length(ad.uuids);
+	ad.uuids_len[type] = g_strv_length(ad.uuids[type]);
 
-	g_dbus_emit_property_changed(conn, AD_PATH, AD_IFACE, "ServiceUUIDs");
+	g_dbus_emit_property_changed(conn, AD_PATH, AD_IFACE,
+							prop_names.uuid[type]);
 
 	return bt_shell_noninteractive_quit(EXIT_SUCCESS);
 }
 
-void ad_disable_uuids(DBusConnection *conn)
+void ad_disable_uuids(DBusConnection *conn, int type)
 {
-	if (!ad.uuids)
+	if (!ad.uuids[type])
 		return bt_shell_noninteractive_quit(EXIT_SUCCESS);
 
-	ad_clear_uuids();
-	g_dbus_emit_property_changed(conn, AD_PATH, AD_IFACE, "ServiceUUIDs");
+	ad_clear_uuids(type);
+	g_dbus_emit_property_changed(conn, AD_PATH, AD_IFACE,
+							prop_names.uuid[type]);
 
 	return bt_shell_noninteractive_quit(EXIT_SUCCESS);
 }
 
-static void ad_clear_service(void)
+static void ad_clear_solicit(int type)
 {
-	g_free(ad.service.uuid);
-	memset(&ad.service, 0, sizeof(ad.service));
+	g_strfreev(ad.solicit[type]);
+	ad.solicit[type] = NULL;
+	ad.solicit_len[type] = 0;
+}
+
+void ad_advertise_solicit(DBusConnection *conn, int type,
+							int argc, char *argv[])
+{
+	if (argc < 2 || !strlen(argv[1])) {
+		print_ad_solicit(type);
+		return bt_shell_noninteractive_quit(EXIT_SUCCESS);
+	}
+
+	ad_clear_solicit(type);
+
+	ad.solicit[type] = g_strdupv(&argv[1]);
+	if (!ad.solicit[type]) {
+		bt_shell_printf("Failed to parse input\n");
+		return bt_shell_noninteractive_quit(EXIT_FAILURE);
+	}
+
+	ad.solicit_len[type] = g_strv_length(ad.solicit[type]);
+
+	g_dbus_emit_property_changed(conn, AD_PATH, AD_IFACE,
+						prop_names.solicit[type]);
+
+	return bt_shell_noninteractive_quit(EXIT_SUCCESS);
+}
+
+void ad_disable_solicit(DBusConnection *conn, int type)
+{
+	if (!ad.solicit[type])
+		return bt_shell_noninteractive_quit(EXIT_SUCCESS);
+
+	ad_clear_solicit(type);
+	g_dbus_emit_property_changed(conn, AD_PATH, AD_IFACE,
+						prop_names.solicit[type]);
+
+	return bt_shell_noninteractive_quit(EXIT_SUCCESS);
+}
+
+static void ad_clear_service(int type)
+{
+	g_free(ad.service[type].uuid);
+	memset(&ad.service[type], 0, sizeof(ad.service[type]));
 
 	return bt_shell_noninteractive_quit(EXIT_SUCCESS);
 }
@@ -658,15 +906,17 @@ static bool ad_add_data(struct ad_data *data, int argc, char *argv[])
 	return true;
 }
 
-void ad_advertise_service(DBusConnection *conn, int argc, char *argv[])
+void ad_advertise_service(DBusConnection *conn, int type,
+							int argc, char *argv[])
 {
 	struct ad_data data;
 
 	if (argc < 2 || !strlen(argv[1])) {
-		if (ad.service.uuid) {
-			print_uuid(ad.service.uuid);
-			bt_shell_hexdump(ad.service.data.data,
-						ad.service.data.len);
+		if (ad.service[type].uuid) {
+			print_uuid(ad_names.service[type],
+						ad.service[type].uuid);
+			bt_shell_hexdump(ad.service[type].data.data,
+						ad.service[type].data.len);
 		}
 		return bt_shell_noninteractive_quit(EXIT_SUCCESS);
 	}
@@ -674,46 +924,49 @@ void ad_advertise_service(DBusConnection *conn, int argc, char *argv[])
 	if (!ad_add_data(&data, argc - 2, argv + 2))
 		return bt_shell_noninteractive_quit(EXIT_FAILURE);
 
-	ad_clear_service();
+	ad_clear_service(type);
 
-	ad.service.uuid = g_strdup(argv[1]);
-	ad.service.data = data;
+	ad.service[type].uuid = g_strdup(argv[1]);
+	ad.service[type].data = data;
 
-	g_dbus_emit_property_changed(conn, AD_PATH, AD_IFACE, "ServiceData");
+	g_dbus_emit_property_changed(conn, AD_PATH, AD_IFACE,
+						prop_names.service[type]);
 
 	return bt_shell_noninteractive_quit(EXIT_SUCCESS);
 }
 
-void ad_disable_service(DBusConnection *conn)
+void ad_disable_service(DBusConnection *conn, int type)
 {
-	if (!ad.service.uuid)
+	if (!ad.service[type].uuid)
 		return bt_shell_noninteractive_quit(EXIT_SUCCESS);
 
-	ad_clear_service();
-	g_dbus_emit_property_changed(conn, AD_PATH, AD_IFACE, "ServiceData");
+	ad_clear_service(type);
+	g_dbus_emit_property_changed(conn, AD_PATH, AD_IFACE,
+						prop_names.service[type]);
 
 	return bt_shell_noninteractive_quit(EXIT_SUCCESS);
 }
 
-static void ad_clear_manufacturer(void)
+static void ad_clear_manufacturer(int type)
 {
-	memset(&ad.manufacturer, 0, sizeof(ad.manufacturer));
+	memset(&ad.manufacturer[type], 0, sizeof(ad.manufacturer[type]));
 
 	return bt_shell_noninteractive_quit(EXIT_SUCCESS);
 }
 
-void ad_advertise_manufacturer(DBusConnection *conn, int argc, char *argv[])
+void ad_advertise_manufacturer(DBusConnection *conn, int type,
+							int argc, char *argv[])
 {
 	char *endptr = NULL;
 	long int val;
 	struct ad_data data;
 
 	if (argc < 2 || !strlen(argv[1])) {
-		if (ad.manufacturer.data.len) {
-			bt_shell_printf("Manufacturer: %u\n",
-						ad.manufacturer.id);
-			bt_shell_hexdump(ad.manufacturer.data.data,
-						ad.manufacturer.data.len);
+		if (ad.manufacturer[type].data.len) {
+			bt_shell_printf("%s: %u\n", ad_names.manufacturer[type],
+						ad.manufacturer[type].id);
+			bt_shell_hexdump(ad.manufacturer[type].data.data,
+						ad.manufacturer[type].data.len);
 		}
 
 		return bt_shell_noninteractive_quit(EXIT_SUCCESS);
@@ -728,45 +981,48 @@ void ad_advertise_manufacturer(DBusConnection *conn, int argc, char *argv[])
 	if (!ad_add_data(&data, argc - 2, argv + 2))
 		return bt_shell_noninteractive_quit(EXIT_FAILURE);
 
-	ad_clear_manufacturer();
-	ad.manufacturer.id = val;
-	ad.manufacturer.data = data;
+	ad_clear_manufacturer(type);
+	ad.manufacturer[type].id = val;
+	ad.manufacturer[type].data = data;
 
 	g_dbus_emit_property_changed(conn, AD_PATH, AD_IFACE,
-							"ManufacturerData");
+						prop_names.manufacturer[type]);
 
 	return bt_shell_noninteractive_quit(EXIT_SUCCESS);
 }
 
-void ad_disable_manufacturer(DBusConnection *conn)
+void ad_disable_manufacturer(DBusConnection *conn, int type)
 {
-	if (!ad.manufacturer.id && !ad.manufacturer.data.len)
+	if (!ad.manufacturer[type].id && !ad.manufacturer[type].data.len)
 		return bt_shell_noninteractive_quit(EXIT_SUCCESS);
 
-	ad_clear_manufacturer();
+	ad_clear_manufacturer(type);
 	g_dbus_emit_property_changed(conn, AD_PATH, AD_IFACE,
-							"ManufacturerData");
+						prop_names.manufacturer[type]);
 
 	return bt_shell_noninteractive_quit(EXIT_SUCCESS);
 }
 
-static void ad_clear_data(void)
+static void ad_clear_data(int type)
 {
-	memset(&ad.data, 0, sizeof(ad.data));
+	memset(&ad.data[type], 0, sizeof(ad.data[type]));
 
 	return bt_shell_noninteractive_quit(EXIT_SUCCESS);
 }
 
-void ad_advertise_data(DBusConnection *conn, int argc, char *argv[])
+void ad_advertise_data(DBusConnection *conn, int type, int argc, char *argv[])
 {
 	char *endptr = NULL;
 	long int val;
 	struct ad_data data;
 
 	if (argc < 2 || !strlen(argv[1])) {
-		if (ad.data.data.len) {
-			bt_shell_printf("Type: 0x%02x\n", ad.data.type);
-			bt_shell_hexdump(ad.data.data.data, ad.data.data.len);
+		if (ad.data[type].data.len) {
+			bt_shell_printf("%s Type: 0x%02x\n",
+							ad_names.data[type],
+							ad.data[type].type);
+			bt_shell_hexdump(ad.data[type].data.data,
+							ad.data[type].data.len);
 		}
 
 		return bt_shell_noninteractive_quit(EXIT_SUCCESS);
@@ -781,23 +1037,25 @@ void ad_advertise_data(DBusConnection *conn, int argc, char *argv[])
 	if (!ad_add_data(&data, argc - 2, argv + 2))
 		return bt_shell_noninteractive_quit(EXIT_FAILURE);
 
-	ad_clear_data();
-	ad.data.valid = true;
-	ad.data.type = val;
-	ad.data.data = data;
+	ad_clear_data(type);
+	ad.data[type].valid = true;
+	ad.data[type].type = val;
+	ad.data[type].data = data;
 
-	g_dbus_emit_property_changed(conn, AD_PATH, AD_IFACE, "Data");
+	g_dbus_emit_property_changed(conn, AD_PATH, AD_IFACE,
+							prop_names.data[type]);
 
 	return bt_shell_noninteractive_quit(EXIT_SUCCESS);
 }
 
-void ad_disable_data(DBusConnection *conn)
+void ad_disable_data(DBusConnection *conn, int type)
 {
-	if (!ad.data.type && !ad.data.data.len)
+	if (!ad.data[type].type && !ad.data[type].data.len)
 		return bt_shell_noninteractive_quit(EXIT_SUCCESS);
 
-	ad_clear_data();
-	g_dbus_emit_property_changed(conn, AD_PATH, AD_IFACE, "Data");
+	ad_clear_data(type);
+	g_dbus_emit_property_changed(conn, AD_PATH, AD_IFACE,
+							prop_names.data[type]);
 
 	return bt_shell_noninteractive_quit(EXIT_SUCCESS);
 }

--- a/client/advertising.h
+++ b/client/advertising.h
@@ -8,15 +8,24 @@
  *
  */
 
+#define AD_TYPE_AD	0
+#define AD_TYPE_SRD	1
+#define AD_TYPE_COUNT	2
+
 void ad_register(DBusConnection *conn, GDBusProxy *manager, const char *type);
 void ad_unregister(DBusConnection *conn, GDBusProxy *manager);
 
-void ad_advertise_uuids(DBusConnection *conn, int argc, char *argv[]);
-void ad_disable_uuids(DBusConnection *conn);
-void ad_advertise_service(DBusConnection *conn, int argc, char *argv[]);
-void ad_disable_service(DBusConnection *conn);
-void ad_advertise_manufacturer(DBusConnection *conn, int argc, char *argv[]);
-void ad_disable_manufacturer(DBusConnection *conn);
+void ad_advertise_uuids(DBusConnection *conn, int type, int argc, char *argv[]);
+void ad_disable_uuids(DBusConnection *conn, int type);
+void ad_advertise_solicit(DBusConnection *conn, int type,
+							int argc, char *argv[]);
+void ad_disable_solicit(DBusConnection *conn, int type);
+void ad_advertise_service(DBusConnection *conn, int type,
+							int argc, char *argv[]);
+void ad_disable_service(DBusConnection *conn, int type);
+void ad_advertise_manufacturer(DBusConnection *conn, int type,
+							int argc, char *argv[]);
+void ad_disable_manufacturer(DBusConnection *conn, int type);
 void ad_advertise_tx_power(DBusConnection *conn, dbus_bool_t *value);
 void ad_advertise_name(DBusConnection *conn, bool value);
 void ad_advertise_appearance(DBusConnection *conn, bool value);
@@ -24,8 +33,8 @@ void ad_advertise_local_name(DBusConnection *conn, const char *name);
 void ad_advertise_local_appearance(DBusConnection *conn, long int *value);
 void ad_advertise_duration(DBusConnection *conn, long int *value);
 void ad_advertise_timeout(DBusConnection *conn, long int *value);
-void ad_advertise_data(DBusConnection *conn, int argc, char *argv[]);
-void ad_disable_data(DBusConnection *conn);
+void ad_advertise_data(DBusConnection *conn, int type, int argc, char *argv[]);
+void ad_disable_data(DBusConnection *conn, int type);
 void ad_advertise_discoverable(DBusConnection *conn, dbus_bool_t *value);
 void ad_advertise_discoverable_timeout(DBusConnection *conn, long int *value);
 void ad_advertise_secondary(DBusConnection *conn, const char *value);

--- a/client/bluetoothctl-advertise.rst
+++ b/client/bluetoothctl-advertise.rst
@@ -31,6 +31,12 @@ Set/Get advertise uuids.
 :Example: **> uuids 0x12345678**
 :Example: **> uuids 90f95193-35de-4306-a6e9-699328f15059**
 
+solicit
+-------
+
+Set/Get advertise solicit uuids.
+:Usage: **# solicit [all/uuid1 uuid2 ...]**
+
 service
 -------
 
@@ -70,6 +76,39 @@ To get the currently set data use the command data without any arguments.
 
 :Usage: **> data [type] [data=xx xx ...]**
 :Example: **> data 0x0C 01 0x0F 13**
+
+sr-uuids
+--------
+
+Set/Get scan response uuids.
+
+:Usage: **# sr-uuids [all/uuid1 uuid2 ...]**
+
+sr-solicit
+----------
+
+Set/Get scan response solicit uuids.
+:Usage: **# sr-solicit [all/uuid1 uuid2 ...]**
+
+sr-service
+----------
+
+Set/Get scan response service data.
+
+:Usage: **# sr-service [uuid] [data=xx xx ...]**
+
+sr-manufacturer
+---------------
+
+Set/Get scan response manufacturer data.
+
+:Usage: **# sr-manufacturer [id] [data=xx xx ...]**
+
+sr-data
+-------
+
+Set/Get scan response data.
+:Usage: **# sr-data [type] [data=xx xx ...]**
 
 discoverable
 ------------

--- a/client/main.c
+++ b/client/main.c
@@ -2575,22 +2575,52 @@ static char *ad_generator(const char *text, int state)
 
 static void cmd_advertise_uuids(int argc, char *argv[])
 {
-	ad_advertise_uuids(dbus_conn, argc, argv);
+	ad_advertise_uuids(dbus_conn, AD_TYPE_AD, argc, argv);
+}
+
+static void cmd_advertise_solicit(int argc, char *argv[])
+{
+	ad_advertise_solicit(dbus_conn, AD_TYPE_AD, argc, argv);
 }
 
 static void cmd_advertise_service(int argc, char *argv[])
 {
-	ad_advertise_service(dbus_conn, argc, argv);
+	ad_advertise_service(dbus_conn, AD_TYPE_AD, argc, argv);
 }
 
 static void cmd_advertise_manufacturer(int argc, char *argv[])
 {
-	ad_advertise_manufacturer(dbus_conn, argc, argv);
+	ad_advertise_manufacturer(dbus_conn, AD_TYPE_AD, argc, argv);
 }
 
 static void cmd_advertise_data(int argc, char *argv[])
 {
-	ad_advertise_data(dbus_conn, argc, argv);
+	ad_advertise_data(dbus_conn, AD_TYPE_AD, argc, argv);
+}
+
+static void cmd_advertise_sr_uuids(int argc, char *argv[])
+{
+	ad_advertise_uuids(dbus_conn, AD_TYPE_SRD, argc, argv);
+}
+
+static void cmd_advertise_sr_solicit(int argc, char *argv[])
+{
+	ad_advertise_solicit(dbus_conn, AD_TYPE_SRD, argc, argv);
+}
+
+static void cmd_advertise_sr_service(int argc, char *argv[])
+{
+	ad_advertise_service(dbus_conn, AD_TYPE_SRD, argc, argv);
+}
+
+static void cmd_advertise_sr_manufacturer(int argc, char *argv[])
+{
+	ad_advertise_manufacturer(dbus_conn, AD_TYPE_SRD, argc, argv);
+}
+
+static void cmd_advertise_sr_data(int argc, char *argv[])
+{
+	ad_advertise_data(dbus_conn, AD_TYPE_SRD, argc, argv);
 }
 
 static void cmd_advertise_discoverable(int argc, char *argv[])
@@ -2790,22 +2820,52 @@ static void cmd_advertise_rsi(int argc, char *argv[])
 
 static void ad_clear_uuids(void)
 {
-	ad_disable_uuids(dbus_conn);
+	ad_disable_uuids(dbus_conn, AD_TYPE_AD);
+}
+
+static void ad_clear_solicit(void)
+{
+	ad_disable_solicit(dbus_conn, AD_TYPE_AD);
 }
 
 static void ad_clear_service(void)
 {
-	ad_disable_service(dbus_conn);
+	ad_disable_service(dbus_conn, AD_TYPE_AD);
 }
 
 static void ad_clear_manufacturer(void)
 {
-	ad_disable_manufacturer(dbus_conn);
+	ad_disable_manufacturer(dbus_conn, AD_TYPE_AD);
 }
 
 static void ad_clear_data(void)
 {
-	ad_disable_data(dbus_conn);
+	ad_disable_data(dbus_conn, AD_TYPE_AD);
+}
+
+static void ad_clear_sr_uuids(void)
+{
+	ad_disable_uuids(dbus_conn, AD_TYPE_SRD);
+}
+
+static void ad_clear_sr_solicit(void)
+{
+	ad_disable_solicit(dbus_conn, AD_TYPE_SRD);
+}
+
+static void ad_clear_sr_service(void)
+{
+	ad_disable_service(dbus_conn, AD_TYPE_SRD);
+}
+
+static void ad_clear_sr_manufacturer(void)
+{
+	ad_disable_manufacturer(dbus_conn, AD_TYPE_SRD);
+}
+
+static void ad_clear_sr_data(void)
+{
+	ad_disable_data(dbus_conn, AD_TYPE_SRD);
 }
 
 static void ad_clear_tx_power(void)
@@ -2856,9 +2916,15 @@ static void ad_clear_interval(void)
 
 static const struct clear_entry ad_clear[] = {
 	{ "uuids",		ad_clear_uuids },
+	{ "solicit",		ad_clear_solicit },
 	{ "service",		ad_clear_service },
 	{ "manufacturer",	ad_clear_manufacturer },
 	{ "data",		ad_clear_data },
+	{ "sr-uuids",		ad_clear_sr_uuids },
+	{ "sr-solicit",		ad_clear_sr_solicit },
+	{ "sr-service",		ad_clear_sr_service },
+	{ "sr-manufacturer",	ad_clear_sr_manufacturer },
+	{ "sr-data",		ad_clear_sr_data },
 	{ "tx-power",		ad_clear_tx_power },
 	{ "name",		ad_clear_name },
 	{ "appearance",		ad_clear_appearance },
@@ -2959,6 +3025,8 @@ static const struct bt_shell_menu advertise_menu = {
 	.entries = {
 	{ "uuids", "[uuid1 uuid2 ...]", cmd_advertise_uuids,
 			"Set/Get advertise uuids" },
+	{ "solicit", "[uuid1 uuid2 ...]", cmd_advertise_solicit,
+			"Set/Get advertise solicit uuids" },
 	{ "service", "[uuid] [data=xx xx ...]", cmd_advertise_service,
 			"Set/Get advertise service data" },
 	{ "manufacturer", "[id] [data=xx xx ...]",
@@ -2966,6 +3034,17 @@ static const struct bt_shell_menu advertise_menu = {
 			"Set/Get advertise manufacturer data" },
 	{ "data", "[type] [data=xx xx ...]", cmd_advertise_data,
 			"Set/Get advertise data" },
+	{ "sr-uuids", "[uuid1 uuid2 ...]", cmd_advertise_sr_uuids,
+			"Set/Get scan response uuids" },
+	{ "sr-solicit", "[uuid1 uuid2 ...]", cmd_advertise_sr_solicit,
+			"Set/Get scan response solicit uuids" },
+	{ "sr-service", "[uuid] [data=xx xx ...]", cmd_advertise_sr_service,
+			"Set/Get scan response service data" },
+	{ "sr-manufacturer", "[id] [data=xx xx ...]",
+			cmd_advertise_sr_manufacturer,
+			"Set/Get scan response manufacturer data" },
+	{ "sr-data", "[type] [data=xx xx ...]", cmd_advertise_sr_data,
+			"Set/Get scan response data" },
 	{ "discoverable", "[on/off]", cmd_advertise_discoverable,
 			"Set/Get advertise discoverable" },
 	{ "discoverable-timeout", "[seconds]",

--- a/doc/org.bluez.LEAdvertisement.rst
+++ b/doc/org.bluez.LEAdvertisement.rst
@@ -60,31 +60,32 @@ string Type [readonly]
 	:"broadcast":
 	:"peripheral":
 
-array{string} ServiceUUIDs
-``````````````````````````
+array{string} ServiceUUIDs [readonly, optional]
+```````````````````````````````````````````````
 
 	List of UUIDs to include in the "Service UUID" field of the Advertising
 	Data.
 
-dict ManufacturerData
-`````````````````````
+dict ManufacturerData [readonly, optional]
+``````````````````````````````````````````
 
 	Manufacturer Data fields to include in the Advertising Data.  Keys are
 	the Manufacturer ID to associate with the data.
 
-array{string} SolicitUUIDs
-``````````````````````````
+array{string} SolicitUUIDs [readonly, optional]
+```````````````````````````````````````````````
 
-	Array of UUIDs to include in "Service Solicitation" Advertisement Data.
+	List of UUIDs to include in the "Service Solicitation" field of the
+	Advertising Data.
 
-dict ServiceData
-````````````````
+dict ServiceData [readonly, optional]
+`````````````````````````````````````
 
-	Service Data elements to include. The keys are the UUID to associate
-	with the data.
+	Service Data elements to include in the Advertising Data. The keys
+	are the UUID to associate with the data.
 
-dict Data
-`````````
+dict Data [readonly, optional]
+``````````````````````````````
 
 	Advertising Data to include. Key is the advertising type and value is
 	the data as byte array.
@@ -101,8 +102,38 @@ dict Data
 		<Transport Discovery> <Organization Flags...>
 		0x26                   0x01         0x01...
 
-bool Discoverable
-`````````````````
+array{string} ScanResponseServiceUUIDs [readonly, optional, experimental]
+`````````````````````````````````````````````````````````````````````````
+
+	List of UUIDs to include in the "Service UUID" field of the Scan
+	Response Data.
+
+dict ScanResponseManufacturerData [readonly, optional, experimental]
+````````````````````````````````````````````````````````````````````
+
+	Manufacturer Data fields to include in the Scan Response Data. Keys
+	are the Manufacturer ID to associate with the data.
+
+array{string} ScanResponseSolicitUUIDs [readonly, optional, experimental]
+`````````````````````````````````````````````````````````````````````````
+
+	List of UUIDs to include in the "Service Solicitation" field of the
+	Scan Response Data.
+
+dict ScanResponseServiceData [readonly, optional, experimental]
+```````````````````````````````````````````````````````````````
+
+	Service Data elements to include in the Scan Response Data. The keys
+	are the UUID to associate with the data.
+
+dict ScanResponseData [readonly, optional, experimental]
+````````````````````````````````````````````````````````
+
+	Scan Response Data to include. Key is the advertising type and value is
+	the data as byte array.
+
+bool Discoverable [readonly, optional]
+``````````````````````````````````````
 
 	Advertise as general discoverable. When present this will override
 	adapter Discoverable property.
@@ -110,8 +141,8 @@ bool Discoverable
 	Note: This property shall not be set when **Type** is set to
 	"broadcast".
 
-uint16 DiscoverableTimeout
-``````````````````````````
+uint16 DiscoverableTimeout [readonly, optional]
+```````````````````````````````````````````````
 
 	The discoverable timeout in seconds. A value of zero means that the
 	timeout is disabled and it will stay in discoverable/limited mode
@@ -120,8 +151,8 @@ uint16 DiscoverableTimeout
 	Note: This property shall not be set when **Type** is set to
 	"broadcast".
 
-array{string} Includes
-``````````````````````
+array{string} Includes [readonly, optional]
+```````````````````````````````````````````
 
 	List of features to be included in the advertising packet.
 
@@ -130,8 +161,8 @@ array{string} Includes
 	See **org.bluez.LEAdvertisingManager(5)** **SupportedIncludes**
 	property.
 
-string LocalName
-````````````````
+string LocalName [readonly, optional]
+`````````````````````````````````````
 
 	Local name to be used in the advertising report. If the string is too
 	big to fit into the packet it will be truncated.
@@ -139,27 +170,27 @@ string LocalName
 	If this property is available 'local-name' cannot be present in the
 	**Includes**.
 
-uint16 Appearance
-`````````````````
+uint16 Appearance [readonly, optional]
+``````````````````````````````````````
 
 	Appearance to be used in the advertising report.
 
 	Possible values: as found on GAP Service.
 
-uint16_t Duration
-`````````````````
+uint16_t Duration [readonly, optional]
+``````````````````````````````````````
 
 	Rotation duration of the advertisement in seconds. If there are other
 	applications advertising no duration is set the default is 2 seconds.
 
-uint16_t Timeout
-````````````````
+uint16_t Timeout [readonly, optional]
+`````````````````````````````````````
 
 	Timeout of the advertisement in seconds. This defines the lifetime of
 	the advertisement.
 
-string SecondaryChannel
-```````````````````````
+string SecondaryChannel [readonly, optional]
+````````````````````````````````````````````
 
 	Secondary channel to be used. Primary channel is always set to "1M"
 	except when "Coded" is set.
@@ -170,24 +201,24 @@ string SecondaryChannel
 	:"2M":
 	:"Coded":
 
-uint32 MinInterval
-``````````````````
+uint32 MinInterval [readonly, optional]
+```````````````````````````````````````
 
 	Minimum advertising interval to be used by the advertising set, in
 	milliseconds. Acceptable values are in the range [20ms, 10,485s].
 	If the provided MinInterval is larger than the provided MaxInterval,
 	the registration will return failure.
 
-uint32 MaxInterval
-``````````````````
+uint32 MaxInterval [readonly, optional]
+```````````````````````````````````````
 
 	Maximum advertising interval to be used by the advertising set, in
 	milliseconds. Acceptable values are in the range [20ms, 10,485s]. If the
 	provided MinInterval is larger than the provided MaxInterval, the
 	registration will return failure.
 
-int16 TxPower
-`````````````
+int16 TxPower [readonly, optional]
+``````````````````````````````````
 
 	Requested transmission power of this advertising set. The provided value
 	is used only if the "CanSetTxPower" feature is enabled on the

--- a/src/advertising.c
+++ b/src/advertising.c
@@ -255,13 +255,12 @@ static bool parse_type(DBusMessageIter *iter, struct btd_adv_client *client)
 	return false;
 }
 
-static bool parse_service_uuids(DBusMessageIter *iter,
-					struct btd_adv_client *client)
+static bool parse_service_uuids(DBusMessageIter *iter, struct bt_ad *ad)
 {
 	DBusMessageIter ariter;
 
 	if (!iter) {
-		bt_ad_clear_service_uuid(client->data);
+		bt_ad_clear_service_uuid(ad);
 		return true;
 	}
 
@@ -270,7 +269,7 @@ static bool parse_service_uuids(DBusMessageIter *iter,
 
 	dbus_message_iter_recurse(iter, &ariter);
 
-	bt_ad_clear_service_uuid(client->data);
+	bt_ad_clear_service_uuid(ad);
 
 	while (dbus_message_iter_get_arg_type(&ariter) == DBUS_TYPE_STRING) {
 		const char *uuid_str;
@@ -283,7 +282,7 @@ static bool parse_service_uuids(DBusMessageIter *iter,
 		if (bt_string_to_uuid(&uuid, uuid_str) < 0)
 			goto fail;
 
-		if (!bt_ad_add_service_uuid(client->data, &uuid))
+		if (!bt_ad_add_service_uuid(ad, &uuid))
 			goto fail;
 
 		dbus_message_iter_next(&ariter);
@@ -292,17 +291,28 @@ static bool parse_service_uuids(DBusMessageIter *iter,
 	return true;
 
 fail:
-	bt_ad_clear_service_uuid(client->data);
+	bt_ad_clear_service_uuid(ad);
 	return false;
 }
 
-static bool parse_solicit_uuids(DBusMessageIter *iter,
+static bool parse_service_uuids_ad(DBusMessageIter *iter,
 					struct btd_adv_client *client)
+{
+	return parse_service_uuids(iter, client->data);
+}
+
+static bool parse_service_uuids_sr(DBusMessageIter *iter,
+					struct btd_adv_client *client)
+{
+	return parse_service_uuids(iter, client->scan);
+}
+
+static bool parse_solicit_uuids(DBusMessageIter *iter, struct bt_ad *ad)
 {
 	DBusMessageIter ariter;
 
 	if (!iter) {
-		bt_ad_clear_solicit_uuid(client->data);
+		bt_ad_clear_solicit_uuid(ad);
 		return true;
 	}
 
@@ -311,7 +321,7 @@ static bool parse_solicit_uuids(DBusMessageIter *iter,
 
 	dbus_message_iter_recurse(iter, &ariter);
 
-	bt_ad_clear_solicit_uuid(client->data);
+	bt_ad_clear_solicit_uuid(ad);
 
 	while (dbus_message_iter_get_arg_type(&ariter) == DBUS_TYPE_STRING) {
 		const char *uuid_str;
@@ -324,7 +334,7 @@ static bool parse_solicit_uuids(DBusMessageIter *iter,
 		if (bt_string_to_uuid(&uuid, uuid_str) < 0)
 			goto fail;
 
-		if (!bt_ad_add_solicit_uuid(client->data, &uuid))
+		if (!bt_ad_add_solicit_uuid(ad, &uuid))
 			goto fail;
 
 		dbus_message_iter_next(&ariter);
@@ -333,17 +343,28 @@ static bool parse_solicit_uuids(DBusMessageIter *iter,
 	return true;
 
 fail:
-	bt_ad_clear_solicit_uuid(client->data);
+	bt_ad_clear_solicit_uuid(ad);
 	return false;
 }
 
-static bool parse_manufacturer_data(DBusMessageIter *iter,
+static bool parse_solicit_uuids_ad(DBusMessageIter *iter,
 					struct btd_adv_client *client)
+{
+	return parse_solicit_uuids(iter, client->data);
+}
+
+static bool parse_solicit_uuids_sr(DBusMessageIter *iter,
+					struct btd_adv_client *client)
+{
+	return parse_solicit_uuids(iter, client->scan);
+}
+
+static bool parse_manufacturer_data(DBusMessageIter *iter, struct bt_ad *ad)
 {
 	DBusMessageIter entries;
 
 	if (!iter) {
-		bt_ad_clear_manufacturer_data(client->data);
+		bt_ad_clear_manufacturer_data(ad);
 		return true;
 	}
 
@@ -352,7 +373,7 @@ static bool parse_manufacturer_data(DBusMessageIter *iter,
 
 	dbus_message_iter_recurse(iter, &entries);
 
-	bt_ad_clear_manufacturer_data(client->data);
+	bt_ad_clear_manufacturer_data(ad);
 
 	while (dbus_message_iter_get_arg_type(&entries)
 						== DBUS_TYPE_DICT_ENTRY) {
@@ -383,7 +404,7 @@ static bool parse_manufacturer_data(DBusMessageIter *iter,
 
 		DBG("Adding ManufacturerData for %04x", manuf_id);
 
-		if (!bt_ad_add_manufacturer_data(client->data, manuf_id,
+		if (!bt_ad_add_manufacturer_data(ad, manuf_id,
 							manuf_data, len))
 			goto fail;
 
@@ -393,17 +414,28 @@ static bool parse_manufacturer_data(DBusMessageIter *iter,
 	return true;
 
 fail:
-	bt_ad_clear_manufacturer_data(client->data);
+	bt_ad_clear_manufacturer_data(ad);
 	return false;
 }
 
-static bool parse_service_data(DBusMessageIter *iter,
+static bool parse_manufacturer_data_ad(DBusMessageIter *iter,
 					struct btd_adv_client *client)
+{
+	return parse_manufacturer_data(iter, client->data);
+}
+
+static bool parse_manufacturer_data_sr(DBusMessageIter *iter,
+					struct btd_adv_client *client)
+{
+	return parse_manufacturer_data(iter, client->scan);
+}
+
+static bool parse_service_data(DBusMessageIter *iter, struct bt_ad *ad)
 {
 	DBusMessageIter entries;
 
 	if (!iter) {
-		bt_ad_clear_service_data(client->data);
+		bt_ad_clear_service_data(ad);
 		return true;
 	}
 
@@ -412,7 +444,7 @@ static bool parse_service_data(DBusMessageIter *iter,
 
 	dbus_message_iter_recurse(iter, &entries);
 
-	bt_ad_clear_service_data(client->data);
+	bt_ad_clear_service_data(ad);
 
 	while (dbus_message_iter_get_arg_type(&entries)
 						== DBUS_TYPE_DICT_ENTRY) {
@@ -447,7 +479,7 @@ static bool parse_service_data(DBusMessageIter *iter,
 
 		DBG("Adding ServiceData for %s", uuid_str);
 
-		if (!bt_ad_add_service_data(client->data, &uuid, service_data,
+		if (!bt_ad_add_service_data(ad, &uuid, service_data,
 									len))
 			goto fail;
 
@@ -457,8 +489,20 @@ static bool parse_service_data(DBusMessageIter *iter,
 	return true;
 
 fail:
-	bt_ad_clear_service_data(client->data);
+	bt_ad_clear_service_data(ad);
 	return false;
+}
+
+static bool parse_service_data_ad(DBusMessageIter *iter,
+					struct btd_adv_client *client)
+{
+	return parse_service_data(iter, client->data);
+}
+
+static bool parse_service_data_sr(DBusMessageIter *iter,
+					struct btd_adv_client *client)
+{
+	return parse_service_data(iter, client->scan);
 }
 
 static bool set_rsi(struct btd_adv_client *client)
@@ -667,12 +711,12 @@ static bool parse_timeout(DBusMessageIter *iter,
 	return true;
 }
 
-static bool parse_data(DBusMessageIter *iter, struct btd_adv_client *client)
+static bool parse_data(DBusMessageIter *iter, struct bt_ad *ad)
 {
 	DBusMessageIter entries;
 
 	if (!iter) {
-		bt_ad_clear_data(client->data);
+		bt_ad_clear_data(ad);
 		return true;
 	}
 
@@ -681,7 +725,7 @@ static bool parse_data(DBusMessageIter *iter, struct btd_adv_client *client)
 
 	dbus_message_iter_recurse(iter, &entries);
 
-	bt_ad_clear_data(client->data);
+	bt_ad_clear_data(ad);
 
 	while (dbus_message_iter_get_arg_type(&entries)
 						== DBUS_TYPE_DICT_ENTRY) {
@@ -712,7 +756,7 @@ static bool parse_data(DBusMessageIter *iter, struct btd_adv_client *client)
 
 		DBG("Adding Data for type 0x%02x len %u", type, len);
 
-		if (!bt_ad_add_data(client->data, type, data, len))
+		if (!bt_ad_add_data(ad, type, data, len))
 			goto fail;
 
 		dbus_message_iter_next(&entries);
@@ -721,8 +765,20 @@ static bool parse_data(DBusMessageIter *iter, struct btd_adv_client *client)
 	return true;
 
 fail:
-	bt_ad_clear_data(client->data);
+	bt_ad_clear_data(ad);
 	return false;
+}
+
+static bool parse_data_ad(DBusMessageIter *iter,
+					struct btd_adv_client *client)
+{
+	return parse_data(iter, client->data);
+}
+
+static bool parse_data_sr(DBusMessageIter *iter,
+					struct btd_adv_client *client)
+{
+	return parse_data(iter, client->scan);
 }
 
 static bool set_flags(struct btd_adv_client *client, uint8_t flags)
@@ -837,14 +893,13 @@ static uint8_t *generate_adv_data(struct btd_adv_client *client,
 static uint8_t *generate_scan_rsp(struct btd_adv_client *client,
 						uint32_t *flags, size_t *len)
 {
-	if (!client->name) {
+	if (client->name) {
+		*flags &= ~MGMT_ADV_FLAG_LOCAL_NAME;
+		bt_ad_add_name(client->scan, client->name);
+	} else if (bt_ad_is_empty(client->scan)) {
 		*len = 0;
 		return NULL;
 	}
-
-	*flags &= ~MGMT_ADV_FLAG_LOCAL_NAME;
-
-	bt_ad_add_name(client->scan, client->name);
 
 	return bt_ad_generate(client->scan, len);
 }
@@ -1215,18 +1270,24 @@ static bool parse_tx_power(DBusMessageIter *iter,
 static struct adv_parser {
 	const char *name;
 	bool (*func)(DBusMessageIter *iter, struct btd_adv_client *client);
+	bool experimental;
 } parsers[] = {
 	{ "Type", parse_type },
-	{ "ServiceUUIDs", parse_service_uuids },
-	{ "SolicitUUIDs", parse_solicit_uuids },
-	{ "ManufacturerData", parse_manufacturer_data },
-	{ "ServiceData", parse_service_data },
+	{ "ServiceUUIDs", parse_service_uuids_ad },
+	{ "ScanResponseServiceUUIDs", parse_service_uuids_sr, true },
+	{ "SolicitUUIDs", parse_solicit_uuids_ad },
+	{ "ScanResponseSolicitUUIDs", parse_solicit_uuids_sr, true },
+	{ "ManufacturerData", parse_manufacturer_data_ad },
+	{ "ScanResponseManufacturerData", parse_manufacturer_data_sr, true },
+	{ "ServiceData", parse_service_data_ad },
+	{ "ScanResponseServiceData", parse_service_data_sr, true },
 	{ "Includes", parse_includes },
 	{ "LocalName", parse_local_name },
 	{ "Appearance", parse_appearance },
 	{ "Duration", parse_duration },
 	{ "Timeout", parse_timeout },
-	{ "Data", parse_data },
+	{ "Data", parse_data_ad },
+	{ "ScanResponseData", parse_data_sr },
 	{ "Discoverable", parse_discoverable },
 	{ "DiscoverableTimeout", parse_discoverable_timeout },
 	{ "SecondaryChannel", parse_secondary },
@@ -1244,6 +1305,13 @@ static void properties_changed(GDBusProxy *proxy, const char *name,
 
 	for (parser = parsers; parser && parser->name; parser++) {
 		if (strcmp(parser->name, name))
+			continue;
+
+		/* Ignore experimental parsers if the experimental flag is not
+		 * set.
+		 */
+		if (parser->experimental && !(g_dbus_get_flags() &
+					G_DBUS_FLAG_ENABLE_EXPERIMENTAL))
 			continue;
 
 		if (parser->func(iter, client)) {


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

This adds Scan Response fields as experimental so we can evaluate if
this should be made into a stable API.
---
 doc/org.bluez.LEAdvertisement.rst | 101 +++++++++++++++++++-----------
 1 file changed, 66 insertions(+), 35 deletions(-)