### PR TITLE
[PW_SID:928898] [v1] obex: Update the MAP Client version to 1.4 in SDP record

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/doc/supported-features.txt
+++ b/doc/supported-features.txt
@@ -40,7 +40,8 @@ FTP			1.3		Client, Server
 OPP			1.2		Client, Server
 SYNCH			1.1		Client
 PBAP			1.1		Client, Server
-MAP			1.0		Client, Server
+MAP			1.0		Server
+MAP			1.4		Client
 
 HID			1.1		Host
 

--- a/src/profile.c
+++ b/src/profile.c
@@ -2167,7 +2167,7 @@ static struct default_settings {
 		.mode		= BT_IO_MODE_ERTM,
 		.authorize	= true,
 		.get_record	= get_mns_record,
-		.version	= 0x0102
+		.version	= 0x0104
 	},
 };
 


### PR DESCRIPTION
This change is required in below PTS testcase:
1. MAP/MCE/SGSIT/ATTR/BV-10-C
Attribute GSIT - Bluetooth Profile Descriptor List, MAP 1.4

Current MAP Client version 1.2 is being deprecated and withdrawn
from BT Sig, so it is mandatory to update the version.

No additional changes are needed for supporting the new version.

---
 doc/supported-features.txt | 3 ++-
 src/profile.c              | 2 +-
 2 files changed, 3 insertions(+), 2 deletions(-)