### PR TITLE
[PW_SID:944727] [BlueZ,v1] shared/hci: Make use of util_iov* to parse packets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/client/hci.c
+++ b/client/hci.c
@@ -102,10 +102,10 @@ static uint8_t *str2bytearray(char *arg, size_t *val_len)
 	return util_memdup(value, i);
 }
 
-static void hci_cmd_complete(const void *data, uint8_t size, void *user_data)
+static void hci_cmd_complete(struct iovec *iov, void *user_data)
 {
 	bt_shell_printf("HCI Command complete:\n");
-	bt_shell_hexdump(data, size);
+	bt_shell_hexdump(iov->iov_base, iov->iov_len);
 
 	return bt_shell_noninteractive_quit(EXIT_SUCCESS);
 }
@@ -198,12 +198,12 @@ static bool match_event(const void *data, const void *match_data)
 	return evt->event == event;
 }
 
-static void hci_evt_received(const void *data, uint8_t size, void *user_data)
+static void hci_evt_received(struct iovec *iov, void *user_data)
 {
 	struct hci_event *evt = user_data;
 
 	bt_shell_printf("HCI Event 0x%02x received:\n", evt->event);
-	bt_shell_hexdump(data, size);
+	bt_shell_hexdump(iov->iov_base, iov->iov_len);
 }
 
 static void hci_register(int argc, char *argv[])

--- a/src/shared/hci-crypto.c
+++ b/src/shared/hci-crypto.c
@@ -25,13 +25,13 @@ struct crypto_data {
 	void *user_data;
 };
 
-static void le_encrypt_callback(const void *response, uint8_t size,
-							void *user_data)
+static void le_encrypt_callback(struct iovec *iov, void *user_data)
 {
 	struct crypto_data *data = user_data;
-	const struct bt_hci_rsp_le_encrypt *rsp = response;
+	const struct bt_hci_rsp_le_encrypt *rsp;
 
-	if (rsp->status) {
+	rsp = util_iov_pull_mem(iov, sizeof(*rsp));
+	if (!rsp || rsp->status) {
 		data->callback(NULL, 0, data->user_data);
 		return;
 	}
@@ -66,14 +66,14 @@ static bool le_encrypt(struct bt_hci *hci, uint8_t size,
 	return true;
 }
 
-static void prand_callback(const void *response, uint8_t size,
-							void *user_data)
+static void prand_callback(struct iovec *iov, void *user_data)
 {
 	struct crypto_data *data = user_data;
-	const struct bt_hci_rsp_le_rand *rsp = response;
+	const struct bt_hci_rsp_le_rand *rsp;
 	uint8_t prand[3];
 
-	if (rsp->status) {
+	rsp = util_iov_pull_mem(iov, sizeof(*rsp));
+	if (!rsp || rsp->status) {
 		data->callback(NULL, 0, data->user_data);
 		return;
 	}

--- a/src/shared/hci.h
+++ b/src/shared/hci.h
@@ -10,6 +10,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <sys/uio.h>
 
 typedef void (*bt_hci_destroy_func_t)(void *user_data);
 
@@ -24,8 +25,7 @@ void bt_hci_unref(struct bt_hci *hci);
 
 bool bt_hci_set_close_on_unref(struct bt_hci *hci, bool do_close);
 
-typedef void (*bt_hci_callback_func_t)(const void *data, uint8_t size,
-							void *user_data);
+typedef void (*bt_hci_callback_func_t)(struct iovec *iov, void *user_data);
 
 unsigned int bt_hci_send(struct bt_hci *hci, uint16_t opcode,
 				const void *data, uint8_t size,

--- a/tools/advtest.c
+++ b/tools/advtest.c
@@ -146,25 +146,25 @@ static void scan_le_adv_report(const void *data, uint8_t size,
 	}
 }
 
-static void scan_le_meta_event(const void *data, uint8_t size,
-							void *user_data)
+static void scan_le_meta_event(struct iovec *iov, void *user_data)
 {
-	uint8_t evt_code = ((const uint8_t *) data)[0];
+	uint8_t evt_code;
+
+	if (!util_iov_pull_u8(iov, &evt_code))
+		return;
 
 	switch (evt_code) {
 	case BT_HCI_EVT_LE_ADV_REPORT:
-		scan_le_adv_report(data + 1, size - 1, user_data);
+		scan_le_adv_report(iov->iov_base, iov->iov_len, user_data);
 		break;
 	}
 }
 
-static void scan_enable_callback(const void *data, uint8_t size,
-							void *user_data)
+static void scan_enable_callback(struct iovec *iov, void *user_data)
 {
 }
 
-static void adv_enable_callback(const void *data, uint8_t size,
-							void *user_data)
+static void adv_enable_callback(struct iovec *iov, void *user_data)
 {
 	struct bt_hci_cmd_le_set_scan_parameters cmd4;
 	struct bt_hci_cmd_le_set_scan_enable cmd5;
@@ -186,8 +186,7 @@ static void adv_enable_callback(const void *data, uint8_t size,
 					scan_enable_callback, NULL, NULL);
 }
 
-static void adv_le_evtmask_callback(const void *data, uint8_t size,
-							void *user_data)
+static void adv_le_evtmask_callback(struct iovec *iov, void *user_data)
 {
 	struct bt_hci_cmd_le_set_resolv_timeout cmd0;
 	struct bt_hci_cmd_le_add_to_resolv_list cmd1;
@@ -244,13 +243,13 @@ static void adv_le_evtmask_callback(const void *data, uint8_t size,
 					adv_enable_callback, NULL, NULL);
 }
 
-static void adv_le_features_callback(const void *data, uint8_t size,
-							void *user_data)
+static void adv_le_features_callback(struct iovec *iov, void *user_data)
 {
-	const struct bt_hci_rsp_le_read_local_features *rsp = data;
+	const struct bt_hci_rsp_le_read_local_features *rsp;
 	uint8_t evtmask[] = { 0xff, 0xff, 0x0f, 0x00, 0x00, 0x00, 0x00, 0x00 };
 
-	if (rsp->status) {
+	rsp = util_iov_pull_mem(iov, sizeof(*rsp));
+	if (!rsp || rsp->status) {
 		fprintf(stderr, "Failed to read local LE features\n");
 		mainloop_exit_failure();
 		return;
@@ -260,13 +259,13 @@ static void adv_le_features_callback(const void *data, uint8_t size,
 					adv_le_evtmask_callback, NULL, NULL);
 }
 
-static void adv_features_callback(const void *data, uint8_t size,
-							void *user_data)
+static void adv_features_callback(struct iovec *iov, void *user_data)
 {
-	const struct bt_hci_rsp_read_local_features *rsp = data;
+	const struct bt_hci_rsp_read_local_features *rsp;
 	uint8_t evtmask[] = { 0x90, 0xe8, 0x04, 0x02, 0x00, 0x80, 0x00, 0x20 };
 
-	if (rsp->status) {
+	rsp = util_iov_pull_mem(iov, sizeof(*rsp));
+	if (!rsp || rsp->status) {
 		fprintf(stderr, "Failed to read local features\n");
 		mainloop_exit_failure();
 		return;
@@ -285,8 +284,7 @@ static void adv_features_callback(const void *data, uint8_t size,
 					adv_le_features_callback, NULL, NULL);
 }
 
-static void scan_le_evtmask_callback(const void *data, uint8_t size,
-							void *user_data)
+static void scan_le_evtmask_callback(struct iovec *iov, void *user_data)
 {
 	bt_hci_send(adv_dev, BT_HCI_CMD_RESET, NULL, 0, NULL, NULL, NULL);
 
@@ -294,13 +292,13 @@ static void scan_le_evtmask_callback(const void *data, uint8_t size,
 					adv_features_callback, NULL, NULL);
 }
 
-static void scan_le_features_callback(const void *data, uint8_t size,
-							void *user_data)
+static void scan_le_features_callback(struct iovec *iov, void *user_data)
 {
-	const struct bt_hci_rsp_le_read_local_features *rsp = data;
+	const struct bt_hci_rsp_le_read_local_features *rsp;
 	uint8_t evtmask[] = { 0xff, 0xff, 0x0f, 0x00, 0x00, 0x00, 0x00, 0x00 };
 
-	if (rsp->status) {
+	rsp = util_iov_pull_mem(iov, sizeof(*rsp));
+	if (!rsp || rsp->status) {
 		fprintf(stderr, "Failed to read local LE features\n");
 		mainloop_exit_failure();
 		return;
@@ -310,13 +308,13 @@ static void scan_le_features_callback(const void *data, uint8_t size,
 					scan_le_evtmask_callback, NULL, NULL);
 }
 
-static void scan_features_callback(const void *data, uint8_t size,
-							void *user_data)
+static void scan_features_callback(struct iovec *iov, void *user_data)
 {
-	const struct bt_hci_rsp_read_local_features *rsp = data;
+	const struct bt_hci_rsp_read_local_features *rsp;
 	uint8_t evtmask[] = { 0x90, 0xe8, 0x04, 0x02, 0x00, 0x80, 0x00, 0x20 };
 
-	if (rsp->status) {
+	rsp = util_iov_pull_mem(iov, sizeof(*rsp));
+	if (!rsp || rsp->status) {
 		fprintf(stderr, "Failed to read local features\n");
 		mainloop_exit_failure();
 		return;

--- a/tools/btattach.c
+++ b/tools/btattach.c
@@ -88,10 +88,15 @@ static int open_serial(const char *path, unsigned int speed, bool flowctl)
 	return fd;
 }
 
-static void local_version_callback(const void *data, uint8_t size,
-							void *user_data)
+static void local_version_callback(struct iovec *iov, void *user_data)
 {
-	const struct bt_hci_rsp_read_local_version *rsp = data;
+	const struct bt_hci_rsp_read_local_version *rsp;
+
+	rsp = util_iov_pull_mem(iov, sizeof(*rsp));
+	if (!rsp || rsp->status) {
+		fprintf(stderr, "Failed to read local version\n");
+		return;
+	}
 
 	printf("Manufacturer: %u\n", le16_to_cpu(rsp->manufacturer));
 }

--- a/tools/ibeacon.c
+++ b/tools/ibeacon.c
@@ -39,7 +39,7 @@ static bool shutdown_timeout(void *user_data)
 	return false;
 }
 
-static void shutdown_complete(const void *data, uint8_t size, void *user_data)
+static void shutdown_complete(struct iovec *iov, void *user_data)
 {
 	unsigned int id = PTR_TO_UINT(user_data);
 
@@ -106,12 +106,11 @@ static void set_adv_enable(void)
 					&enable, 1, NULL, NULL, NULL);
 }
 
-static void adv_data_callback(const void *data, uint8_t size,
-							void *user_data)
+static void adv_data_callback(struct iovec *iov, void *user_data)
 {
-	uint8_t status = *((uint8_t *) data);
+	uint8_t status;
 
-	if (status) {
+	if (!util_iov_pull_u8(iov, &status) || status) {
 		fprintf(stderr, "Failed to set advertising data\n");
 		shutdown_device();
 		return;
@@ -122,13 +121,13 @@ static void adv_data_callback(const void *data, uint8_t size,
 	set_adv_enable();
 }
 
-static void adv_tx_power_callback(const void *data, uint8_t size,
-							void *user_data)
+static void adv_tx_power_callback(struct iovec *iov, void *user_data)
 {
-	const struct bt_hci_rsp_le_read_adv_tx_power *rsp = data;
+	const struct bt_hci_rsp_le_read_adv_tx_power *rsp;
 	struct bt_hci_cmd_le_set_adv_data cmd;
 
-	if (rsp->status) {
+	rsp = util_iov_pull_mem(iov, sizeof(*rsp));
+	if (!rsp || rsp->status) {
 		fprintf(stderr, "Failed to read advertising TX power\n");
 		shutdown_device();
 		return;
@@ -159,12 +158,12 @@ static void adv_tx_power_callback(const void *data, uint8_t size,
 					adv_data_callback, NULL, NULL);
 }
 
-static void local_features_callback(const void *data, uint8_t size,
-							void *user_data)
+static void local_features_callback(struct iovec *iov, void *user_data)
 {
-	const struct bt_hci_rsp_read_local_features *rsp = data;
+	const struct bt_hci_rsp_read_local_features *rsp;
 
-	if (rsp->status) {
+	rsp = util_iov_pull_mem(iov, sizeof(*rsp));
+	if (!rsp || rsp->status) {
 		fprintf(stderr, "Failed to read local features\n");
 		shutdown_device();
 		return;


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

Instead of pairing HCI directly this uses struct iovec and util_iov*
helper functions to parse packets.
---
 client/hci.c            |   8 +-
 mesh/mesh-io-generic.c  |  66 +++++----
 src/shared/hci-crypto.c |  16 +--
 src/shared/hci.c        |  50 +++----
 src/shared/hci.h        |   4 +-
 tools/3dsp.c            | 116 +++++++++-------
 tools/advtest.c         |  54 ++++----
 tools/bluemoon.c        | 104 ++++++---------
 tools/btattach.c        |  11 +-
 tools/btinfo.c          |  19 +--
 tools/eddystone.c       |  25 ++--
 tools/hci-tester.c      | 289 +++++++++++++++++++++++++++++-----------
 tools/ibeacon.c         |  25 ++--
 13 files changed, 463 insertions(+), 324 deletions(-)