### PR TITLE
[PW_SID:948097] [BlueZ,v1] a2dp: Fix removing local cache on restart

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/profiles/audio/a2dp.c
+++ b/profiles/audio/a2dp.c
@@ -880,44 +880,6 @@ static void store_remote_seps(struct a2dp_channel *chan)
 	g_key_file_free(key_file);
 }
 
-static void remove_endpoints_cache(struct btd_service *service)
-{
-	struct btd_device *device = btd_service_get_device(service);
-	char filename[PATH_MAX];
-	char dst_addr[18];
-	GKeyFile *key_file;
-	GError *gerr = NULL;
-	char *data;
-	gsize length = 0;
-
-	ba2str(device_get_address(device), dst_addr);
-
-	create_filename(filename, PATH_MAX, "/%s/cache/%s",
-		btd_adapter_get_storage_dir(device_get_adapter(device)),
-		dst_addr);
-
-	key_file = g_key_file_new();
-	if (!g_key_file_load_from_file(key_file, filename, 0, &gerr)) {
-		g_error_free(gerr);
-		g_key_file_free(key_file);
-		return;
-	}
-	g_key_file_remove_group(key_file, "Endpoints", NULL);
-
-	data = g_key_file_to_data(key_file, &length, NULL);
-	if (length > 0) {
-		create_file(filename, 0600);
-		if (!g_file_set_contents(filename, data, length, &gerr)) {
-			error("Unable set contents for %s: (%s)", filename,
-								gerr->message);
-			g_error_free(gerr);
-		}
-	}
-
-	g_free(data);
-	g_key_file_free(key_file);
-}
-
 static void invalidate_remote_cache(struct a2dp_setup *setup,
 						struct avdtp_error *err)
 {
@@ -3390,7 +3352,6 @@ static int a2dp_source_probe(struct btd_service *service)
 static void a2dp_source_remove(struct btd_service *service)
 {
 	source_unregister(service);
-	remove_endpoints_cache(service);
 }
 
 static int a2dp_sink_probe(struct btd_service *service)
@@ -3405,7 +3366,6 @@ static int a2dp_sink_probe(struct btd_service *service)
 static void a2dp_sink_remove(struct btd_service *service)
 {
 	sink_unregister(service);
-	remove_endpoints_cache(service);
 }
 
 static int a2dp_source_connect(struct btd_service *service)

--- a/src/device.c
+++ b/src/device.c
@@ -4984,6 +4984,7 @@ static void device_remove_stored(struct btd_device *device)
 	}
 	g_key_file_remove_group(key_file, "ServiceRecords", NULL);
 	g_key_file_remove_group(key_file, "Attributes", NULL);
+	g_key_file_remove_group(key_file, "Endpoints", NULL);
 
 	data = g_key_file_to_data(key_file, &length, NULL);
 	if (length > 0) {


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

Endpoint cache shall only be removed when the device is being removed
not when just because the service is being removed since that is also
done when bluetoothd is being restarted.

Fixes: https://github.com/bluez/bluez/issues/1146
---
 profiles/audio/a2dp.c | 40 ----------------------------------------
 src/device.c          |  1 +
 2 files changed, 1 insertion(+), 40 deletions(-)