### PR TITLE
[PW_SID:931146] [v1] obex: Add messages_get_message() implementation for MAP plugin

### DIFF
--- a/obexd/plugins/mas.c
+++ b/obexd/plugins/mas.c
@@ -612,10 +612,10 @@ static void *message_open(const char *name, int oflag, mode_t mode,
 		return NULL;
 	}
 
+	mas->buffer = g_string_new("");
+
 	*err = messages_get_message(mas->backend_data, name, 0,
 			get_message_cb, mas);
-
-	mas->buffer = g_string_new("");
 
 	if (*err < 0)
 		return NULL;

--- a/obexd/plugins/messages-dummy.c
+++ b/obexd/plugins/messages-dummy.c
@@ -516,7 +516,37 @@ int messages_get_message(void *session, const char *handle,
 					messages_get_message_cb callback,
 					void *user_data)
 {
-	return -ENOSYS;
+	struct session *s =  session;
+	FILE *fp;
+	char *path;
+	char buffer[1024];
+
+	DBG(" ");
+	path = g_build_filename(s->cwd_absolute, handle, NULL);
+	fp = fopen(path, "r");
+	if (fp == NULL)
+	{
+		DBG("fopen() failed");
+		return -EBADR;
+	}
+
+	/* 1024 is the maximum size of the line which is calculated to be more
+	 * sufficient*/
+	while (fgets(buffer, 1024, fp)) {
+		if (callback)
+		{
+			callback(session, 0, 0, &buffer, user_data);
+		}
+	}
+
+	if (callback)
+	{
+		callback(session, 0, 0, NULL, user_data);
+	}
+
+	g_free(path);
+	fclose(fp);
+	return 0;
 }
 
 int messages_update_inbox(void *session, messages_status_cb callback,


### PR DESCRIPTION
GET Message() operation should be supported for passing below PTS
testcases -
1.MAP/MSE/MMB/BV-12-C
Verify that the MSE can return an email message to the MCE.
2.MAP/MSE/MMB/BV-13-C
Verify that the MSE can return a SMS message in native format to the MCE.
3.MAP/MSE/MMB/BV-14-C
Verify that the MSE can return a SMS message with text trans-coded to UTF-8
to the MCE.

---
 obexd/plugins/mas.c            |  4 ++--
 obexd/plugins/messages-dummy.c | 32 +++++++++++++++++++++++++++++++-
 2 files changed, 33 insertions(+), 3 deletions(-)