### PR TITLE
[PW_SID:939746] [BlueZ] doc: Fix typo in the copyright header

### DIFF
--- a/client/bluetoothctl-admin.rst
+++ b/client/bluetoothctl-admin.rst
@@ -7,7 +7,7 @@ Admin Policy Submenu
 --------------------
 
 :Version: BlueZ
-:Copyright: Free use of this software is granted under ther terms of the GNU
+:Copyright: Free use of this software is granted under the terms of the GNU
             Lesser General Public Licenses (LGPL).
 :Date: November 2022
 :Manual section: 1

--- a/client/bluetoothctl-advertise.rst
+++ b/client/bluetoothctl-advertise.rst
@@ -7,7 +7,7 @@ Advertise Submenu
 -----------------
 
 :Version: BlueZ
-:Copyright: Free use of this software is granted under ther terms of the GNU
+:Copyright: Free use of this software is granted under the terms of the GNU
             Lesser General Public Licenses (LGPL).
 :Date: November 2022
 :Manual section: 1

--- a/client/bluetoothctl-assistant.rst
+++ b/client/bluetoothctl-assistant.rst
@@ -7,7 +7,7 @@ Assistant Submenu
 -----------------
 
 :Version: BlueZ
-:Copyright: Free use of this software is granted under ther terms of the GNU
+:Copyright: Free use of this software is granted under the terms of the GNU
             Lesser General Public Licenses (LGPL).
 :Date: August 2024
 :Manual section: 1

--- a/client/bluetoothctl-endpoint.rst
+++ b/client/bluetoothctl-endpoint.rst
@@ -7,7 +7,7 @@ Endpoint Submenu
 ----------------
 
 :Version: BlueZ
-:Copyright: Free use of this software is granted under ther terms of the GNU
+:Copyright: Free use of this software is granted under the terms of the GNU
             Lesser General Public Licenses (LGPL).
 :Date: November 2022
 :Manual section: 1

--- a/client/bluetoothctl-gatt.rst
+++ b/client/bluetoothctl-gatt.rst
@@ -7,7 +7,7 @@ Generic Attribute Submenu
 -------------------------
 
 :Version: BlueZ
-:Copyright: Free use of this software is granted under ther terms of the GNU
+:Copyright: Free use of this software is granted under the terms of the GNU
             Lesser General Public Licenses (LGPL).
 :Date: November 2022
 :Manual section: 1

--- a/client/bluetoothctl-hci.rst
+++ b/client/bluetoothctl-hci.rst
@@ -7,7 +7,7 @@ HCI Submenu
 -----------
 
 :Version: BlueZ
-:Copyright: Free use of this software is granted under ther terms of the GNU
+:Copyright: Free use of this software is granted under the terms of the GNU
             Lesser General Public Licenses (LGPL).
 :Date: December 2024
 :Manual section: 1

--- a/client/bluetoothctl-mgmt.rst
+++ b/client/bluetoothctl-mgmt.rst
@@ -7,7 +7,7 @@ Management Submenu
 ------------------
 
 :Version: BlueZ
-:Copyright: Free use of this software is granted under ther terms of the GNU
+:Copyright: Free use of this software is granted under the terms of the GNU
             Lesser General Public Licenses (LGPL).
 :Date: July 2023
 :Manual section: 1

--- a/client/bluetoothctl-monitor.rst
+++ b/client/bluetoothctl-monitor.rst
@@ -7,7 +7,7 @@ Monitor Submenu
 ---------------
 
 :Version: BlueZ
-:Copyright: Free use of this software is granted under ther terms of the GNU
+:Copyright: Free use of this software is granted under the terms of the GNU
             Lesser General Public Licenses (LGPL).
 :Date: July 2023
 :Manual section: 1
@@ -86,4 +86,3 @@ REPORTING BUGS
 ==============
 
 linux-bluetooth@vger.kernel.org
-

--- a/client/bluetoothctl-player.rst
+++ b/client/bluetoothctl-player.rst
@@ -7,7 +7,7 @@ Media Player Submenu
 --------------------
 
 :Version: BlueZ
-:Copyright: Free use of this software is granted under ther terms of the GNU
+:Copyright: Free use of this software is granted under the terms of the GNU
             Lesser General Public Licenses (LGPL).
 :Date: November 2022
 :Manual section: 1

--- a/client/bluetoothctl-scan.rst
+++ b/client/bluetoothctl-scan.rst
@@ -7,7 +7,7 @@ Scan Submenu
 ------------
 
 :Version: BlueZ
-:Copyright: Free use of this software is granted under ther terms of the GNU
+:Copyright: Free use of this software is granted under the terms of the GNU
             Lesser General Public Licenses (LGPL).
 :Date: July 2023
 :Manual section: 1

--- a/client/bluetoothctl-transport.rst
+++ b/client/bluetoothctl-transport.rst
@@ -7,7 +7,7 @@ Media Transport Submenu
 -----------------------
 
 :Version: BlueZ
-:Copyright: Free use of this software is granted under ther terms of the GNU
+:Copyright: Free use of this software is granted under the terms of the GNU
             Lesser General Public Licenses (LGPL).
 :Date: November 2022
 :Manual section: 1
@@ -71,7 +71,7 @@ Once a transport is selected, the audio server will automatically acquire.
 unselect
 --------
 
-Unelect transport. For transports created on a Broadcast Sink device only. This moves
+Unselect transport. For transports created on a Broadcast Sink device only. This moves
 the transport to the "idle" state, pending release by the audio server. If the transport
 was acquired by bluetoothctl it can be released straight away, without having to be
 unselected.

--- a/doc/hci.rst
+++ b/doc/hci.rst
@@ -7,7 +7,7 @@ Bluetooth HCI protocol
 ----------------------
 
 :Version: BlueZ
-:Copyright: Free use of this software is granted under ther terms of the GNU
+:Copyright: Free use of this software is granted under the terms of the GNU
             Lesser General Public Licenses (LGPL).
 :Date: October 2024
 :Manual section: 7

--- a/doc/l2cap.rst
+++ b/doc/l2cap.rst
@@ -7,7 +7,7 @@ L2CAP protocol
 --------------
 
 :Version: BlueZ
-:Copyright: Free use of this software is granted under ther terms of the GNU
+:Copyright: Free use of this software is granted under the terms of the GNU
             Lesser General Public Licenses (LGPL).
 :Date: May 2024
 :Manual section: 7

--- a/doc/rfcomm.rst
+++ b/doc/rfcomm.rst
@@ -7,7 +7,7 @@ RFCOMM protocol
 ---------------
 
 :Version: BlueZ
-:Copyright: Free use of this software is granted under ther terms of the GNU
+:Copyright: Free use of this software is granted under the terms of the GNU
             Lesser General Public Licenses (LGPL).
 :Date: May 2024
 :Manual section: 7

--- a/mesh/bluetooth-meshd.rst.in
+++ b/mesh/bluetooth-meshd.rst.in
@@ -7,7 +7,7 @@ Bluetooth Mesh daemon
 ---------------------
 
 :Version: BlueZ
-:Copyright: Free use of this software is granted under ther terms of the GNU
+:Copyright: Free use of this software is granted under the terms of the GNU
             Lesser General Public Licenses (LGPL).
 :Date: March 2021
 :Manual section: 8

--- a/monitor/btmon.rst
+++ b/monitor/btmon.rst
@@ -8,7 +8,7 @@ Bluetooth monitor
 
 :Authors: - Marcel Holtmann <marcel@holtmann.org>
           - Tedd Ho-Jeong An <tedd.an@intel.com>
-:Copyright: Free use of this software is granted under ther terms of the GNU
+:Copyright: Free use of this software is granted under the terms of the GNU
             Lesser General Public Licenses (LGPL).
 :Version: BlueZ
 :Date: April 2021

--- a/src/bluetoothd.rst.in
+++ b/src/bluetoothd.rst.in
@@ -10,7 +10,7 @@ Bluetooth daemon
           - Philipp Matthias Hahn
           - Fredrik Noring
 :Version: BlueZ
-:Copyright: Free use of this software is granted under ther terms of the GNU
+:Copyright: Free use of this software is granted under the terms of the GNU
             Lesser General Public Licenses (LGPL).
 :Date: March, 2004
 :Manual section: 8

--- a/tools/bdaddr.rst
+++ b/tools/bdaddr.rst
@@ -9,7 +9,7 @@ Utility for changing the Bluetooth device address
 :Authors: - Marcel Holtmann <marcel@holtmann.org>
           - Adam Laurie <adam@algroup.co.uk>
 :Version: BlueZ
-:Copyright: Free use of this software is granted under ther terms of the GNU
+:Copyright: Free use of this software is granted under the terms of the GNU
             Lesser General Public Licenses (LGPL).
 :Date: Sep 27, 2005
 :Manual section: 1

--- a/tools/btattach.rst
+++ b/tools/btattach.rst
@@ -7,7 +7,7 @@ Attach serial devices to BlueZ stack
 ------------------------------------
 
 :Version: BlueZ
-:Copyright: Free use of this software is granted under ther terms of the GNU
+:Copyright: Free use of this software is granted under the terms of the GNU
             Lesser General Public Licenses (LGPL).
 :Date: November 2015
 :Manual section: 1

--- a/tools/btmgmt.rst
+++ b/tools/btmgmt.rst
@@ -7,7 +7,7 @@ interactive bluetooth management tool
 -------------------------------------
 
 :Version: BlueZ
-:Copyright: Free use of this software is granted under ther terms of the GNU
+:Copyright: Free use of this software is granted under the terms of the GNU
             Lesser General Public Licenses (LGPL).
 :Date: July 2023
 :Manual section: 1

--- a/tools/ciptool.rst
+++ b/tools/ciptool.rst
@@ -8,7 +8,7 @@ Bluetooth Common ISDN Access Profile (CIP)
 
 :Author: Marcel Holtmann <marcel@holtmann.org>
 :Version: BlueZ
-:Copyright: Free use of this software is granted under ther terms of the GNU
+:Copyright: Free use of this software is granted under the terms of the GNU
             Lesser General Public Licenses (LGPL).
 :Date: June 3, 2003
 :Manual section: 1

--- a/tools/hciattach.rst
+++ b/tools/hciattach.rst
@@ -9,7 +9,7 @@ attach serial devices via UART HCI to BlueZ stack
 :Authors: - Maxim Krasnyansky <maxk@qualcomm.com>
           - Nils Faerber <nils@kernelconcepts.de>
 :Version: BlueZ
-:Copyright: Free use of this software is granted under ther terms of the GNU
+:Copyright: Free use of this software is granted under the terms of the GNU
             Lesser General Public Licenses (LGPL).
 :Date: Jan 22, 2002
 :Manual section: 1

--- a/tools/hciconfig.rst
+++ b/tools/hciconfig.rst
@@ -10,7 +10,7 @@ Configure Bluetooth devices
           - Marcel Holtmann <marcel@holtmann.org>
           - Fabrizio Gennari <fabrizio.gennari@philips.com>
 :Version: BlueZ
-:Copyright: Free use of this software is granted under ther terms of the GNU
+:Copyright: Free use of this software is granted under the terms of the GNU
             Lesser General Public Licenses (LGPL).
 :Date: Nov 11, 2002
 :Manual section: 1

--- a/tools/hcidump.rst
+++ b/tools/hcidump.rst
@@ -10,7 +10,7 @@ Parse HCI data
           - Marcel Holtmann <marcel@holtmann.org>
           - Fabrizio Gennari <fabrizio.gennari@philips.com>
 :Version: BlueZ
-:Copyright: Free use of this software is granted under ther terms of the GNU
+:Copyright: Free use of this software is granted under the terms of the GNU
             Lesser General Public Licenses (LGPL).
 :Date: Nov 12, 2002
 :Manual section: 1

--- a/tools/hcitool.rst
+++ b/tools/hcitool.rst
@@ -10,7 +10,7 @@ Configure Bluetooth connections
           - Marcel Holtmann <marcel@holtmann.org>
           - Fabrizio Gennari <fabrizio.gennari@philips.com>
 :Version: BlueZ
-:Copyright: Free use of this software is granted under ther terms of the GNU
+:Copyright: Free use of this software is granted under the terms of the GNU
             Lesser General Public Licenses (LGPL).
 :Date: Nov 12, 2002
 :Manual section: 1

--- a/tools/hid2hci.rst
+++ b/tools/hid2hci.rst
@@ -8,7 +8,7 @@ Bluetooth HID to HCI mode switching utility
 
 :Author: Marcel Holtmann <marcel@holtmann.org>
 :Version: BlueZ
-:Copyright: Free use of this software is granted under ther terms of the GNU
+:Copyright: Free use of this software is granted under the terms of the GNU
             Lesser General Public Licenses (LGPL).
 :Date: May 15, 2009
 :Manual section: 1

--- a/tools/isotest.rst
+++ b/tools/isotest.rst
@@ -8,7 +8,7 @@ ISO testing
 
 :Authors: - Luiz Augusto Von Dentz <luiz.von.dentz@intel.com>
 :Version: BlueZ
-:Copyright: Free use of this software is granted under ther terms of the GNU
+:Copyright: Free use of this software is granted under the terms of the GNU
             Lesser General Public Licenses (LGPL).
 :Date: May 4, 2022
 :Manual section: 1

--- a/tools/l2ping.rst
+++ b/tools/l2ping.rst
@@ -11,7 +11,7 @@ Send L2CAP echo request and receive answer
           - Nils Faerber <nils@kernelconcepts.de>
           - Adam Laurie <adam@algroup.co.uk>.
 :Version: BlueZ
-:Copyright: Free use of this software is granted under ther terms of the GNU
+:Copyright: Free use of this software is granted under the terms of the GNU
             Lesser General Public Licenses (LGPL).
 :Date: Jan 22, 2002
 :Manual section: 1

--- a/tools/rctest.rst
+++ b/tools/rctest.rst
@@ -10,7 +10,7 @@ RFCOMM testing
           - Marcel Holtmann <marcel@holtmann.org>
           - Filippo Giunchedi <filippo@debian.org>
 :Version: BlueZ
-:Copyright: Free use of this software is granted under ther terms of the GNU
+:Copyright: Free use of this software is granted under the terms of the GNU
             Lesser General Public Licenses (LGPL).
 :Date: Jul 6, 2009
 :Manual section: 1

--- a/tools/rfcomm.rst
+++ b/tools/rfcomm.rst
@@ -8,7 +8,7 @@ RFCOMM configuration utility
 
 :Author: Marcel Holtmann <marcel@holtmann.org>
 :Version: BlueZ
-:Copyright: Free use of this software is granted under ther terms of the GNU
+:Copyright: Free use of this software is granted under the terms of the GNU
             Lesser General Public Licenses (LGPL).
 :Date: April 28, 2002
 :Manual section: 1

--- a/tools/sdptool.rst
+++ b/tools/sdptool.rst
@@ -9,7 +9,7 @@ control and interrogate SDP servers
 :Authors: - Maxim Krasnyansky <maxk@qualcomm.com>
           - Edd Dumbill <ejad@debian.org>
 :Version: BlueZ
-:Copyright: Free use of this software is granted under ther terms of the GNU
+:Copyright: Free use of this software is granted under the terms of the GNU
             Lesser General Public Licenses (LGPL).
 :Manual section: 1
 :Manual group: Linux System Administration


### PR DESCRIPTION
---
 client/bluetoothctl-admin.rst     | 2 +-
 client/bluetoothctl-advertise.rst | 2 +-
 client/bluetoothctl-assistant.rst | 2 +-
 client/bluetoothctl-endpoint.rst  | 2 +-
 client/bluetoothctl-gatt.rst      | 2 +-
 client/bluetoothctl-hci.rst       | 2 +-
 client/bluetoothctl-mgmt.rst      | 2 +-
 client/bluetoothctl-monitor.rst   | 3 +--
 client/bluetoothctl-player.rst    | 2 +-
 client/bluetoothctl-scan.rst      | 2 +-
 client/bluetoothctl-transport.rst | 4 ++--
 doc/hci.rst                       | 2 +-
 doc/l2cap.rst                     | 2 +-
 doc/rfcomm.rst                    | 2 +-
 mesh/bluetooth-meshd.rst.in       | 2 +-
 monitor/btmon.rst                 | 2 +-
 src/bluetoothd.rst.in             | 2 +-
 tools/bdaddr.rst                  | 2 +-
 tools/btattach.rst                | 2 +-
 tools/btmgmt.rst                  | 2 +-
 tools/ciptool.rst                 | 2 +-
 tools/hciattach.rst               | 2 +-
 tools/hciconfig.rst               | 2 +-
 tools/hcidump.rst                 | 2 +-
 tools/hcitool.rst                 | 2 +-
 tools/hid2hci.rst                 | 2 +-
 tools/isotest.rst                 | 2 +-
 tools/l2ping.rst                  | 2 +-
 tools/rctest.rst                  | 2 +-
 tools/rfcomm.rst                  | 2 +-
 tools/sdptool.rst                 | 2 +-
 31 files changed, 32 insertions(+), 33 deletions(-)