### PR TITLE
[PW_SID:939597] [BlueZ] client: add input validation to main()

### DIFF
--- a/client/main.c
+++ b/client/main.c
@@ -843,6 +843,17 @@ static gboolean parse_argument(int argc, char *argv[], const char **arg_table,
 	return FALSE;
 }
 
+static int validate_input(int argc, char *argv[]) {
+	for (int i = 0; i < argc; i++) {
+		if (!strisutf8(argv[i], strlen(argv[i]))) {
+			printf("Invalid character in string: %s\n", argv[i]);
+			return -EINVAL;
+		}
+	}
+
+	return 0;
+}
+
 static void cmd_list(int argc, char *argv[])
 {
 	GList *list;
@@ -3298,6 +3309,10 @@ int main(int argc, char *argv[])
 	int status;
 	int timeout;
 	unsigned int timeout_id;
+
+	status = validate_input(argc, argv);
+	if (status)
+		return status;
 
 	bt_shell_init(argc, argv, &opt);
 	bt_shell_set_menu(&main_menu);


### PR DESCRIPTION
An error was found during fuzzing testing. When passing Unicode
characters to bluetoothctl the application crashes in dbus:

dbus[5324]: arguments to dbus_message_iter_append_basic() were
incorrect, assertion "_dbus_check_is_valid_utf8 (*string_p)"
failed in file .../dbus-message.c line 2765.

Check that all characters are written in utf8.

Fixes: https://github.com/bluez/bluez/issues/1118
---
 client/main.c | 15 +++++++++++++++
 1 file changed, 15 insertions(+)