### PR TITLE
[PW_SID:935872] [BlueZ,1/2] obexd/client/map: Add SupportedTypes property to MessageAccess1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/doc/org.bluez.obex.MessageAccess.rst
+++ b/doc/org.bluez.obex.MessageAccess.rst
@@ -199,3 +199,33 @@ object, dict PushMessage(string sourcefile, string folder, dict args)
 
 	:org.bluez.obex.Error.InvalidArguments:
 	:org.bluez.obex.Error.Failed:
+
+Properties
+----------
+
+array{string} SupportedTypes [readonly]
+```````````````````````````````````````
+
+	List of supported message types.
+
+	Possible values:
+
+	:"EMAIL":
+
+		Email messages.
+
+	:"SMS_GSM":
+
+		GSM short messages.
+
+	:"SMS_CDMA":
+
+		CDMA short messages.
+
+	:"MMS":
+
+		MMS messages.
+
+	:"IM":
+
+		Instant messaging.


### PR DESCRIPTION
This lists the message types supported the remote MSE.
Possible values are: EMAIL, SMS_GSM, SMS_CDMA, MMS and IM.

Those values can be used as message type when sending a message
using PushMessage method.
---
 obexd/client/map.c | 47 +++++++++++++++++++++++++++++++++++++++++++++-
 1 file changed, 46 insertions(+), 1 deletion(-)