### PR TITLE
[PW_SID:933378] [BlueZ,v1] build: Add alternate configuration for enabling LE Audio

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/src/leaudio.conf
+++ b/src/leaudio.conf
@@ -1,0 +1,370 @@
+[General]
+
+# Default adapter name
+# Defaults to 'BlueZ X.YZ'
+#Name = BlueZ
+
+# Default device class. Only the major and minor device class bits are
+# considered. Defaults to '0x000000'.
+#Class = 0x000100
+
+# How long to stay in discoverable mode before going back to non-discoverable
+# The value is in seconds. Default is 180, i.e. 3 minutes.
+# 0 = disable timer, i.e. stay discoverable forever
+#DiscoverableTimeout = 0
+
+# Always allow pairing even if there are no agent registered
+# Possible values: true, false
+# Default: false
+#AlwaysPairable = false
+
+# How long to stay in pairable mode before going back to non-discoverable
+# The value is in seconds. Default is 0.
+# 0 = disable timer, i.e. stay pairable forever
+#PairableTimeout = 0
+
+# Use vendor id source (assigner), vendor, product and version information for
+# DID profile support. The values are separated by ":" and assigner, VID, PID
+# and version.
+# Possible vendor id source values: bluetooth, usb (default) or false (disabled)
+#DeviceID = bluetooth:1234:5678:abcd
+
+# Do reverse service discovery for previously unknown devices that connect to
+# us. For BR/EDR this option is really only needed for qualification since the
+# BITE tester doesn't like us doing reverse SDP for some test cases, for LE
+# this disables the GATT client functionally so it can be used in system which
+# can only operate as peripheral (see also GATT Client option).
+# Defaults to 'true'.
+#ReverseServiceDiscovery = true
+
+# Enable name resolving after inquiry. Set it to 'false' if you don't need
+# remote devices name and want shorter discovery cycle. Defaults to 'true'.
+#NameResolving = true
+
+# Enable runtime persistency of debug link keys. Default is false which
+# makes debug link keys valid only for the duration of the connection
+# that they were created for.
+#DebugKeys = false
+
+# Restricts all controllers to the specified transport. Default value
+# is "dual", i.e. both BR/EDR and LE enabled (when supported by the HW).
+# Possible values: "dual", "bredr", "le"
+#ControllerMode = dual
+
+# Maximum number of controllers allowed to be exposed to the system.
+# Default=0 (unlimited)
+#MaxControllers=0
+
+# Enables Multi Profile Specification support. This allows to specify if
+# system supports only Multiple Profiles Single Device (MPSD) configuration
+# or both Multiple Profiles Single Device (MPSD) and Multiple Profiles Multiple
+# Devices (MPMD) configurations.
+# Possible values: "off", "single", "multiple"
+#MultiProfile = off
+
+# Permanently enables the Fast Connectable setting for adapters that
+# support it. When enabled other devices can connect faster to us,
+# however the tradeoff is increased power consumptions. This feature
+# will fully work only on kernel version 4.1 and newer. Defaults to
+# 'false'.
+#FastConnectable = false
+
+# Default privacy setting.
+# Enables use of private address.
+# Possible values for LE mode: "off", "network/on", "device"
+# Possible values for Dual mode: "off", "network/on", "device",
+# "limited-network", "limited-device"
+#
+# - off: Local privacy disabled.
+#
+# - network/on: A device will only accept advertising packets from peer
+# devices that contain private addresses. It may not be compatible with some
+# legacy devices since it requires the use of RPA(s) all the time.
+#
+# - device: A device in device privacy mode is only concerned about the
+# privacy of the device and will accept advertising packets from peer devices
+# that contain their Identity Address as well as ones that contain a private
+# address, even if the peer device has distributed its IRK in the past.
+
+# - limited-network: Apply Limited Discoverable Mode to advertising, which
+# follows the same policy as to BR/EDR that publishes the identity address when
+# discoverable, and Network Privacy Mode for scanning.
+#
+# - limited-device: Apply Limited Discoverable Mode to advertising, which
+# follows the same policy as to BR/EDR that publishes the identity address when
+# discoverable, and Device Privacy Mode for scanning.
+#
+# Defaults to "off"
+#Privacy = off
+
+# Specify the policy to the JUST-WORKS repairing initiated by peer
+# Possible values: "never", "confirm", "always"
+# Defaults to "never"
+#JustWorksRepairing = never
+
+# How long to keep temporary devices around
+# The value is in seconds. Default is 30.
+# 0 = disable timer, i.e. never keep temporary devices
+#TemporaryTimeout = 30
+
+# Enables the device to issue an SDP request to update known services when
+# profile is connected. Defaults to true.
+#RefreshDiscovery = true
+
+# Default Secure Connections setting.
+# Enables the Secure Connections setting for adapters that support it. It
+# provides better crypto algorithms for BT links and also enables CTKD (cross
+# transport key derivation) during pairing on any link.
+# Possible values: "off", "on", "only"
+# - "off": Secure Connections are disabled
+# - "on": Secure Connections are enabled when peer device supports them
+# - "only": we allow only Secure Connections
+# Defaults to "on"
+#SecureConnections = on
+
+# Enables D-Bus experimental interfaces
+# Possible values: true or false
+Experimental = true
+
+# Enables D-Bus testing interfaces
+# Possible values: true or false
+#Testing = false
+
+# Enables kernel experimental features, alternatively a list of UUIDs
+# can be given.
+# Possible values: true,false,<UUID List>
+# Possible UUIDS:
+# d4992530-b9ec-469f-ab01-6c481c47da1c (BlueZ Experimental Debug)
+# 671b10b5-42c0-4696-9227-eb28d1b049d6 (BlueZ Experimental Simultaneous Central and Peripheral)
+# 15c0a148-c273-11ea-b3de-0242ac130004 (BlueZ Experimental LL privacy)
+# 330859bc-7506-492d-9370-9a6f0614037f (BlueZ Experimental Bluetooth Quality Report)
+# a6695ace-ee7f-4fb9-881a-5fac66c629af (BlueZ Experimental Offload Codecs)
+# 6fbaf188-05e0-496a-9885-d6ddfdb4e03e (BlueZ Experimental ISO socket)
+# Defaults to false.
+KernelExperimental = 6fbaf188-05e0-496a-9885-d6ddfdb4e03e
+
+# The duration to avoid retrying to resolve a peer's name, if the previous
+# try failed.
+# The value is in seconds. Default is 300, i.e. 5 minutes.
+#RemoteNameRequestRetryDelay = 300
+
+[BR]
+# The following values are used to load default adapter parameters for BR/EDR.
+# BlueZ loads the values into the kernel before the adapter is powered if the
+# kernel supports the MGMT_LOAD_DEFAULT_PARAMETERS command. If a value isn't
+# provided, the kernel will be initialized to it's default value.  The actual
+# value will vary based on the kernel version and thus aren't provided here.
+# The Bluetooth Core Specification should be consulted for the meaning and valid
+# domain of each of these values.
+
+# BR/EDR Page scan activity configuration
+#PageScanType=
+#PageScanInterval=
+#PageScanWindow=
+
+# BR/EDR Inquiry scan activity configuration
+#InquiryScanType=
+#InquiryScanInterval=
+#InquiryScanWindow=
+
+# BR/EDR Link supervision timeout
+#LinkSupervisionTimeout=
+
+# BR/EDR Page Timeout
+#PageTimeout=
+
+# BR/EDR Sniff Intervals
+#MinSniffInterval=
+#MaxSniffInterval=
+
+[LE]
+# Enable/Disable Central Address Resolution.
+# 0: disable
+# 1: enable
+# Defaults to 1
+#CentralAddressResolution = 1
+
+# The following values are used to load default adapter parameters for LE.
+# BlueZ loads the values into the kernel before the adapter is powered if the
+# kernel supports the MGMT_LOAD_DEFAULT_PARAMETERS command. If a value isn't
+# provided, the kernel will be initialized to it's default value.  The actual
+# value will vary based on the kernel version and thus aren't provided here.
+# The Bluetooth Core Specification should be consulted for the meaning and valid
+# domain of each of these values.
+# LE advertisement interval (used for legacy advertisement interface only)
+#MinAdvertisementInterval=
+#MaxAdvertisementInterval=
+#MultiAdvertisementRotationInterval=
+
+# LE scanning parameters used for passive scanning supporting auto connect
+# scenarios
+#ScanIntervalAutoConnect=
+#ScanWindowAutoConnect=
+
+# LE scanning parameters used for passive scanning supporting wake from suspend
+# scenarios
+#ScanIntervalSuspend=
+#ScanWindowSuspend=
+
+# LE scanning parameters used for active scanning supporting discovery
+# proceedure
+#ScanIntervalDiscovery=
+#ScanWindowDiscovery=
+
+# LE scanning parameters used for passive scanning supporting the advertisement
+# monitor Apis
+#ScanIntervalAdvMonitor=
+#ScanWindowAdvMonitor=
+
+# LE scanning parameters used for connection establishment.
+#ScanIntervalConnect=
+#ScanWindowConnect=
+
+# LE default connection parameters.  These values are superceeded by any
+# specific values provided via the Load Connection Parameters interface
+#MinConnectionInterval=
+#MaxConnectionInterval=
+#ConnectionLatency=
+#ConnectionSupervisionTimeout=
+#Autoconnecttimeout=
+
+# Scan duration during interleaving scan. Only used when scanning for ADV
+# monitors. The units are msec.
+# Default: 300
+#AdvMonAllowlistScanDuration=
+# Default: 500
+#AdvMonNoFilterScanDuration=
+
+# Enable/Disable Advertisement Monitor interleave scan for power saving.
+# 0: disable
+# 1: enable
+# Defaults to 1
+#EnableAdvMonInterleaveScan=
+
+[GATT]
+# GATT attribute cache.
+# Possible values:
+# always: Always cache attributes even for devices not paired, this is
+# recommended as it is best for interoperability, with more consistent
+# reconnection times and enables proper tracking of notifications for all
+# devices.
+# yes: Only cache attributes of paired devices.
+# no: Never cache attributes
+# Default: always
+#Cache = always
+
+# Minimum required Encryption Key Size for accessing secured characteristics.
+# Possible values: 0 and 7-16. 0 means don't care.
+# Defaults to 0
+#KeySize = 0
+
+# Exchange MTU size.
+# Possible values: 23-517
+# Defaults to 517
+#ExchangeMTU = 517
+
+# Number of ATT channels
+# Possible values: 1-5 (1 disables EATT)
+# Default to 1
+#Channels = 1
+
+# Export claimed services by plugins
+# Possible values: no, read-only, read-write
+# Default: read-only
+#ExportClaimedServices = read-only
+
+[CSIS]
+# SIRK - Set Identification Resolution Key which is common for all the
+# sets. They SIRK key is used to identify its sets. This can be any
+# 128 bit value or a string value (e.g. product name) which is then hashed.
+# Possible Values:
+# 16 byte hexadecimal value: 861FAE703ED681F0C50B34155B6434FB
+# String value: "My Product Name"
+# Defaults to none
+#SIRK =
+
+# SIRK Encryption
+# Possible values:
+# true: Encrypt SIRK when read
+# false: Do not encrypt SIRK when read. (plaintext)
+# Defaults to true
+#Encryption = true
+
+# Total no of sets belongs to this Profile
+# Defaults to 0
+#Size = 0
+
+# Rank for the device
+# Defaults to 0
+#Rank = 0
+
+# This enables the GATT client functionally, so it can be disabled in system
+# which can only operate as a peripheral.
+# Defaults to 'true'.
+#Client = true
+
+[AVDTP]
+# AVDTP L2CAP Signalling Channel Mode.
+# Possible values:
+# basic: Use L2CAP Basic Mode
+# ertm: Use L2CAP Enhanced Retransmission Mode
+#SessionMode = basic
+
+# AVDTP L2CAP Transport Channel Mode.
+# Possible values:
+# basic: Use L2CAP Basic Mode
+# streaming: Use L2CAP Streaming Mode
+#StreamMode = basic
+
+[AVRCP]
+# Allow SetAbsoluteVolume calls to a peer device that does not advertise the
+# AVRCP remote control target profile.  If it does advertise this profile, the
+# version is ignored.
+#VolumeWithoutTarget = false
+
+# Validate that remote AVRCP profiles advertise the category-2 bit before
+# allowing SetAbsoluteVolume calls or registering for EVENT_VOLUME_CHANGED
+# notifications.
+#VolumeCategory = true
+
+[Policy]
+#
+# The ReconnectUUIDs defines the set of remote services that should try
+# to be reconnected to in case of a link loss (link supervision
+# timeout). The policy plugin should contain a sane set of values by
+# default, but this list can be overridden here. By setting the list to
+# empty the reconnection feature gets disabled.
+#ReconnectUUIDs=00001112-0000-1000-8000-00805f9b34fb,0000111f-0000-1000-8000-00805f9b34fb,0000110a-0000-1000-8000-00805f9b34fb,0000110b-0000-1000-8000-00805f9b34fb
+
+# ReconnectAttempts define the number of attempts to reconnect after a link
+# lost. Setting the value to 0 disables reconnecting feature.
+#ReconnectAttempts=7
+
+# ReconnectIntervals define the set of intervals in seconds to use in between
+# attempts.
+# If the number of attempts defined in ReconnectAttempts is bigger than the
+# set of intervals the last interval is repeated until the last attempt.
+#ReconnectIntervals=1,2,4,8,16,32,64
+
+# AutoEnable defines option to enable all controllers when they are found.
+# This includes adapters present on start as well as adapters that are plugged
+# in later on. Defaults to 'true'.
+#AutoEnable=true
+
+# Audio devices that were disconnected due to suspend will be reconnected on
+# resume. ResumeDelay determines the delay between when the controller
+# resumes from suspend and a connection attempt is made. A longer delay is
+# better for better co-existence with Wi-Fi.
+# The value is in seconds.
+# Default: 2
+#ResumeDelay = 2
+
+[AdvMon]
+# Default RSSI Sampling Period. This is used when a client registers an
+# advertisement monitor and leaves the RSSISamplingPeriod unset.
+# Possible values:
+# 0x00       Report all advertisements
+# N = 0xXX   Report advertisements every N x 100 msec (range: 0x01 to 0xFE)
+# 0xFF       Report only one advertisement per device during monitoring period
+# Default: 0xFF
+#RSSISamplingPeriod=0xFF


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

This adds an alternate configuration file that enables LE Audio by
default, this can then be loaded with e.g:

src/bluetoothd -f src/leaudio.conf
---
 src/{main.conf => leaudio.conf} | 9 ++++-----
 1 file changed, 4 insertions(+), 5 deletions(-)
 copy src/{main.conf => leaudio.conf} (98%)