### PR TITLE
[PW_SID:929013] [BlueZ,v2,1/2] audio: actually try to enable MTU auto-tuning

### DIFF
--- a/profiles/audio/a2dp.c
+++ b/profiles/audio/a2dp.c
@@ -2592,6 +2592,8 @@ static bool a2dp_server_listen(struct a2dp_server *server)
 				BT_IO_OPT_MODE, mode,
 				BT_IO_OPT_SEC_LEVEL, BT_IO_SEC_MEDIUM,
 				BT_IO_OPT_CENTRAL, true,
+				/* Set Input MTU to 0 for auto-tune attempt */
+				BT_IO_OPT_IMTU, 0,
 				BT_IO_OPT_INVALID);
 	if (server->io)
 		return true;


### PR DESCRIPTION
A "0" for the input MTU passed to the underlying socket is supposed to
indicate that its value should be determined by the L2CAP layer.
However, the current code treats a zero imtu just as if there is
nothing to change.

Introduce an additional flag to indicate that the zero imtu is
explicitly requested by the caller for the purpose of auto-tuning.
Otherwise, the similar behavior remains.

Found by Linux Verification Center (linuxtesting.org).

Fixes: ae5be371a9f5 ("avdtp: Enable MTU auto tunning")
---
v1->v2: incorporate error handling in case the kernel still doesn't
support MTU auto-tuning

 btio/btio.c | 34 ++++++++++++++++++++++------------
 1 file changed, 22 insertions(+), 12 deletions(-)