### PR TITLE
[PW_SID:928791] [BlueZ] device: Clear pending_flags on error

### DIFF
--- a/src/adapter.c
+++ b/src/adapter.c
@@ -5580,6 +5580,7 @@ static void set_device_privacy_complete(uint8_t status, uint16_t length,
 	if (status != MGMT_STATUS_SUCCESS) {
 		error("Set device flags return status: %s",
 					mgmt_errstr(status));
+		dev->pending_flags = 0;
 		return;
 	}
 

--- a/src/device.c
+++ b/src/device.c
@@ -1575,6 +1575,7 @@ static void set_wake_allowed_complete(uint8_t status, uint16_t length,
 			dev->wake_id = -1U;
 		}
 		dev->pending_wake_allowed = FALSE;
+		dev->pending_flags = 0;
 		return;
 	}
 


### PR DESCRIPTION
If setting WakeAllowed, or the device privacy, fails, we may end up in a
situation where `pending_flags` is still set to some `DEVICE_FLAG_*`
values, for example from `device_set_wake_allowed()` or
`adapter_set_device_flags()`.

This can confuse further requests because they'll assume that there is
still a pending request in progress.
---
 src/adapter.c | 1 +
 src/device.c  | 1 +
 2 files changed, 2 insertions(+)