### PR TITLE
[PW_SID:939060] bass: Register broadcast code request callback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/Makefile.plugins
+++ b/Makefile.plugins
@@ -118,7 +118,7 @@ endif
 
 if BASS
 builtin_modules += bass
-builtin_sources += profiles/audio/bass.h profiles/audio/bass.c
+builtin_sources += profiles/audio/bass.c
 endif
 
 if MCP

--- a/profiles/audio/bap.c
+++ b/profiles/audio/bap.c
@@ -57,7 +57,6 @@
 #include "src/error.h"
 
 #include "bap.h"
-#include "bass.h"
 
 #define ISO_SOCKET_UUID "6fbaf188-05e0-496a-9885-d6ddfdb4e03e"
 #define PACS_UUID_STR "00001850-0000-1000-8000-00805f9b34fb"

--- a/profiles/audio/bass.c
+++ b/profiles/audio/bass.c
@@ -52,7 +52,6 @@
 #include "src/log.h"
 #include "src/error.h"
 
-#include "bass.h"
 #include "bap.h"
 
 #define BASS_UUID_STR "0000184f-0000-1000-8000-00805f9b34fb"

--- a/profiles/audio/bass.h
+++ b/profiles/audio/bass.h
@@ -7,8 +7,3 @@
  *
  */
 
-typedef void (*bt_bass_bcode_func_t)(void *user_data, int err);
-
-void bass_req_bcode(struct bt_bap_stream *stream,
-				bt_bass_bcode_func_t cb,
-				void *user_data);

--- a/profiles/audio/bass.h
+++ b/profiles/audio/bass.h
@@ -1,9 +1,0 @@
-/* SPDX-License-Identifier: GPL-2.0-or-later */
-/*
- *
- *  BlueZ - Bluetooth protocol stack for Linux
- *
- *  Copyright 2024-2025 NXP
- *
- */
-

--- a/profiles/audio/transport.c
+++ b/profiles/audio/transport.c
@@ -54,7 +54,6 @@
 
 #include "media.h"
 #include "transport.h"
-#include "bass.h"
 #include "vcp.h"
 
 #define MEDIA_TRANSPORT_INTERFACE "org.bluez.MediaTransport1"

--- a/profiles/audio/transport.c
+++ b/profiles/audio/transport.c
@@ -5,7 +5,7 @@
  *
  *  Copyright (C) 2006-2007  Nokia Corporation
  *  Copyright (C) 2004-2009  Marcel Holtmann <marcel@holtmann.org>
- *  Copyright 2023-2024 NXP
+ *  Copyright 2023-2025 NXP
  *
  *
  */
@@ -1537,7 +1537,7 @@ static void set_bcast_qos(const GDBusPropertyTable *property,
 			 * for the encrypted stream, request the code from
 			 * Broadcast Assistants, if any are available.
 			 */
-			bass_req_bcode(bap->stream, bcast_qos_set,
+			bt_bap_req_bcode(bap->stream, bcast_qos_set,
 						GUINT_TO_POINTER(id));
 			return;
 		}

--- a/src/shared/bap.c
+++ b/src/shared/bap.c
@@ -88,6 +88,13 @@ struct bt_bap_bis_cb {
 	void *data;
 };
 
+struct bt_bap_bcode_cb {
+	unsigned int id;
+	bt_bap_bcode_func_t func;
+	bt_bap_destroy_func_t destroy;
+	void *data;
+};
+
 struct bt_bap_cb {
 	unsigned int id;
 	bt_bap_func_t attached;
@@ -189,6 +196,7 @@ struct bt_bap {
 	struct queue *ready_cbs;
 	struct queue *state_cbs;
 	struct queue *bis_cbs;
+	struct queue *bcode_cbs;
 
 	bt_bap_debug_func_t debug_func;
 	bt_bap_destroy_func_t debug_destroy;
@@ -4226,6 +4234,16 @@ static void bap_bis_cb_free(void *data)
 	free(bis_cb);
 }
 
+static void bap_bcode_cb_free(void *data)
+{
+	struct bt_bap_bcode_cb *cb = data;
+
+	if (cb->destroy)
+		cb->destroy(cb->data);
+
+	free(cb);
+}
+
 static void bap_ep_free(void *data)
 {
 	struct bt_bap_endpoint *ep = data;
@@ -4265,6 +4283,7 @@ static void bap_free(void *data)
 	queue_destroy(bap->ready_cbs, bap_ready_free);
 	queue_destroy(bap->state_cbs, bap_state_free);
 	queue_destroy(bap->bis_cbs, bap_bis_cb_free);
+	queue_destroy(bap->bcode_cbs, bap_bcode_cb_free);
 	queue_destroy(bap->local_eps, free);
 	queue_destroy(bap->remote_eps, bap_ep_free);
 
@@ -4348,6 +4367,7 @@ struct bt_bap *bt_bap_new(struct gatt_db *ldb, struct gatt_db *rdb)
 	bap->streams = queue_new();
 	bap->state_cbs = queue_new();
 	bap->bis_cbs = queue_new();
+	bap->bcode_cbs = queue_new();
 	bap->local_eps = queue_new();
 
 	if (!rdb)
@@ -7349,4 +7369,82 @@ done:
 		util_debug(func, NULL, "Unable to parse Base");
 
 	return ret;
+}
+
+void bt_bap_req_bcode(struct bt_bap_stream *stream,
+				bt_bap_bcode_reply_t reply,
+				void *reply_data)
+{
+	const struct queue_entry *entry;
+
+	if (!bap_stream_valid(stream))
+		return;
+
+	bt_bap_stream_ref(stream);
+
+	if (!bt_bap_ref_safe(stream->bap))
+		goto done;
+
+	entry = queue_get_entries(stream->bap->bcode_cbs);
+
+	while (entry) {
+		struct bt_bap_bcode_cb *cb = entry->data;
+
+		entry = entry->next;
+
+		if (cb->func)
+			cb->func(stream, reply, reply_data, cb->data);
+	}
+
+	bt_bap_unref(stream->bap);
+
+done:
+	bt_bap_stream_unref(stream);
+}
+
+unsigned int bt_bap_bcode_cb_register(struct bt_bap *bap,
+				bt_bap_bcode_func_t func,
+				void *user_data,
+				bt_bap_destroy_func_t destroy)
+{
+	struct bt_bap_bcode_cb *cb;
+	static unsigned int id;
+
+	if (!bap)
+		return 0;
+
+	cb = new0(struct bt_bap_bcode_cb, 1);
+	cb->id = ++id ? id : ++id;
+	cb->func = func;
+	cb->destroy = destroy;
+	cb->data = user_data;
+
+	queue_push_tail(bap->bcode_cbs, cb);
+
+	return cb->id;
+}
+
+static bool match_bcode_cb_id(const void *data, const void *match_data)
+{
+	const struct bt_bap_bcode_cb *cb = data;
+	unsigned int id = PTR_TO_UINT(match_data);
+
+	return (cb->id == id);
+}
+
+bool bt_bap_bcode_cb_unregister(struct bt_bap *bap, unsigned int id)
+{
+	struct bt_bap_bcode_cb *cb;
+
+	if (!bap)
+		return false;
+
+	cb = queue_remove_if(bap->bcode_cbs, match_bcode_cb_id,
+						UINT_TO_PTR(id));
+	if (!cb)
+		return false;
+
+	bap_bcode_cb_free(cb);
+
+	return false;
 }

--- a/src/shared/bap.h
+++ b/src/shared/bap.h
@@ -44,6 +44,12 @@ typedef void (*bt_bap_bis_func_t)(uint8_t bis, uint8_t sgrp,
 		struct iovec *caps, struct iovec *meta,
 		struct bt_bap_qos *qos, void *user_data);
 
+typedef void (*bt_bap_bcode_reply_t)(void *user_data, int err);
+
+typedef void (*bt_bap_bcode_func_t)(struct bt_bap_stream *stream,
+				bt_bap_bcode_reply_t reply, void *reply_data,
+				void *user_data);
+
 /* Local PAC related functions */
 struct bt_bap_pac_qos {
 	uint8_t  framing;
@@ -279,3 +285,14 @@ bool bt_bap_bis_cb_unregister(struct bt_bap *bap, unsigned int id);
 void bt_bap_bis_probe(struct bt_bap *bap, uint8_t bis, uint8_t sgrp,
 	struct iovec *caps, struct iovec *meta, struct bt_bap_qos *qos);
 void bt_bap_bis_remove(struct bt_bap *bap);
+
+void bt_bap_req_bcode(struct bt_bap_stream *stream,
+				bt_bap_bcode_reply_t reply,
+				void *reply_data);
+
+unsigned int bt_bap_bcode_cb_register(struct bt_bap *bap,
+				bt_bap_bcode_func_t func,
+				void *user_data,
+				bt_bap_destroy_func_t destroy);
+
+bool bt_bap_bcode_cb_unregister(struct bt_bap *bap, unsigned int id);


### PR DESCRIPTION
This adds support for registering Broadcast Code request callback with
shared/bap, to be called when a BAP Scan Delegator needs to receive the
Code from peer Broadcast Assistants.
---
 src/shared/bap.c | 98 ++++++++++++++++++++++++++++++++++++++++++++++++
 src/shared/bap.h | 17 +++++++++
 2 files changed, 115 insertions(+)