### PR TITLE
[PW_SID:945530] [BlueZ,1/5] tools: iso-tester: add inclusion of time.h

### DIFF
--- a/client/player.c
+++ b/client/player.c
@@ -5551,10 +5551,11 @@ static int transport_send_seq(struct transport *transport, int fd, uint32_t num)
 
 		offset = lseek(fd, 0, SEEK_CUR);
 
-		bt_shell_echo("[seq %d %d.%03ds] send: %zd/%zd bytes",
+		bt_shell_echo("[seq %d %d.%03ds] send: %lld/%lld bytes",
 				transport->seq, secs,
 				(nsecs + 500000) / 1000000,
-				offset, transport->stat.st_size);
+				(long long int)offset,
+				(long long int)transport->stat.st_size);
 	}
 
 	free(buf);

--- a/mesh/agent.c
+++ b/mesh/agent.c
@@ -12,6 +12,8 @@
 #include <config.h>
 #endif
 
+#include <time.h>
+
 #include <ell/ell.h>
 
 #include "mesh/mesh.h"

--- a/mesh/appkey.c
+++ b/mesh/appkey.c
@@ -12,6 +12,8 @@
 #include <config.h>
 #endif
 
+#include <time.h>
+
 #define _GNU_SOURCE
 #include <ell/ell.h>
 

--- a/mesh/cfgmod-server.c
+++ b/mesh/cfgmod-server.c
@@ -13,6 +13,7 @@
 #endif
 
 #include <sys/time.h>
+#include <time.h>
 #include <ell/ell.h>
 
 #include "mesh/mesh-defs.h"

--- a/mesh/crypto.c
+++ b/mesh/crypto.c
@@ -15,6 +15,7 @@
 #define _GNU_SOURCE
 #include <unistd.h>
 #include <sys/socket.h>
+#include <time.h>
 #include <ell/ell.h>
 
 #include "mesh/mesh-defs.h"

--- a/mesh/dbus.c
+++ b/mesh/dbus.c
@@ -12,6 +12,8 @@
 #include <config.h>
 #endif
 
+#include <time.h>
+
 #include <ell/ell.h>
 
 #include "mesh/mesh-defs.h"

--- a/mesh/friend.c
+++ b/mesh/friend.c
@@ -12,6 +12,8 @@
 #include <config.h>
 #endif
 
+#include <time.h>
+
 #include <ell/ell.h>
 
 #include "mesh/mesh-defs.h"

--- a/mesh/keyring.c
+++ b/mesh/keyring.c
@@ -18,6 +18,7 @@
 #include <errno.h>
 #include <limits.h>
 #include <stdio.h>
+#include <time.h>
 #include <unistd.h>
 
 #include <sys/stat.h>

--- a/mesh/main.c
+++ b/mesh/main.c
@@ -18,6 +18,7 @@
 #include <unistd.h>
 #include <ctype.h>
 #include <signal.h>
+#include <time.h>
 
 #include <sys/prctl.h>
 #include <sys/stat.h>

--- a/mesh/manager.c
+++ b/mesh/manager.c
@@ -12,6 +12,8 @@
 #include <config.h>
 #endif
 
+#include <time.h>
+
 #define _GNU_SOURCE
 #include <ell/ell.h>
 

--- a/mesh/mesh-config-json.c
+++ b/mesh/mesh-config-json.c
@@ -21,6 +21,7 @@
 #include <limits.h>
 #include <stdio.h>
 #include <string.h>
+#include <time.h>
 #include <unistd.h>
 
 #include <sys/time.h>

--- a/mesh/mesh-io-generic.c
+++ b/mesh/mesh-io-generic.c
@@ -15,6 +15,7 @@
 #include <errno.h>
 #include <string.h>
 #include <sys/time.h>
+#include <time.h>
 #include <ell/ell.h>
 
 #include "monitor/bt.h"

--- a/mesh/mesh-io-mgmt.c
+++ b/mesh/mesh-io-mgmt.c
@@ -16,6 +16,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <sys/time.h>
+#include <time.h>
 #include <ell/ell.h>
 
 #include "monitor/bt.h"

--- a/mesh/mesh-io-unit.c
+++ b/mesh/mesh-io-unit.c
@@ -19,6 +19,7 @@
 #include <sys/un.h>
 #include <unistd.h>
 #include <stdio.h>
+#include <time.h>
 #include <ell/ell.h>
 
 #include "mesh/mesh-defs.h"

--- a/mesh/mesh-io.c
+++ b/mesh/mesh-io.c
@@ -12,6 +12,8 @@
 #include <config.h>
 #endif
 
+#include <time.h>
+
 #include <ell/ell.h>
 
 #include "lib/bluetooth.h"

--- a/mesh/mesh-mgmt.c
+++ b/mesh/mesh-mgmt.c
@@ -12,6 +12,8 @@
 #include <config.h>
 #endif
 
+#include <time.h>
+
 #include <ell/ell.h>
 
 #include "lib/bluetooth.h"

--- a/mesh/mesh.c
+++ b/mesh/mesh.c
@@ -12,6 +12,8 @@
 #include <config.h>
 #endif
 
+#include <time.h>
+
 #define _GNU_SOURCE
 #include <ell/ell.h>
 

--- a/mesh/model.c
+++ b/mesh/model.c
@@ -13,6 +13,7 @@
 #endif
 
 #include <sys/time.h>
+#include <time.h>
 #include <ell/ell.h>
 
 #include "mesh/mesh-defs.h"

--- a/mesh/net-keys.c
+++ b/mesh/net-keys.c
@@ -12,6 +12,8 @@
 #include <config.h>
 #endif
 
+#include <time.h>
+
 #include <ell/ell.h>
 
 #include "mesh/mesh-defs.h"

--- a/mesh/net.c
+++ b/mesh/net.c
@@ -15,6 +15,7 @@
 #define _GNU_SOURCE
 
 #include <sys/time.h>
+#include <time.h>
 
 #include <ell/ell.h>
 

--- a/mesh/node.c
+++ b/mesh/node.c
@@ -17,6 +17,7 @@
 #include <limits.h>
 #include <stdio.h>
 #include <sys/time.h>
+#include <time.h>
 
 #include <ell/ell.h>
 

--- a/mesh/pb-adv.c
+++ b/mesh/pb-adv.c
@@ -12,6 +12,8 @@
 #include <config.h>
 #endif
 
+#include <time.h>
+
 #include <ell/ell.h>
 
 #include "mesh/mesh-defs.h"

--- a/mesh/prov-acceptor.c
+++ b/mesh/prov-acceptor.c
@@ -12,6 +12,8 @@
 #include <config.h>
 #endif
 
+#include <time.h>
+
 #include <ell/ell.h>
 
 #include "src/shared/ecc.h"

--- a/mesh/prov-initiator.c
+++ b/mesh/prov-initiator.c
@@ -12,6 +12,8 @@
 #include <config.h>
 #endif
 
+#include <time.h>
+
 #include <ell/ell.h>
 
 #include "src/shared/ecc.h"

--- a/mesh/prvbeac-server.c
+++ b/mesh/prvbeac-server.c
@@ -22,6 +22,7 @@
 #endif
 
 #include <sys/time.h>
+#include <time.h>
 #include <ell/ell.h>
 
 #include "mesh/mesh-defs.h"

--- a/mesh/remprv-server.c
+++ b/mesh/remprv-server.c
@@ -22,6 +22,7 @@
 #endif
 
 #include <sys/time.h>
+#include <time.h>
 #include <ell/ell.h>
 
 #include "src/shared/ad.h"

--- a/mesh/rpl.c
+++ b/mesh/rpl.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <dirent.h>
 #include <errno.h>
+#include <time.h>
 
 #include <sys/stat.h>
 

--- a/src/shared/bap.c
+++ b/src/shared/bap.c
@@ -7313,7 +7313,7 @@ bool bt_bap_parse_base(struct iovec *iov,
 	uint8_t sgrps;
 	bool ret = true;
 
-	util_debug(func, NULL, "BASE len: %ld", iov->iov_len);
+	util_debug(func, NULL, "BASE len: %zd", iov->iov_len);
 
 	if (!util_iov_pull_le24(iov, &delay))
 		return false;
@@ -7359,7 +7359,7 @@ bool bt_bap_parse_base(struct iovec *iov,
 		l2_cc.iov_len = l2_cc_len;
 
 		/* Print Codec Specific Configuration */
-		util_debug(func, NULL, "CC len: %ld", l2_cc.iov_len);
+		util_debug(func, NULL, "CC len: %zd", l2_cc.iov_len);
 		bt_bap_debug_config(l2_cc.iov_base, l2_cc.iov_len,
 								func, NULL);
 

--- a/src/shared/btp.c
+++ b/src/shared/btp.c
@@ -11,6 +11,7 @@
 #include <stdbool.h>
 #include <sys/socket.h>
 #include <sys/un.h>
+#include <time.h>
 #include <unistd.h>
 
 #include <ell/ell.h>

--- a/src/shared/io-ell.c
+++ b/src/shared/io-ell.c
@@ -15,6 +15,7 @@
 #include <unistd.h>
 #include <errno.h>
 #include <sys/socket.h>
+#include <time.h>
 
 #include <ell/ell.h>
 

--- a/src/shared/mainloop-ell.c
+++ b/src/shared/mainloop-ell.c
@@ -16,6 +16,7 @@
 #include <errno.h>
 #include <unistd.h>
 #include <stdlib.h>
+#include <time.h>
 
 #include <ell/ell.h>
 

--- a/src/shared/timeout-ell.c
+++ b/src/shared/timeout-ell.c
@@ -8,6 +8,8 @@
  *
  */
 
+#include <time.h>
+
 #include <ell/ell.h>
 
 #include "timeout.h"

--- a/tools/btpclient.c
+++ b/tools/btpclient.c
@@ -17,6 +17,7 @@
 #include <assert.h>
 #include <getopt.h>
 #include <signal.h>
+#include <time.h>
 
 #include <ell/ell.h>
 

--- a/tools/iso-tester.c
+++ b/tools/iso-tester.c
@@ -17,6 +17,7 @@
 #include <errno.h>
 #include <poll.h>
 #include <stdbool.h>
+#include <time.h>
 
 #include <linux/errqueue.h>
 #include <linux/net_tstamp.h>

--- a/tools/mesh/cfgcli.c
+++ b/tools/mesh/cfgcli.c
@@ -14,6 +14,7 @@
 
 #include <stdio.h>
 #include <stdbool.h>
+#include <time.h>
 
 #include <ell/ell.h>
 

--- a/tools/mesh/keys.c
+++ b/tools/mesh/keys.c
@@ -12,6 +12,8 @@
 #include <config.h>
 #endif
 
+#include <time.h>
+
 #include <ell/ell.h>
 
 #include "src/shared/shell.h"

--- a/tools/mesh/remote.c
+++ b/tools/mesh/remote.c
@@ -12,6 +12,8 @@
 #include <config.h>
 #endif
 
+#include <time.h>
+
 #include <ell/ell.h>
 
 #include "src/shared/shell.h"

--- a/tools/mesh/util.c
+++ b/tools/mesh/util.c
@@ -13,6 +13,7 @@
 #endif
 
 #include <stdio.h>
+#include <time.h>
 
 #include <ell/ell.h>
 


### PR DESCRIPTION
Inclusion of <linux/errqueue.h> requires that 'struct timespec' has
already been defined:

| In file included from ../bluez-5.79/tools/iso-tester.c:21:
| /usr/include/linux/errqueue.h:57:25: error: array type has incomplete element type 'struct timespec'
|    57 |         struct timespec ts[3];
|       |                         ^~
---
 tools/iso-tester.c | 1 +
 1 file changed, 1 insertion(+)