### PR TITLE
[PW_SID:947225] [BlueZ] profiles/avdtp: Fix reply for bad media transport format

### DIFF
--- a/profiles/audio/avdtp.c
+++ b/profiles/audio/avdtp.c
@@ -1328,6 +1328,17 @@ static GSList *caps_to_list(uint8_t *data, size_t size,
 
 		cap = (struct avdtp_service_capability *)data;
 
+		if (cap->category == AVDTP_MEDIA_TRANSPORT &&
+					cap->length != 0) {
+			error("Invalid media transport in getcap resp");
+			cpy = util_malloc(sizeof(*cpy) + 1);
+			memcpy(cpy, cap, sizeof(*cap));
+			cpy->length = 1;
+			cpy->data[0] = 0;
+			caps = g_slist_append(caps, cpy);
+			break;
+		}
+
 		if (sizeof(*cap) + cap->length > size) {
 			error("Invalid capability data in getcap resp");
 			break;


### PR DESCRIPTION
Currently the avdtp_setconf_cmd() fails to check the capability length
of the Media Transport Service Category, which should be 0, because
caps_to_list() doesn't add it to the list of services as it should
be bigger than packet boundary.

This commit add a fake Media Transport capability with invalid length
of 1, so avdtp_setconf_cmd() can check it and send reject error
AVDTP_BAD_MEDIA_TRANSPORT_FORMAT.

This is required for passing AVDTP/SNK/ACP/TRA/BTR/BI-01-C PTS test
case:
To verify that the IUT (ACP) is able to issue a set configuration
reject response to the INT if the format of the media transport is
incorrect.
---
 profiles/audio/avdtp.c | 11 +++++++++++
 1 file changed, 11 insertions(+)