### PR TITLE
[PW_SID:937409] [bluez] adapter: Prepend the new added device to the adapter devices list

### DIFF
--- a/src/adapter.c
+++ b/src/adapter.c
@@ -5252,7 +5252,7 @@ void device_resolved_drivers(struct btd_adapter *adapter,
 static void adapter_add_device(struct btd_adapter *adapter,
 						struct btd_device *device)
 {
-	adapter->devices = g_slist_append(adapter->devices, device);
+	adapter->devices = g_slist_prepend(adapter->devices, device);
 	device_added_drivers(adapter, device);
 }
 


### PR DESCRIPTION
From: "ye.he" <ye.he@amlogic.com>

When the DUT is paired with a mobile phone using RPA multiple times,
multiple device contexts with the same bdaddr will be cached.
When we query the device context through bdaddr, we always get the
context at the head of adapter->devices, but its status is inactive.

https://github.com/bluez/bluez/issues/1095

Signed-off-by: ye.he <ye.he@amlogic.com>
---
 src/adapter.c | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)


---
base-commit: 0845b8f6ef2ac004b1c953cf4fe4ca3458cd8e36
change-id: 20250225-leaudio-no-media-634423086ea4

Best regards,