### PR TITLE
[PW_SID:935909] bap: Update bt_bap user data handling

### DIFF
--- a/profiles/audio/bap.c
+++ b/profiles/audio/bap.c
@@ -192,10 +192,8 @@ static void bap_data_free(struct bap_data *data)
 	if (data->io_id)
 		g_source_remove(data->io_id);
 
-	if (data->service && btd_service_get_user_data(data->service) == data) {
+	if (data->service && btd_service_get_user_data(data->service) == data)
 		btd_service_set_user_data(data->service, NULL);
-		bt_bap_set_user_data(data->bap, NULL);
-	}
 
 	queue_destroy(data->snks, ep_unregister);
 	queue_destroy(data->srcs, ep_unregister);

--- a/profiles/audio/bap.c
+++ b/profiles/audio/bap.c
@@ -3280,7 +3280,6 @@ static int bap_adapter_probe(struct btd_profile *p, struct btd_adapter *adapter)
 	data->pac_id = bt_bap_pac_register(data->bap, pac_added_broadcast,
 					pac_removed_broadcast, data, NULL);
 
-	bt_bap_set_user_data(data->bap, adapter);
 	bap_data_set_user_data(data, adapter);
 
 	data->adapter = adapter;

--- a/profiles/audio/bass.c
+++ b/profiles/audio/bass.c
@@ -559,13 +559,20 @@ static void confirm_cb(GIOChannel *io, void *user_data)
 
 static void bap_attached(struct bt_bap *bap, void *user_data)
 {
-	struct btd_service *service = bt_bap_get_user_data(bap);
-	struct btd_device *device = btd_service_get_device(service);
-	struct btd_adapter *adapter = device_get_adapter(device);
+	struct btd_service *service;
+	struct btd_device *device;
+	struct btd_adapter *adapter;
 	struct bass_delegator *dg;
 	GError *err = NULL;
 
 	DBG("%p", bap);
+
+	service = bt_bap_get_user_data(bap);
+	if (!service)
+		return;
+
+	device = btd_service_get_device(service);
+	adapter = device_get_adapter(device);
 
 	dg = queue_find(delegators, delegator_match_device, device);
 	if (!dg)
@@ -620,11 +627,17 @@ static void setup_free(void *data)
 
 static void bap_detached(struct bt_bap *bap, void *user_data)
 {
-	struct btd_service *service = bt_bap_get_user_data(bap);
-	struct btd_device *device = btd_service_get_device(service);
+	struct btd_service *service;
+	struct btd_device *device;
 	struct bass_delegator *dg;
 
 	DBG("%p", bap);
+
+	service = bt_bap_get_user_data(bap);
+	if (!service)
+		return;
+
+	device = btd_service_get_device(service);
 
 	dg = queue_remove_if(delegators, delegator_match_device, device);
 	if (!dg)


### PR DESCRIPTION
After detaching a bt_bap session, each plugin that registered a bap
detached callback will be notified. The bt_bap user data should be
set when calling these callbacks, so the bt_bap session can be
matched to the associated service and the cleanup is handled
accordingly.
---
 profiles/audio/bap.c | 4 +---
 1 file changed, 1 insertion(+), 3 deletions(-)