### PR TITLE
[PW_SID:932732] bass: Register bap attached/detached callbacks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/profiles/audio/bass.h
+++ b/profiles/audio/bass.h
@@ -3,7 +3,7 @@
  *
  *  BlueZ - Bluetooth protocol stack for Linux
  *
- *  Copyright 2024 NXP
+ *  Copyright 2024-2025 NXP
  *
  */
 
@@ -11,9 +11,6 @@ void bass_add_stream(struct btd_device *device, struct iovec *meta,
 			struct iovec *caps, struct bt_bap_qos *qos,
 			uint8_t sgrp, uint8_t bis);
 void bass_remove_stream(struct btd_device *device);
-
-bool bass_bcast_probe(struct btd_service *service, int *ret);
-bool bass_bcast_remove(struct btd_device *device);
 
 typedef void (*bt_bass_bcode_func_t)(void *user_data, int err);
 


### PR DESCRIPTION
This removes the bass_bcast_probe and bass_bcast_remove APIs, in order to
decouple the BASS and BAP plugins.

Instead, since the BASS Server (BAP Scan Delegator) implementation needs
to reference the bap session, BASS registers bap attached/detached
callbacks with shared/bap.

- After receiving a request from a Broadcast Assistant, the BASS Server
creates a device for the Broadcaster and adds the UUID to probe.

- The service is probed inside the BAP plugin, where a new bt_bap session
is attached. The service is set as user data beforehand.

- The bt_bap session is notified in the BASS bap_attached callback. The
reference to the service is accessible from the user data.

- The BASS Server takes ownership for the service by setting its user
data. This way, short-lived PA sync will be skipped inside BAP, and the
BASS Server will handle long-lived PA sync and stream configuration.

- When the bt_bap session is removed, it will be notified in the
bap_detached callback.
---
 profiles/audio/bap.c  | 53 ++++++++++++++++++++++++++++++-------------
 profiles/audio/bass.c | 46 +++++++++++++++++++++----------------
 profiles/audio/bass.h |  5 +---
 3 files changed, 64 insertions(+), 40 deletions(-)