### PR TITLE
[PW_SID:942240] [v1] obex: Add base implementation for get_mas_instance info and set notification filter

### DIFF
--- a/obexd/plugins/mas.c
+++ b/obexd/plugins/mas.c
@@ -782,6 +782,36 @@ static void *notification_registration_open(const char *name, int oflag,
 	return mas;
 }
 
+static void *message_get_instance_open(const char *name, int oflag,
+					mode_t mode, void *driver_data,
+					size_t *size, int *err)
+{
+	struct mas_session *mas = driver_data;
+
+	DBG("");
+
+	mas->buffer = g_string_new("Mas Instance 0");
+	mas->finished = TRUE;
+	*err = 0;
+
+	return mas;
+}
+
+static void *message_notification_filter_open(const char *name, int oflag,
+					mode_t mode, void *driver_data,
+					size_t *size, int *err)
+{
+	struct mas_session *mas = driver_data;
+
+	DBG("");
+
+	//TODO notifcation filter add
+	mas->finished = TRUE;
+	*err = 0;
+
+	return mas;
+}
+
 static const struct obex_service_driver mas = {
 	.name = "Message Access server",
 	.service = OBEX_MAS,
@@ -866,6 +896,26 @@ static const struct obex_mime_type_driver mime_message_update = {
 	.write = any_write,
 };
 
+static struct obex_mime_type_driver mime_message_instance = {
+	.target = MAS_TARGET,
+	.target_size = TARGET_SIZE,
+	.mimetype = "x-bt/MASInstanceInformation",
+	.open = message_get_instance_open,
+	.close = any_close,
+	.read = any_read,
+	.write = any_write,
+};
+
+static struct obex_mime_type_driver mime_message_notification_filter = {
+	.target = MAS_TARGET,
+	.target_size = TARGET_SIZE,
+	.mimetype = "x-bt/MAP-notification-filter",
+	.open = message_notification_filter_open,
+	.close = any_close,
+	.read = any_read,
+	.write = any_write,
+};
+
 static const struct obex_mime_type_driver *map_drivers[] = {
 	&mime_map,
 	&mime_message,
@@ -874,6 +924,8 @@ static const struct obex_mime_type_driver *map_drivers[] = {
 	&mime_notification_registration,
 	&mime_message_status,
 	&mime_message_update,
+	&mime_message_instance,
+	&mime_message_notification_filter,
 	NULL
 };
 


### PR DESCRIPTION
This change is required for passing below testcases-
1. MAP/MSE/MMI/BV-02-C
   Verify that the MCE can return user-readable information about the
   MAS-instance to the MCE
2. MAP/MSE/MMN/BV-06-C
   Verify that the MSE correctly responds to a request
   to filter notifications.

We are adding the raw skeleton implementaton for PTS certification.
Although the functionality can be added later as per requirement.

---
 obexd/plugins/mas.c | 52 +++++++++++++++++++++++++++++++++++++++++++++
 1 file changed, 52 insertions(+)