### PR TITLE
[PW_SID:930511] [BlueZ,v1,1/2] build: Enable -Wstringop-overflow and -D_FORTIFY_SOURCE=3

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -61,9 +61,11 @@ AC_DEFUN([COMPILER_FLAGS], [
 		with_cflags="$with_cflags -Wcast-align"
 		with_cflags="$with_cflags -Wswitch-enum"
 		with_cflags="$with_cflags -Wformat -Wformat-security"
+		with_cflags="$with_cflags -Wstringop-overflow"
 		with_cflags="$with_cflags -DG_DISABLE_DEPRECATED"
 		with_cflags="$with_cflags -DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_28"
 		with_cflags="$with_cflags -DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_2_32"
+		with_cflags="$with_cflags -D_FORTIFY_SOURCE=3"
 	fi
 	AC_SUBST([WARNING_CFLAGS], $with_cflags)
 ])

--- a/emulator/serial.c
+++ b/emulator/serial.c
@@ -75,7 +75,7 @@ static void serial_write_callback(const struct iovec *iov, int iovlen,
 static void serial_read_callback(int fd, uint32_t events, void *user_data)
 {
 	struct serial *serial = user_data;
-	static uint8_t buf[4096];
+	uint8_t buf[4096];
 	uint8_t *ptr = buf;
 	ssize_t len;
 	uint16_t count;
@@ -87,8 +87,7 @@ static void serial_read_callback(int fd, uint32_t events, void *user_data)
 	}
 
 again:
-	len = read(serial->fd, buf + serial->pkt_offset,
-			sizeof(buf) - serial->pkt_offset);
+	len = read(serial->fd, buf, sizeof(buf));
 	if (len < 0) {
 		if (errno == EAGAIN)
 			goto again;
@@ -98,7 +97,7 @@ again:
 	if (!serial->btdev)
 		return;
 
-	count = serial->pkt_offset + len;
+	count = len;
 
 	while (count > 0) {
 		hci_command_hdr *cmd_hdr;


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

This enables -Wstringop-overflow compiler warnings:

  'Warn for calls to string manipulation functions such as "memcpy" and
  "strcpy" that are determined to overflow the destination buffer.'

Along with -D_FORTIFY_SOURCE=3 so the errors like the following can be
captured:

In function ‘read’,
    inlined from ‘serial_read_callback’ at emulator/serial.c:90:8:
/usr/include/bits/unistd.h:32:10: error: ‘__read_alias’ specified size between 18446744073709490177 and 18446744073709551615 exceeds maximum object size 9223372036854775807 [-Werror=stringop-overflow=]
   32 |   return __glibc_fortify (read, __nbytes, sizeof (char),
      |          ^~~~~~~~~~~~~~~
---
 acinclude.m4 | 2 ++
 1 file changed, 2 insertions(+)