### PR TITLE
[PW_SID:931990] tools/tester: update TX timestamping tests for COMPLETION

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/configure.ac
+++ b/configure.ac
@@ -389,6 +389,13 @@ AC_ARG_ENABLE(testing, AS_HELP_STRING([--enable-testing],
 					[enable_testing=${enableval}])
 AM_CONDITIONAL(TESTING, test "${enable_testing}" = "yes")
 
+if (test "${enable_testing}" = "yes"); then
+   AC_CHECK_DECLS([SOF_TIMESTAMPING_TX_COMPLETION, SCM_TSTAMP_COMPLETION],
+	[], [], [[#include <time.h>
+		#include <linux/errqueue.h>
+		#include <linux/net_tstamp.h>]])
+fi
+
 AC_ARG_ENABLE(experimental, AS_HELP_STRING([--enable-experimental],
 			[enable experimental tools]),
 					[enable_experimental=${enableval}])

--- a/tools/iso-tester.c
+++ b/tools/iso-tester.c
@@ -2285,10 +2285,10 @@ static void iso_tx_timestamping(struct test_data *data, GIOChannel *io)
 
 	tester_print("Enabling TX timestamping");
 
-	tx_tstamp_init(&data->tx_ts, isodata->so_timestamping);
+	tx_tstamp_init(&data->tx_ts, isodata->so_timestamping, false);
 
 	for (count = 0; count < isodata->repeat_send + 1; ++count)
-		data->step += tx_tstamp_expect(&data->tx_ts);
+		data->step += tx_tstamp_expect(&data->tx_ts, 0);
 
 	sk = g_io_channel_unix_get_fd(io);
 

--- a/tools/iso-tester.c
+++ b/tools/iso-tester.c
@@ -691,7 +691,7 @@ static void test_pre_setup(const void *test_data)
 	struct test_data *data = tester_get_data();
 	const struct iso_client_data *isodata = test_data;
 
-	if (isodata && isodata->so_timestamping) {
+	if (isodata && isodata->no_poll_errqueue) {
 		if (tester_pre_setup_skip_by_default())
 			return;
 	}

--- a/tools/l2cap-tester.c
+++ b/tools/l2cap-tester.c
@@ -381,7 +381,8 @@ static const struct l2cap_data client_connect_tx_timestamping_test = {
 	.data_len = sizeof(l2_data),
 	.so_timestamping = (SOF_TIMESTAMPING_SOFTWARE |
 					SOF_TIMESTAMPING_OPT_ID |
-					SOF_TIMESTAMPING_TX_SOFTWARE),
+					SOF_TIMESTAMPING_TX_SOFTWARE |
+					SOF_TIMESTAMPING_TX_COMPLETION),
 	.repeat_send = 2,
 };
 
@@ -594,7 +595,8 @@ static const struct l2cap_data le_client_connect_tx_timestamping_test = {
 	.data_len = sizeof(l2_data),
 	.so_timestamping = (SOF_TIMESTAMPING_SOFTWARE |
 					SOF_TIMESTAMPING_OPT_ID |
-					SOF_TIMESTAMPING_TX_SOFTWARE),
+					SOF_TIMESTAMPING_TX_SOFTWARE |
+					SOF_TIMESTAMPING_TX_COMPLETION),
 };
 
 static const struct l2cap_data le_client_connect_adv_success_test_1 = {
@@ -1345,10 +1347,10 @@ static gboolean recv_errqueue(GIOChannel *io, GIOCondition cond,
 	err = tx_tstamp_recv(&data->tx_ts, sk, l2data->data_len);
 	if (err > 0)
 		return TRUE;
-	else if (!err && !data->step)
-		tester_test_passed();
-	else
+	else if (err)
 		tester_test_failed();
+	else if (!data->step)
+		tester_test_passed();
 
 	data->err_io_id = 0;
 	return FALSE;
@@ -1362,7 +1364,7 @@ static void l2cap_tx_timestamping(struct test_data *data, GIOChannel *io)
 	int err;
 	unsigned int count;
 
-	if (!(l2data->so_timestamping & SOF_TIMESTAMPING_TX_RECORD_MASK))
+	if (!(l2data->so_timestamping & TS_TX_RECORD_MASK))
 		return;
 
 	sk = g_io_channel_unix_get_fd(io);

--- a/tools/l2cap-tester.c
+++ b/tools/l2cap-tester.c
@@ -221,12 +221,6 @@ static void read_index_list_callback(uint8_t status, uint16_t length,
 static void test_pre_setup(const void *test_data)
 {
 	struct test_data *data = tester_get_data();
-	const struct l2cap_data *l2data = test_data;
-
-	if (l2data && l2data->so_timestamping) {
-		if (tester_pre_setup_skip_by_default())
-			return;
-	}
 
 	data->mgmt = mgmt_new_default();
 	if (!data->mgmt) {

--- a/tools/sco-tester.c
+++ b/tools/sco-tester.c
@@ -689,10 +689,10 @@ static void sco_tx_timestamping(struct test_data *data, GIOChannel *io)
 
 	tester_print("Enabling TX timestamping");
 
-	tx_tstamp_init(&data->tx_ts, scodata->so_timestamping);
+	tx_tstamp_init(&data->tx_ts, scodata->so_timestamping, false);
 
 	for (count = 0; count < scodata->repeat_send + 1; ++count)
-		data->step += tx_tstamp_expect(&data->tx_ts);
+		data->step += tx_tstamp_expect(&data->tx_ts, 0);
 
 	err = setsockopt(sk, SOL_SOCKET, SO_TIMESTAMPING, &so, sizeof(so));
 	if (err < 0) {

--- a/tools/sco-tester.c
+++ b/tools/sco-tester.c
@@ -665,10 +665,10 @@ static gboolean recv_errqueue(GIOChannel *io, GIOCondition cond,
 	err = tx_tstamp_recv(&data->tx_ts, sk, scodata->data_len);
 	if (err > 0)
 		return TRUE;
-	else if (!err && !data->step)
-		tester_test_passed();
-	else
+	else if (err)
 		tester_test_failed();
+	else if (!data->step)
+		tester_test_passed();
 
 	data->err_io_id = 0;
 	return FALSE;
@@ -682,7 +682,7 @@ static void sco_tx_timestamping(struct test_data *data, GIOChannel *io)
 	int err;
 	unsigned int count;
 
-	if (!(scodata->so_timestamping & SOF_TIMESTAMPING_TX_RECORD_MASK))
+	if (!(scodata->so_timestamping & TS_TX_RECORD_MASK))
 		return;
 
 	sk = g_io_channel_unix_get_fd(io);

--- a/tools/sco-tester.c
+++ b/tools/sco-tester.c
@@ -197,12 +197,6 @@ static void read_index_list_callback(uint8_t status, uint16_t length,
 static void test_pre_setup(const void *test_data)
 {
 	struct test_data *data = tester_get_data();
-	const struct sco_client_data *scodata = test_data;
-
-	if (scodata && scodata->so_timestamping) {
-		if (tester_pre_setup_skip_by_default())
-			return;
-	}
 
 	data->mgmt = mgmt_new_default();
 	if (!data->mgmt) {

--- a/tools/tester.h
+++ b/tools/tester.h
@@ -20,6 +20,15 @@
 #define SEC_NSEC(_t)  ((_t) * 1000000000LL)
 #define TS_NSEC(_ts)  (SEC_NSEC((_ts)->tv_sec) + (_ts)->tv_nsec)
 
+#if !HAVE_DECL_SOF_TIMESTAMPING_TX_COMPLETION
+#define SOF_TIMESTAMPING_TX_COMPLETION	(SOF_TIMESTAMPING_LAST << 1)
+#endif
+#if !HAVE_DECL_SCM_TSTAMP_COMPLETION
+#define SCM_TSTAMP_COMPLETION		(SCM_TSTAMP_ACK + 1)
+#endif
+#define TS_TX_RECORD_MASK		(SOF_TIMESTAMPING_TX_RECORD_MASK | \
+						SOF_TIMESTAMPING_TX_COMPLETION)
+
 struct tx_tstamp_data {
 	struct {
 		uint32_t id;
@@ -59,6 +68,13 @@ static inline int tx_tstamp_expect(struct tx_tstamp_data *data)
 		pos++;
 	}
 
+	if (data->so_timestamping & SOF_TIMESTAMPING_TX_COMPLETION) {
+		g_assert(pos < ARRAY_SIZE(data->expect));
+		data->expect[pos].type = SCM_TSTAMP_COMPLETION;
+		data->expect[pos].id = data->sent;
+		pos++;
+	}
+
 	data->sent++;
 
 	steps = pos - data->count;
@@ -77,6 +93,7 @@ static inline int tx_tstamp_recv(struct tx_tstamp_data *data, int sk, int len)
 	struct scm_timestamping *tss = NULL;
 	struct sock_extended_err *serr = NULL;
 	struct timespec now;
+	unsigned int i;
 
 	iov.iov_base = buf;
 	iov.iov_len = sizeof(buf);
@@ -89,7 +106,7 @@ static inline int tx_tstamp_recv(struct tx_tstamp_data *data, int sk, int len)
 
 	ret = recvmsg(sk, &msg, MSG_ERRQUEUE);
 	if (ret < 0) {
-		if (ret == EAGAIN || ret == EWOULDBLOCK)
+		if (errno == EAGAIN || errno == EWOULDBLOCK)
 			return data->count - data->pos;
 
 		tester_warn("Failed to read from errqueue: %s (%d)",
@@ -147,18 +164,29 @@ static inline int tx_tstamp_recv(struct tx_tstamp_data *data, int sk, int len)
 		return -EINVAL;
 	}
 
-	if ((data->so_timestamping & SOF_TIMESTAMPING_OPT_ID) &&
-				serr->ee_data != data->expect[data->pos].id) {
-		tester_warn("Bad timestamp id %u", serr->ee_data);
-		return -EINVAL;
-	}
+	/* Find first unreceived timestamp of the right type */
+	for (i = 0; i < data->count; ++i) {
+		if (data->expect[i].type >= 0xffff)
+			continue;
 
-	if (serr->ee_info != data->expect[data->pos].type) {
+		if (serr->ee_info == data->expect[i].type) {
+			data->expect[i].type = 0xffff;
+			break;
+		}
+	}
+	if (i == data->count) {
 		tester_warn("Bad timestamp type %u", serr->ee_info);
 		return -EINVAL;
 	}
 
-	tester_print("Got valid TX timestamp %u", data->pos);
+	if ((data->so_timestamping & SOF_TIMESTAMPING_OPT_ID) &&
+				serr->ee_data != data->expect[i].id) {
+		tester_warn("Bad timestamp id %u", serr->ee_data);
+		return -EINVAL;
+	}
+
+	tester_print("Got valid TX timestamp %u (type %u, id %u)", i,
+						serr->ee_info, serr->ee_data);
 
 	++data->pos;
 


### PR DESCRIPTION
Add support for SOF_TIMESTAMPING_TX_COMPLETION also in cases where
errqueue.h is old and doesn't define it.

Support timestamps of different types arriving out of order, as multiple
SND may well arrive before COMPLETION.  Also allow TX timestamp arriving
before bthost receives data, as that may well happen.

Remove tests SCHED timestamps, as those won't be generated for now.

Don't test COMPLETION for SCO, since it's not supported now either.
---
 configure.ac         |  7 +++++++
 tools/iso-tester.c   | 36 +++++++++++-------------------------
 tools/l2cap-tester.c | 14 ++++++++------
 tools/sco-tester.c   |  8 ++++----
 tools/tester.h       | 42 +++++++++++++++++++++++++++++++++++-------
 5 files changed, 65 insertions(+), 42 deletions(-)