### PR TITLE
[PW_SID:931887] [BlueZ,bluez] client: Set the feature when initializing the client

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -5628,6 +5628,8 @@ static void gatt_debug(const char *str, void *user_data)
 
 static void gatt_client_init(struct btd_device *device)
 {
+	uint8_t features;
+
 	gatt_client_cleanup(device);
 
 	if (!device->connect && !btd_opts.reverse_discovery) {
@@ -5639,8 +5641,13 @@ static void gatt_client_init(struct btd_device *device)
 		return;
 	}
 
+	features =  BT_GATT_CHRC_CLI_FEAT_ROBUST_CACHING
+				| BT_GATT_CHRC_CLI_FEAT_NFY_MULTI;
+	if (btd_opts.gatt_channels > 1)
+		features |= BT_GATT_CHRC_CLI_FEAT_EATT;
+
 	device->client = bt_gatt_client_new(device->db, device->att,
-							device->att_mtu, 0);
+							device->att_mtu, features);
 	if (!device->client) {
 		DBG("Failed to initialize");
 		return;

--- a/src/gatt-database.c
+++ b/src/gatt-database.c
@@ -1245,7 +1245,8 @@ static void server_feat_read_cb(struct gatt_db_attribute *attrib,
 		goto done;
 	}
 
-	value |= BT_GATT_CHRC_SERVER_FEAT_EATT;
+	if (btd_opts.gatt_channels > 1)
+		value |= BT_GATT_CHRC_SERVER_FEAT_EATT;
 
 done:
 	gatt_db_attribute_read_result(attrib, id, ecode, &value, sizeof(value));

--- a/src/shared/gatt-client.c
+++ b/src/shared/gatt-client.c
@@ -2043,7 +2043,7 @@ static void write_client_features(struct bt_gatt_client *client)
 
 	handle = gatt_db_attribute_get_handle(attr);
 
-	client->features = BT_GATT_CHRC_CLI_FEAT_ROBUST_CACHING;
+	client->features |= BT_GATT_CHRC_CLI_FEAT_ROBUST_CACHING;
 
 	bt_uuid16_create(&uuid, GATT_CHARAC_SERVER_FEAT);
 
@@ -2055,9 +2055,11 @@ static void write_client_features(struct bt_gatt_client *client)
 		gatt_db_attribute_read(attr, 0, BT_ATT_OP_READ_REQ,
 						NULL, server_feat_read_value,
 						&feat);
-		if (feat && feat[0] & BT_GATT_CHRC_SERVER_FEAT_EATT)
-			client->features |= BT_GATT_CHRC_CLI_FEAT_EATT;
+		if (!(feat && feat[0] & BT_GATT_CHRC_SERVER_FEAT_EATT)
+			|| !(client->features & BT_GATT_CHRC_CLI_FEAT_EATT))
+			client->features &= ~BT_GATT_CHRC_CLI_FEAT_EATT;
 	}
+
 
 	client->features |= BT_GATT_CHRC_CLI_FEAT_NFY_MULTI;
 


### PR DESCRIPTION
From: Yang Li <yang.li@amlogic.com>

When writing Client Features feature values, it needs
to determine whether local eatt is enabled.

Signed-off-by: Yang Li <yang.li@amlogic.com>
---
 src/device.c             | 9 ++++++++-
 src/gatt-database.c      | 3 ++-
 src/shared/gatt-client.c | 8 +++++---
 3 files changed, 15 insertions(+), 5 deletions(-)


---
base-commit: 2ee08ffd4d469781dc627fa50b4a015d9ad68007
change-id: 20250208-client_eatt-c715de38312f

Best regards,