### PR TITLE
[PW_SID:945352] [BlueZ] l2cap-tester: ensure SO_SNDBUF is large enough for the writes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/tools/l2cap-tester.c
+++ b/tools/l2cap-tester.c
@@ -1451,8 +1451,9 @@ static void l2cap_write_data(struct test_data *data, GIOChannel *io,
 	const struct l2cap_data *l2data = data->test_data;
 	struct bthost *bthost;
 	ssize_t ret;
-	int sk;
+	int sk, size;
 	unsigned int count;
+	socklen_t len = sizeof(size);
 
 	sk = g_io_channel_unix_get_fd(io);
 
@@ -1463,6 +1464,15 @@ static void l2cap_write_data(struct test_data *data, GIOChannel *io,
 							NULL);
 
 	l2cap_tx_timestamping(data, io);
+
+	/* Socket buffer needs to hold what we send, btdev doesn't flush now */
+	ret = getsockopt(sk, SOL_SOCKET, SO_SNDBUF, &size, &len);
+	if (!ret) {
+		size += l2data->data_len * (l2data->repeat_send + 1);
+		ret = setsockopt(sk, SOL_SOCKET, SO_SNDBUF, &size, len);
+	}
+	if (ret)
+		tester_warn("Failed to set SO_SNDBUF = %d", size);
 
 	for (count = 0; count < l2data->repeat_send + 1; ++count) {
 		ret = l2cap_send(sk, l2data->write_data, l2data->data_len,


### PR DESCRIPTION
Since btdev runs from same thread and won't flush, SO_SNDBUF needs to
hold all data we are going to write.  Fix spurious test failure
in "L2CAP LE Client - Write 32k Success".
---
 tools/l2cap-tester.c | 12 +++++++++++-
 1 file changed, 11 insertions(+), 1 deletion(-)