### PR TITLE
[PW_SID:947070] [BlueZ] client/gatt: Fix pointer assigned with character literal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/client/gatt.c
+++ b/client/gatt.c
@@ -3207,7 +3207,7 @@ static void proxy_property_changed(GDBusProxy *proxy, const char *name,
 			chrc->path, bt_uuidstr_to_str(chrc->uuid), name);
 
 	if (!strcmp(name, "Value")) {
-		uint8_t *value = '\0';  /* don't pass NULL to write_value() */
+		uint8_t *value = NULL;
 		int len = 0;
 
 		if (iter && dbus_message_iter_get_arg_type(iter) ==


### PR DESCRIPTION
A character literl, '\0', is assigned to the pointer. The corresponding
comment doesn't make any sense, since '\0' represents zero and this
statement does the same thing as assigning value with NULL.

Initializing value with NULL (or zero) is safe and correct here: the
only case that the initial value of the pointer is passed to
write_value() is that the if branch isn't executed, where len keeps its
initial value, zero, as well. With src_len equal to zero, write_value()
will bail out and src_val won't be dereferenced.

Let's clean up the misleading comment and change right side of the
assignment to fix compiler warnings about the wrong type,

Fixes: ee750bbaf68c ("client/gatt: proxy_property_changed: check for NULL iterator")
Signed-off-by: Yao Zi <ziyao@disroot.org>
---
 client/gatt.c | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)