### PR TITLE
[PW_SID:934345] [BlueZ,v2] bthost: Set advertising intervals to valid value

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/emulator/btdev.c
+++ b/emulator/btdev.c
@@ -4873,14 +4873,15 @@ static int cmd_set_ext_adv_params(struct btdev *dev, const void *data,
 
 	ext_adv->type = le16_to_cpu(cmd->evt_properties);
 
-	/* In case of direct advertising (type == 0x01) the advertising
-	 * intervals shall be ignored and high duty cycle shall be used.
+	/* In case of high duty cycle directed connectable advertising
+	 * intervals shall be ignored and high duty cycle shall be used
+	 * (advertising interval <= 3.75 ms).
 	 */
-	if (ext_adv->type == 0x01)
-		ext_adv->interval = 10;
+	if ((ext_adv->type & 0x0D) == 0x0D /* 0b1101 */)
+		ext_adv->interval = 3;
 	else {
 		unsigned int min_interval = get_le24(cmd->min_interval);
-		if (min_interval < 0x0020 || min_interval > 0x4000) {
+		if (min_interval < 0x0020 || min_interval > 0xFFFFFF) {
 			rsp.status = BT_HCI_ERR_UNSUPPORTED_FEATURE;
 			cmd_complete(dev, BT_HCI_CMD_LE_SET_EXT_ADV_PARAMS,
 						&rsp, sizeof(rsp));

--- a/emulator/bthost.c
+++ b/emulator/bthost.c
@@ -3249,11 +3249,14 @@ void bthost_set_scan_enable(struct bthost *bthost, uint8_t enable)
 
 void bthost_set_ext_adv_params(struct bthost *bthost)
 {
+	const uint8_t interval_20ms[] = { 0x20, 0x00, 0x00 };
 	struct bt_hci_cmd_le_set_ext_adv_params cp;
 
 	memset(&cp, 0, sizeof(cp));
 	cp.handle = 0x01;
 	cp.evt_properties = cpu_to_le16(0x0013);
+	memcpy(cp.min_interval, interval_20ms, sizeof(cp.min_interval));
+	memcpy(cp.max_interval, interval_20ms, sizeof(cp.max_interval));
 	send_command(bthost, BT_HCI_CMD_LE_SET_EXT_ADV_PARAMS,
 							&cp, sizeof(cp));
 }


### PR DESCRIPTION
The range for LE advertising intervals shall be in range between 20 ms
and 10,485,759.375 ms. Requesting other value should result in the
unsupported feature or parameter value error code (0x11).

After the modification in fa4d477, the btdev emulator no longer accepts
uninitialized LE advertising intervals. To fix that, set the default LE
advertising interval to the lowest possible value - 20 ms - in order to
minimize tests delay cause by device discovery.

Also, this commit fixes the detection of the high duty cycle directed
connectable advertising and sets the advertising interval to 3 ms for
such cases in order to be complaint with the spec.
---
 emulator/btdev.c  | 11 ++++++-----
 emulator/bthost.c |  3 +++
 2 files changed, 9 insertions(+), 5 deletions(-)