### PR TITLE
[PW_SID:931874] [BlueZ] build: check first before enabling -D_FORTIFY_SOURCE=3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -65,7 +65,6 @@ AC_DEFUN([COMPILER_FLAGS], [
 		with_cflags="$with_cflags -DG_DISABLE_DEPRECATED"
 		with_cflags="$with_cflags -DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_28"
 		with_cflags="$with_cflags -DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_2_32"
-		with_cflags="$with_cflags -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3"
 	fi
 	AC_SUBST([WARNING_CFLAGS], $with_cflags)
 ])
@@ -135,6 +134,21 @@ AC_DEFUN([MISC_FLAGS], [
 	if (test "$enable_coverage" = "yes"); then
 		misc_cflags="$misc_cflags --coverage"
 		misc_ldflags="$misc_ldflags --coverage"
+	fi
+	if (test "$USE_MAINTAINER_MODE" = "yes"); then
+		AC_CACHE_CHECK([whether ${CC-cc} accepts -D_FORTIFY_SOURCE=3],
+						ac_cv_prog_cc_fortify_source_3, [
+			echo '#include <errno.h>' > fortify.c
+			if test -z "`${CC-cc} ${CFLAGS} ${misc_cflags} -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -c fortify.c  2>&1`"; then
+				ac_cv_prog_cc_fortify_source_3=yes
+			else
+				ac_cv_prog_cc_fortify_source_3=no
+			fi
+			rm -f fortify.c fortify.o
+		])
+		if test "${ac_cv_prog_cc_fortify_source_3}" = "yes"; then
+			misc_cflags="$misc_cflags -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3"
+		fi
 	fi
 	misc_cflags="$misc_cflags -ffunction-sections -fdata-sections"
 	misc_ldflags="$misc_ldflags -Wl,--gc-sections"


### PR DESCRIPTION
With --disable-optimization, _FORTIFY_SOURCE=3 produces compiler
warnings/errors:

/usr/include/features.h:422:4: error: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Werror=cpp]
  422 | #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)

Before enabling it for --enable-maintainer-mode, check the compiler
doesn't fail when using the flag.
---
 acinclude.m4 | 16 +++++++++++++++-
 1 file changed, 15 insertions(+), 1 deletion(-)