### PR TITLE
[PW_SID:934417] [BlueZ] shared/vcp: fix setting volume back to current value

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/src/shared/vcp.c
+++ b/src/shared/vcp.c
@@ -2119,14 +2119,14 @@ static bool vcp_set_volume_client(struct bt_vcp *vcp, uint8_t volume)
 	 * the current one completes. This may skip over some volume changes,
 	 * as it only sends a request for the final value.
 	 */
-	if (vcp->volume == volume) {
+	if (vcp->pending_op.timeout_id) {
+		vcp->pending_op.volume = volume;
+		vcp->pending_op.resend = true;
+		return true;
+	} else if (vcp->volume == volume) {
 		/* Do not set to current value, as that doesn't generate
 		 * a notification
 		 */
-		return true;
-	} else if (vcp->pending_op.timeout_id) {
-		vcp->pending_op.volume = volume;
-		vcp->pending_op.resend = true;
 		return true;
 	}
 


### PR DESCRIPTION
If there is a volume change request in flight, always update pending
volume. Otherwise, setting the value back to old value before
notification arrives, is wrongly ignored.

Fixes: e77884accdb2 ("shared/vcp: have only one volume change in flight at a time")
---
 src/shared/vcp.c | 10 +++++-----
 1 file changed, 5 insertions(+), 5 deletions(-)