### PR TITLE
[PW_SID:949647] [BlueZ,bluez,v2] bass: Set the service connection flag when BASS connected

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/profiles/audio/bass.c
+++ b/profiles/audio/bass.c
@@ -321,6 +321,8 @@ static void connect_cb(GIOChannel *io, GError *err, void *user_data)
 	if (bt_bap_stream_set_io(stream, fd)) {
 		g_io_channel_set_close_on_unref(io, FALSE);
 	}
+
+	btd_service_connecting_complete(setup->dg->service, 0);
 }
 
 static bool link_enabled(const void *data, const void *match_data)


### PR DESCRIPTION
From: Yang Li <yang.li@amlogic.com>

When BASS serice connected, set the service states to
BTD_SERVICE_STATE_CONNECTED. Otherwise, the device will
timeout and be removed, triggering the automatic termination
 of BIG.

issue: https://github.com/bluez/bluez/issues/1144

Signed-off-by: Yang Li <yang.li@amlogic.com>
---
Changes in v2:
- Set the BASS service connection success flag in the connect_cb function.
- Link to v1: https://patch.msgid.link/20250402-bass-v1-1-3e753841faa5@amlogic.com
---
 profiles/audio/bass.c | 2 ++
 1 file changed, 2 insertions(+)


---
base-commit: 0efa20cbf3fb5693c7c2f14ba8cf67053ca029e5
change-id: 20250402-bass-66200bb7eba1

Best regards,