### PR TITLE
[PW_SID:936519] shared/gatt-db: Fix incorrect attribute type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/src/shared/gatt-db.c
+++ b/src/shared/gatt-db.c
@@ -379,6 +379,9 @@ static void gen_hash_m(struct gatt_db_attribute *attr, void *user_data)
 	uint8_t *data;
 	size_t len;
 
+	if (!attr || !attr->value)
+		return;
+
 	if (bt_uuid_len(&attr->uuid) != 2)
 		return;
 
@@ -1005,6 +1008,10 @@ service_insert_characteristic(struct gatt_db_service *service,
 
 	/* Update handle of characteristic value_handle if it has changed */
 	put_le16(value_handle, &value[1]);
+
+	if (!(*chrc) || !(*chrc)->value)
+		return NULL;
+
 	if (memcmp((*chrc)->value, value, len))
 		memcpy((*chrc)->value, value, len);
 
@@ -1229,6 +1236,9 @@ service_insert_included(struct gatt_db_service *service, uint16_t handle,
 	uint16_t included_handle, len = 0;
 	int index;
 
+	if (!include || !include->value || !include->service || !service)
+		return NULL;
+
 	included = include->service;
 
 	/* Adjust include to point to the first attribute */
@@ -1384,6 +1394,9 @@ static void find_by_type(struct gatt_db_attribute *attribute, void *user_data)
 	/* TODO: fix for read-callback based attributes */
 	if (search_data->value) {
 		if (search_data->value_len != attribute->value_len)
+			return;
+
+		if (!attribute || !attribute->value)
 			return;
 
 		if (memcmp(attribute->value, search_data->value,


### PR DESCRIPTION
As part of BLE GATT Fuzzing testcase,if application sends an invalid
ATT_FIND_BY_TYPE_VALUE_REQ with attribute type as CCC (UUID 0x2902).
However,this request is not valid for descriptors like CCC, as it is 
specifically intended for discovering primary services with a given UUID.
When processed in find_by_type(),attempts to access attribute->value 
without checking if attribute or attribute->value is NULL,
leading to a segmentation fault.

Added NULL pointer checks before accessing attribute values in multiple
functions to prevent potential crashes due to invalid memory access

Bluetoothd crash dump:
0 0x73fec87ae81e  (/lib/x86_64-linux-gnu/libc.so.6+0x1ae81e)
1 0x73fec94942e9 in MemcmpInterceptorCommon(void*, int (*)
(void const*, void const*, unsigned long), void const*, 
void const*, unsigned long) 
../../../../src/libsanitizer/sanitizer_common/
sanitizer_common_interceptors.inc:881
2 0x73fec9494bc6 in __interceptor_memcmp ../../../../src/
libsanitizer/sanitizer_common
/sanitizer_common_interceptors.inc:892
3 0x73fec9494bc6 in __interceptor_memcmp ../../../../src/
libsanitizer/sanitizer_common
/sanitizer_common_interceptors.inc:887
4 0x5d5c290f2456 in find_by_type src/shared/gatt-db.c:1389
5 0x5d5c290ff855 in foreach_in_range src/shared/gatt-db.c:1549
6 0x5d5c29099752 in queue_foreach src/shared/queue.c:207
7 0x5d5c290fb085 in gatt_db_foreach_in_range src/shared/gatt-db.c:1593
8 0x5d5c290fb4ca in gatt_db_find_by_type_value src/shared/gatt-db.c:1434
9 0x5d5c290e1996 in find_by_type_val_cb src/shared/gatt-server.c:745
10 0x5d5c290c3083 in handle_notify src/shared/att.c:1015
11 0x5d5c290c3083 in can_read_data src/shared/att.c:1100
12 0x5d5c291867c1 in watch_callback src/shared/io-glib.c:157
13 0x73fec931bc43 in g_main_context_dispatch 
(/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x55c43)
14 0x73fec93712b7  (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0xab2b7)
15 0x73fec931b2b2 in g_main_loop_run (/lib/x86_64-linux-gnu/
libglib-2.0.so.0+0x552b2)
16 0x5d5c29188518 in mainloop_run src/shared/mainloop-glib.c:66
17 0x5d5c29188e26 in mainloop_run_with_signal src/shared
/mainloop-notify.c:189
18 0x5d5c28d8c6ae in main src/main.c:1544
19 0x73fec8629d8f in __libc_start_call_main ../sysdeps/nptl/
libc_start_call_main.h:58
20 0x73fec8629e3f in __libc_start_main_impl ../csu/libc-start.c:392
21 0x5d5c28d8f4c4 in _start (/root/LE_Audio_Work/Bluez/bluez/
src/bluetoothd+0x6204c4)
---
 src/shared/gatt-db.c | 13 +++++++++++++
 1 file changed, 13 insertions(+)