### PR TITLE
[PW_SID:939722] [v4] obex: Add messages_get_message() implementation for MAP plugin

### DIFF
--- a/obexd/plugins/mas.c
+++ b/obexd/plugins/mas.c
@@ -408,6 +408,7 @@ static void get_message_cb(void *session, int err, gboolean fmore,
 	}
 
 	g_string_append(mas->buffer, chunk);
+	mas->finished = TRUE;
 
 proceed:
 	if (err != -EAGAIN)
@@ -612,10 +613,10 @@ static void *message_open(const char *name, int oflag, mode_t mode,
 		return NULL;
 	}
 
+	mas->buffer = g_string_new("");
+
 	*err = messages_get_message(mas->backend_data, name, 0,
 			get_message_cb, mas);
-
-	mas->buffer = g_string_new("");
 
 	if (*err < 0)
 		return NULL;

--- a/obexd/plugins/messages-dummy.c
+++ b/obexd/plugins/messages-dummy.c
@@ -18,6 +18,8 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
 
 #include "obexd/src/log.h"
 
@@ -516,7 +518,50 @@ int messages_get_message(void *session, const char *handle,
 					messages_get_message_cb callback,
 					void *user_data)
 {
-	return -ENOSYS;
+	struct session *s =  session;
+	FILE *fp;
+	char *path;
+	char *msg;
+	int file_size;
+	struct stat file_info;
+
+	DBG(" ");
+	path = g_build_filename(s->cwd_absolute, handle, NULL);
+	fp = fopen(path, "r");
+	if (fp == NULL) {
+		DBG("fopen() failed");
+		return -EBADR;
+	}
+
+	if (fstat (fileno(fp), &file_info) == -1) {
+		DBG("Error getting file size");
+		fclose(fp);
+		return -EBADR;
+	}
+
+	file_size = file_info.st_size;
+	char buff[file_size+1];
+
+	msg = (char *) mmap(0, file_size, PROT_READ, MAP_PRIVATE, fileno(fp), 0);
+	if (msg == MAP_FAILED) {
+		DBG("Error mapping file");
+		fclose(fp);
+		return -EBADR;
+	}
+
+	fclose(fp);
+	strcpy(buff, msg);
+
+	if (callback)
+		callback(session, 0, 0, (const char*)buff, user_data);
+
+	if (munmap(msg, file_size) == -1) {
+		DBG("Error unmapping");
+		return -EBADR;
+	}
+
+	g_free(path);
+	return 0;
 }
 
 int messages_update_inbox(void *session, messages_status_cb callback,


### PR DESCRIPTION
GET Message() operation should be supported for passing below PTS
testcases -

1.MAP/MSE/MMB/BV-12-C
  Verify that the MSE can return an email message to the MCE.
2.MAP/MSE/MMB/BV-13-C
  Verify that the MSE can return a a*n* SMS message in native format
  to the MCE.
3.MAP/MSE/MMB/BV-14-C
  Verify that the MSE can return a SMS message with text trans-coded
  to UTF-8 to the MCE.

Currently get message operation is not implemented, hence above
testcases are failing.
Added code to send the complete bmessage in response to the get() request
for the requested message handle.

As per suggested in previous patch, mmap() is being used
for reading file.

---
 obexd/plugins/mas.c            |  5 ++--
 obexd/plugins/messages-dummy.c | 47 +++++++++++++++++++++++++++++++++-
 2 files changed, 49 insertions(+), 3 deletions(-)