### PR TITLE
[PW_SID:933151] [v1] Audio Profile version upgrade.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/profiles/audio/a2dp.c
+++ b/profiles/audio/a2dp.c
@@ -1595,7 +1595,7 @@ static sdp_record_t *a2dp_record(uint8_t type)
 	sdp_record_t *record;
 	sdp_data_t *psm, *version, *features;
 	uint16_t lp = AVDTP_UUID;
-	uint16_t a2dp_ver = 0x0103, avdtp_ver = 0x0103, feat = 0x000f;
+	uint16_t a2dp_ver = 0x0104, avdtp_ver = 0x0103, feat = 0x000f;
 
 	record = sdp_record_alloc();
 	if (!record)

--- a/profiles/audio/avrcp.c
+++ b/profiles/audio/avrcp.c
@@ -138,7 +138,7 @@
 
 #define AVRCP_BROWSING_TIMEOUT		1
 #define AVRCP_CT_VERSION		0x0106
-#define AVRCP_TG_VERSION		0x0105
+#define AVRCP_TG_VERSION		0x0106
 
 #define AVRCP_SCOPE_MEDIA_PLAYER_LIST			0x00
 #define AVRCP_SCOPE_MEDIA_PLAYER_VFS			0x01
@@ -414,7 +414,7 @@ static sdp_record_t *avrcp_ct_record(bool browsing)
 	sdp_record_t *record;
 	sdp_data_t *psm[2], *version, *features;
 	uint16_t lp = AVCTP_CONTROL_PSM;
-	uint16_t avctp_ver = 0x0103;
+	uint16_t avctp_ver = 0x0104;
 	uint16_t feat = ( AVRCP_FEATURE_CATEGORY_1 |
 					AVRCP_FEATURE_CATEGORY_2 |
 					AVRCP_FEATURE_CATEGORY_3 |
@@ -493,7 +493,7 @@ static sdp_record_t *avrcp_tg_record(bool browsing)
 	sdp_record_t *record;
 	sdp_data_t *psm_control, *version, *features;
 	uint16_t lp = AVCTP_CONTROL_PSM;
-	uint16_t avctp_ver = 0x0103;
+	uint16_t avctp_ver = 0x0104;
 	uint16_t feat = ( AVRCP_FEATURE_CATEGORY_1 |
 					AVRCP_FEATURE_CATEGORY_2 |
 					AVRCP_FEATURE_CATEGORY_3 |

--- a/src/profile.c
+++ b/src/profile.c
@@ -2075,7 +2075,7 @@ static struct default_settings {
 		.authorize	= true,
 		.auto_connect	= true,
 		.get_record	= get_hfp_hf_record,
-		.version	= 0x0107,
+		.version	= 0x0108,
 	}, {
 		.uuid		= HSP_HS_UUID,
 		.name		= "Headset unit",
@@ -2095,7 +2095,7 @@ static struct default_settings {
 		.authorize	= true,
 		.auto_connect	= true,
 		.get_record	= get_hfp_ag_record,
-		.version	= 0x0107,
+		.version	= 0x0108,
 		/* HFP 1.7.2: By default features bitfield is 0b001001 */
 		.features	= 0x09,
 	}, {


### PR DESCRIPTION
Most of the existing profile versions are withdrawn
to make PTS successfull, need to upgrade the version
for audio profiles and there are no mandatory feature
changes between these versions are seen.

Version changes
A2DP from 1.3 to 1.4
HFP from 1.7 to 1.8
AVRCP TG from 1.5 to 1.6
AVCTP from 1.3 to 1.4

Signed-off-by: Raghavender Reddy Bujala <quic_rbujala@quicinc.com>
---
 profiles/audio/a2dp.c  | 2 +-
 profiles/audio/avrcp.c | 6 +++---
 src/profile.c          | 4 ++--
 3 files changed, 6 insertions(+), 6 deletions(-)