### PR TITLE
[PW_SID:937397] bass: Register bis probe/remove callbacks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/profiles/audio/bap.c
+++ b/profiles/audio/bap.c
@@ -1178,7 +1178,7 @@ static void bis_handler(uint8_t bis, uint8_t sgrp, struct iovec *caps,
 	struct bt_bap_pac *lpac;
 	char *path;
 
-	bass_add_stream(data->device, meta, caps, qos, sgrp, bis);
+	bt_bap_bis_probe(data->bap, bis, sgrp, caps, meta, qos);
 
 	/* Check if this BIS matches any local PAC */
 	bt_bap_verify_bis(data->bap, bis,
@@ -3128,9 +3128,9 @@ static void bap_bcast_remove(struct btd_service *service)
 		return;
 	}
 
-	bap_data_remove(data);
+	bt_bap_bis_remove(data->bap);
 
-	bass_remove_stream(device);
+	bap_data_remove(data);
 }
 
 static int bap_probe(struct btd_service *service)

--- a/profiles/audio/bass.h
+++ b/profiles/audio/bass.h
@@ -7,11 +7,6 @@
  *
  */
 
-void bass_add_stream(struct btd_device *device, struct iovec *meta,
-			struct iovec *caps, struct bt_bap_qos *qos,
-			uint8_t sgrp, uint8_t bis);
-void bass_remove_stream(struct btd_device *device);
-
 typedef void (*bt_bass_bcode_func_t)(void *user_data, int err);
 
 void bass_req_bcode(struct bt_bap_stream *stream,

--- a/src/shared/bap.c
+++ b/src/shared/bap.c
@@ -80,6 +80,14 @@ struct bt_bap_state {
 	void *data;
 };
 
+struct bt_bap_bis_cb {
+	unsigned int id;
+	bt_bap_bis_func_t probe;
+	bt_bap_func_t remove;
+	bt_bap_destroy_func_t destroy;
+	void *data;
+};
+
 struct bt_bap_cb {
 	unsigned int id;
 	bt_bap_func_t attached;
@@ -180,6 +188,7 @@ struct bt_bap {
 	struct queue *pac_cbs;
 	struct queue *ready_cbs;
 	struct queue *state_cbs;
+	struct queue *bis_cbs;
 
 	bt_bap_debug_func_t debug_func;
 	bt_bap_destroy_func_t debug_destroy;
@@ -4190,6 +4199,16 @@ static void bap_state_free(void *data)
 	free(state);
 }
 
+static void bap_bis_cb_free(void *data)
+{
+	struct bt_bap_bis_cb *bis_cb = data;
+
+	if (bis_cb->destroy)
+		bis_cb->destroy(bis_cb->data);
+
+	free(bis_cb);
+}
+
 static void bap_ep_free(void *data)
 {
 	struct bt_bap_endpoint *ep = data;
@@ -4228,6 +4247,7 @@ static void bap_free(void *data)
 	queue_destroy(bap->pac_cbs, pac_changed_free);
 	queue_destroy(bap->ready_cbs, bap_ready_free);
 	queue_destroy(bap->state_cbs, bap_state_free);
+	queue_destroy(bap->bis_cbs, bap_bis_cb_free);
 	queue_destroy(bap->local_eps, free);
 	queue_destroy(bap->remote_eps, bap_ep_free);
 
@@ -4310,6 +4330,7 @@ struct bt_bap *bt_bap_new(struct gatt_db *ldb, struct gatt_db *rdb)
 	bap->ready_cbs = queue_new();
 	bap->streams = queue_new();
 	bap->state_cbs = queue_new();
+	bap->bis_cbs = queue_new();
 	bap->local_eps = queue_new();
 
 	if (!rdb)
@@ -5517,6 +5538,82 @@ bool bt_bap_state_unregister(struct bt_bap *bap, unsigned int id)
 	bap_state_free(state);
 
 	return false;
+}
+
+unsigned int bt_bap_bis_cb_register(struct bt_bap *bap,
+				bt_bap_bis_func_t probe,
+				bt_bap_func_t remove,
+				void *user_data,
+				bt_bap_destroy_func_t destroy)
+{
+	struct bt_bap_bis_cb *bis_cb;
+	static unsigned int id;
+
+	if (!bap)
+		return 0;
+
+	bis_cb = new0(struct bt_bap_bis_cb, 1);
+	bis_cb->id = ++id ? id : ++id;
+	bis_cb->probe = probe;
+	bis_cb->remove = remove;
+	bis_cb->destroy = destroy;
+	bis_cb->data = user_data;
+
+	queue_push_tail(bap->bis_cbs, bis_cb);
+
+	return bis_cb->id;
+}
+
+static bool match_bis_cb_id(const void *data, const void *match_data)
+{
+	const struct bt_bap_bis_cb *bis_cb = data;
+	unsigned int id = PTR_TO_UINT(match_data);
+
+	return (bis_cb->id == id);
+}
+
+bool bt_bap_bis_cb_unregister(struct bt_bap *bap, unsigned int id)
+{
+	struct bt_bap_bis_cb *bis_cb;
+
+	if (!bap)
+		return false;
+
+	bis_cb = queue_remove_if(bap->bis_cbs, match_bis_cb_id,
+						UINT_TO_PTR(id));
+	if (!bis_cb)
+		return false;
+
+	bap_bis_cb_free(bis_cb);
+
+	return false;
+}
+
+void bt_bap_bis_probe(struct bt_bap *bap, uint8_t bis, uint8_t sgrp,
+	struct iovec *caps, struct iovec *meta, struct bt_bap_qos *qos)
+{
+	const struct queue_entry *entry;
+
+	for (entry = queue_get_entries(bap->bis_cbs); entry;
+							entry = entry->next) {
+		struct bt_bap_bis_cb *cb = entry->data;
+
+		if (cb->probe)
+			cb->probe(bis, sgrp, caps, meta, qos, cb->data);
+	}
+}
+
+void bt_bap_bis_remove(struct bt_bap *bap)
+{
+	const struct queue_entry *entry;
+
+	for (entry = queue_get_entries(bap->bis_cbs); entry;
+							entry = entry->next) {
+		struct bt_bap_bis_cb *cb = entry->data;
+
+		if (cb->remove)
+			cb->remove(bap, cb->data);
+	}
 }
 
 const char *bt_bap_stream_statestr(uint8_t state)

--- a/src/shared/bap.h
+++ b/src/shared/bap.h
@@ -4,7 +4,7 @@
  *  BlueZ - Bluetooth protocol stack for Linux
  *
  *  Copyright (C) 2022  Intel Corporation. All rights reserved.
- *  Copyright 2023-2024 NXP
+ *  Copyright 2023-2025 NXP
  *
  */
 
@@ -269,3 +269,13 @@ bool bt_bap_parse_base(struct iovec *base,
 			bt_bap_bis_func_t handler,
 			void *user_data);
 
+unsigned int bt_bap_bis_cb_register(struct bt_bap *bap,
+				bt_bap_bis_func_t probe,
+				bt_bap_func_t remove,
+				void *user_data,
+				bt_bap_destroy_func_t destroy);
+bool bt_bap_bis_cb_unregister(struct bt_bap *bap, unsigned int id);
+
+void bt_bap_bis_probe(struct bt_bap *bap, uint8_t bis, uint8_t sgrp,
+	struct iovec *caps, struct iovec *meta, struct bt_bap_qos *qos);
+void bt_bap_bis_remove(struct bt_bap *bap);


### PR DESCRIPTION
This adds support for registering BIS probe/remove calllbacks with
shared/bap. This is needed by the BAP Broadcast Assistant (BASS Client)
implementation, so that the BAP plugin can notify BISes discovered
after parsing the BASE to BASS, avoiding direct function calls
between plugins.
---
 src/shared/bap.c | 97 ++++++++++++++++++++++++++++++++++++++++++++++++
 src/shared/bap.h | 12 +++++-
 2 files changed, 108 insertions(+), 1 deletion(-)