### PR TITLE
[PW_SID:939333] [BlueZ,1/2] uuid-helper: Accept any 16-bit HEX value as a valid UUID

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/src/device.c
+++ b/src/device.c
@@ -2646,6 +2646,10 @@ static DBusMessage *connect_profile(DBusConnection *conn, DBusMessage *msg,
 	}
 
 	uuid = bt_name2string(pattern);
+	if (uuid == NULL)
+		return btd_error_invalid_args_str(msg,
+					ERR_BREDR_CONN_INVALID_ARGUMENTS);
+
 	reply = connect_profiles(dev, BDADDR_BREDR, msg, uuid);
 	free(uuid);
 

--- a/src/profile.c
+++ b/src/profile.c
@@ -2319,6 +2319,8 @@ static int parse_ext_opt(struct ext_profile *ext, const char *key,
 		dbus_message_iter_get_basic(value, &str);
 		free(ext->service);
 		ext->service = bt_name2string(str);
+		if (ext->service == NULL)
+			return -EINVAL;
 	}
 
 	return 0;

--- a/src/uuid-helper.c
+++ b/src/uuid-helper.c
@@ -169,7 +169,8 @@ static int string2uuid16(uuid_t *uuid, const char *string)
 char *bt_name2string(const char *pattern)
 {
 	uuid_t uuid;
-	uint16_t uuid16;
+	unsigned int uuid16;
+	char *endptr = NULL;
 	int i;
 
 	/* UUID 128 string format */
@@ -182,11 +183,9 @@ char *bt_name2string(const char *pattern)
 		goto proceed;
 
 	/* HEX format */
-	uuid16 = strtol(pattern, NULL, 16);
-	for (i = 0; bt_services[i].class; i++) {
-		if (bt_services[i].class == uuid16)
-			goto proceed;
-	}
+	uuid16 = strtoul(pattern, &endptr, 16);
+	if (uuid16 <= 0xffff && *endptr == '\0')
+		goto proceed;
 
 	return NULL;
 


### PR DESCRIPTION
The bt_name2string() function restricts HEX values to the list of
predefined service names. This list is very limited, so loosing that
restriction will allow to pass any 16-bit HEX value as a profile to
D-Bus API calls like ConnectProfile or RegisterProfile.
---
 src/uuid-helper.c | 11 +++++------
 1 file changed, 5 insertions(+), 6 deletions(-)