### PR TITLE
[PW_SID:943694] [BlueZ,v1] gatt-client: Fix Handle property of descriptors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/src/gatt-client.c
+++ b/src/gatt-client.c
@@ -141,8 +141,8 @@ static bool uuid_cmp(const bt_uuid_t *uuid, uint16_t u16)
 static gboolean descriptor_get_handle(const GDBusPropertyTable *property,
 					DBusMessageIter *iter, void *data)
 {
-	struct service *desc = data;
-	uint16_t handle = desc->start_handle;
+	struct descriptor *desc = data;
+	uint16_t handle = desc->handle;
 
 	dbus_message_iter_append_basic(iter, DBUS_TYPE_UINT16, &handle);
 


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

Patch cda5549f2475 ("gatt-client: Add read-only handles to dbus")
introduced support for Handle properties to GATT attributes but the
function descriptor_get_handle do access the user_pointer as it was a
service not a descriptor.

Fixes: https://github.com/bluez/bluez/issues/1133
---
 src/gatt-client.c | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)