### PR TITLE
[PW_SID:933899] [BlueZ] test-runner: Allow to use host CPU on demand

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/tools/test-runner.c
+++ b/tools/test-runner.c
@@ -52,6 +52,7 @@ static bool start_dbus_session;
 static bool start_daemon = false;
 static bool start_emulator = false;
 static bool start_monitor = false;
+static bool qemu_host_cpu = false;
 static int num_devs = 0;
 static const char *qemu_binary = NULL;
 static const char *kernel_image = NULL;
@@ -211,7 +212,6 @@ static char *const qemu_argv[] = {
 	"-monitor", "none",
 	"-display", "none",
 	"-machine", "type=q35,accel=kvm:tcg",
-	"-cpu", "host",
 	"-m", "256M",
 	"-net", "none",
 	"-no-reboot",
@@ -280,7 +280,7 @@ static void start_qemu(void)
 				testargs);
 
 	argv = alloca(sizeof(qemu_argv) +
-				(sizeof(char *) * (4 + (num_devs * 4))));
+				(sizeof(char *) * (6 + (num_devs * 4))));
 	memcpy(argv, qemu_argv, sizeof(qemu_argv));
 
 	pos = (sizeof(qemu_argv) / sizeof(char *)) - 1;
@@ -291,6 +291,11 @@ static void start_qemu(void)
 		exit(1);
 	}
 	argv[0] = (char *) qemu_binary;
+
+	if (qemu_host_cpu) {
+		argv[pos++] = "-cpu";
+		argv[pos++] = "host";
+	}
 
 	argv[pos++] = "-kernel";
 	argv[pos++] = (char *) kernel_image;
@@ -1171,6 +1176,7 @@ static void usage(void)
 		"\t-A, --audio[=path]     Start audio server\n"
 		"\t-u, --unix [path]      Provide serial device\n"
 		"\t-q, --qemu <path>      QEMU binary\n"
+		"\t-H, --qemu-host-cpu    Use host CPU (requires KVM support)\n"
 		"\t-k, --kernel <image>   Kernel image (bzImage)\n"
 		"\t-h, --help             Show help options\n");
 }
@@ -1185,6 +1191,7 @@ static const struct option main_options[] = {
 	{ "emulator", no_argument,      NULL, 'l' },
 	{ "monitor", no_argument,       NULL, 'm' },
 	{ "qemu",    required_argument, NULL, 'q' },
+	{ "qemu-host-cpu", no_argument, NULL, 'H' },
 	{ "kernel",  required_argument, NULL, 'k' },
 	{ "audio",   optional_argument, NULL, 'A' },
 	{ "version", no_argument,       NULL, 'v' },
@@ -1206,7 +1213,7 @@ int main(int argc, char *argv[])
 	for (;;) {
 		int opt;
 
-		opt = getopt_long(argc, argv, "aubdslmq:k:A::vh", main_options,
+		opt = getopt_long(argc, argv, "aubdslmq:Hk:A::vh", main_options,
 								NULL);
 		if (opt < 0)
 			break;
@@ -1236,6 +1243,9 @@ int main(int argc, char *argv[])
 			break;
 		case 'q':
 			qemu_binary = optarg;
+			break;
+		case 'H':
+			qemu_host_cpu = true;
 			break;
 		case 'k':
 			kernel_image = optarg;


### PR DESCRIPTION
The "-cpu host" option for QEMU can not be enabled by default because
our CI system does not have a support for KVM. In order to allow to run
the test-runner on systems where binaries built on the host are not
compatible with QEMU CPU variant, the "--qemu-host-cpu" option will add
the "-cpu host" to the QEMU command line arguments.
---
 tools/test-runner.c | 16 +++++++++++++---
 1 file changed, 13 insertions(+), 3 deletions(-)