### PR TITLE
[PW_SID:933153] [1/4] test-runner: Increase amount of RAM available in VM

### DIFF
--- a/tools/test-runner.c
+++ b/tools/test-runner.c
@@ -211,7 +211,7 @@ static char *const qemu_argv[] = {
 	"-monitor", "none",
 	"-display", "none",
 	"-machine", "type=q35,accel=kvm:tcg",
-	"-m", "192M",
+	"-m", "256M",
 	"-nographic",
 	"-net", "none",
 	"-no-reboot",

--- a/tools/test-runner.c
+++ b/tools/test-runner.c
@@ -214,7 +214,7 @@ static char *const qemu_argv[] = {
 	"-m", "256M",
 	"-net", "none",
 	"-no-reboot",
-	"-fsdev", "local,id=fsdev-root,path=/,readonly,security_model=none,"
+	"-fsdev", "local,id=fsdev-root,path=/,readonly=on,security_model=none,"
 	"multidevs=remap",
 	"-device", "virtio-9p-pci,fsdev=fsdev-root,mount_tag=/dev/root",
 	"-chardev", "stdio,id=con,mux=on",

--- a/tools/test-runner.c
+++ b/tools/test-runner.c
@@ -212,7 +212,6 @@ static char *const qemu_argv[] = {
 	"-display", "none",
 	"-machine", "type=q35,accel=kvm:tcg",
 	"-m", "256M",
-	"-nographic",
 	"-net", "none",
 	"-no-reboot",
 	"-fsdev", "local,id=fsdev-root,path=/,readonly,security_model=none,"

--- a/tools/test-runner.c
+++ b/tools/test-runner.c
@@ -211,6 +211,7 @@ static char *const qemu_argv[] = {
 	"-monitor", "none",
 	"-display", "none",
 	"-machine", "type=q35,accel=kvm:tcg",
+	"-cpu", "host",
 	"-m", "256M",
 	"-net", "none",
 	"-no-reboot",


### PR DESCRIPTION
When using default kernel configuration from Ubuntu 24.04 patched with
the configuration from tester.config, the kernel image is too big to run
on 192M bytes of RAM. As a result the test-runner exits without any
message (because of the "quite" kernel command line option).
---
 tools/test-runner.c | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)