### PR TITLE
[PW_SID:939100] [BlueZ,v1] shared/bap: Fix not starting released operation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/src/shared/bap.c
+++ b/src/shared/bap.c
@@ -2104,7 +2104,24 @@ static uint8_t stream_release(struct bt_bap_stream *stream, struct iovec *rsp)
 
 	ascs_ase_rsp_success(rsp, stream->ep->id);
 
-	stream_set_state(stream, BT_BAP_STREAM_STATE_RELEASING);
+	/* In case the stream IO is already down the released transition needs
+	 * to take action immeditely.
+	 */
+	if (!stream->io) {
+		switch (bt_bap_stream_get_state(stream)) {
+		case BT_BAP_STREAM_STATE_CONFIG:
+			/* Released (no caching) */
+			stream_set_state(stream, BT_BAP_STREAM_STATE_RELEASING);
+			stream_set_state(stream, BT_BAP_STREAM_STATE_IDLE);
+			break;
+		default:
+			/* Released (caching) */
+			stream_set_state(stream, BT_BAP_STREAM_STATE_RELEASING);
+			stream_set_state(stream, BT_BAP_STREAM_STATE_CONFIG);
+			break;
+		}
+	} else
+		stream_set_state(stream, BT_BAP_STREAM_STATE_RELEASING);
 
 	return 0;
 }


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

The release operation is intended to release CIS resources:

  'Releases resources associated with an ASE, immediately decouples the
  ASE from any previously coupled CIS, and tears down any CIS previously
  established for the ASE for one or more ASEs.

  Valid only if ASE_State field value = 0x01 (Codec Configured),
  0x02 (QoS Configured), 0x03 (Enabling), 0x04 (Streaming), or 0x05
  (Disabling).'

But as the stated in ASCS specification release can also be used with
the likes of Codec/QoS Configured which may not require the CIS to be
established and in that case released operation shall start
autonomously:

  'The Released operation shall be initiated autonomously by the server
  if:
  The Release operation for an ASE has been completed and the server
  controller has indicated that the underlying CIS for the ASE has been
  torn down.'
---
 src/shared/bap.c | 19 ++++++++++++++++++-
 1 file changed, 18 insertions(+), 1 deletion(-)