### PR TITLE
[PW_SID:951032] doc: Fix various typos in D-Bus interface documentation

### DIFF
--- a/doc/org.bluez.AdvertisementMonitorManager.rst
+++ b/doc/org.bluez.AdvertisementMonitorManager.rst
@@ -14,9 +14,9 @@ BlueZ D-Bus AdvertisementMonitorManager API documentation
 Interface
 =========
 
-Service		org.bluez
-Interface	org.bluez.AdvertisementMonitorManager1 [experimental]
-Object path	/org/bluez/{hci0,hci1,...}
+:Service:	org.bluez
+:Interface:	org.bluez.AdvertisementMonitorManager1 [experimental]
+:Object path:	/org/bluez/{hci0,hci1,...}
 
 Methods
 -------

--- a/doc/org.bluez.Agent.rst
+++ b/doc/org.bluez.Agent.rst
@@ -9,7 +9,7 @@ BlueZ D-Bus Agent API documentation
 :Version: BlueZ
 :Date: October 2023
 :Manual section: 5
-:Manual group: Linux System Administration
+:Manual group: Linux System Administration
 
 Interface
 =========

--- a/doc/org.bluez.AgentManager.rst
+++ b/doc/org.bluez.AgentManager.rst
@@ -9,7 +9,7 @@ BlueZ D-Bus AgentManager API documentation
 :Version: BlueZ
 :Date: October 2023
 :Manual section: 5
-:Manual group: Linux System Administration
+:Manual group: Linux System Administration
 
 Interface
 =========
@@ -80,4 +80,3 @@ void RequestDefaultAgent(object agent)
 	Possible errors:
 
 	:org.bluez.Error.DoesNotExist:
-

--- a/doc/org.bluez.GattCharacteristic.rst
+++ b/doc/org.bluez.GattCharacteristic.rst
@@ -50,11 +50,11 @@ array{byte} ReadValue(dict options)
 
 	Possible options:
 
-	:uint16_t offset:
+	:uint16 offset:
 
 		Read start offset in bytes.
 
-	:uint16_t mtu (server only):
+	:uint16 mtu (server only):
 
 		Exchange MTU in bytes.
 

--- a/doc/org.bluez.GattDescriptor.rst
+++ b/doc/org.bluez.GattDescriptor.rst
@@ -50,7 +50,7 @@ array{byte} ReadValue(dict flags)
 
 	Possible options:
 
-	:uint16_t offset:
+	:uint16 offset:
 
 		Read start offset in bytes.
 

--- a/doc/org.bluez.LEAdvertisement.rst
+++ b/doc/org.bluez.LEAdvertisement.rst
@@ -177,13 +177,13 @@ uint16 Appearance [readonly, optional]
 
 	Possible values: as found on GAP Service.
 
-uint16_t Duration [readonly, optional]
+uint16 Duration [readonly, optional]
 ``````````````````````````````````````
 
 	Rotation duration of the advertisement in seconds. If there are other
 	applications advertising no duration is set the default is 2 seconds.
 
-uint16_t Timeout [readonly, optional]
+uint16 Timeout [readonly, optional]
 `````````````````````````````````````
 
 	Timeout of the advertisement in seconds. This defines the lifetime of

--- a/doc/org.bluez.LEAdvertisingManager.rst
+++ b/doc/org.bluez.LEAdvertisingManager.rst
@@ -117,7 +117,7 @@ dict SupportedCapabilities [readonly]
 
 		Max advertising scan response length
 
-	;int16 MinTxPower:
+	:int16 MinTxPower:
 
 		Min advertising tx power (dBm)
 

--- a/doc/org.bluez.Media.rst
+++ b/doc/org.bluez.Media.rst
@@ -14,9 +14,9 @@ BlueZ D-Bus Media API documentation
 Interface
 =========
 
-:Service: org.bluez
-:Interface: org.bluez.Media1
-:Object path: [variable prefix]/{hci0,hci1,...}
+:Service:	org.bluez
+:Interface:	org.bluez.Media1
+:Object path:	[variable prefix]/{hci0,hci1,...}
 
 Methods
 -------

--- a/doc/org.bluez.obex.Agent.rst
+++ b/doc/org.bluez.obex.Agent.rst
@@ -14,7 +14,7 @@ BlueZ D-Bus OBEX Agent API documentation
 Interface
 =========
 
-;Service:	unique name
+:Service:	unique name
 :Interface:	org.bluez.obex.Agent1
 :Object path:	freely definable
 

--- a/doc/org.bluez.obex.AgentManager.rst
+++ b/doc/org.bluez.obex.AgentManager.rst
@@ -19,7 +19,7 @@ Interface
 :Object path:	/org/bluez/obex
 
 Methods
-```````
+-------
 
 void RegisterAgent(object agent)
 ````````````````````````````````

--- a/doc/org.bluez.obex.FileTransfer.rst
+++ b/doc/org.bluez.obex.FileTransfer.rst
@@ -141,7 +141,7 @@ void MoveFile(string sourcefile, string targetfile)
 
 	Possible errors:
 
-	;org.bluez.obex.Error.InvalidArguments:
+	:org.bluez.obex.Error.InvalidArguments:
 	:org.bluez.obex.Error.Failed:
 
 void Delete(string file)


### PR DESCRIPTION
---
 doc/org.bluez.AdvertisementMonitorManager.rst | 6 +++---
 doc/org.bluez.Agent.rst                       | 2 +-
 doc/org.bluez.AgentManager.rst                | 3 +--
 doc/org.bluez.GattCharacteristic.rst          | 4 ++--
 doc/org.bluez.GattDescriptor.rst              | 2 +-
 doc/org.bluez.LEAdvertisement.rst             | 4 ++--
 doc/org.bluez.LEAdvertisingManager.rst        | 2 +-
 doc/org.bluez.Media.rst                       | 6 +++---
 doc/org.bluez.obex.Agent.rst                  | 2 +-
 doc/org.bluez.obex.AgentManager.rst           | 2 +-
 doc/org.bluez.obex.FileTransfer.rst           | 2 +-
 11 files changed, 17 insertions(+), 18 deletions(-)