### PR TITLE
[PW_SID:951544] [v1] obex: Send response to client for Abort request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/obexd/src/obex.c
+++ b/obexd/src/obex.c
@@ -389,6 +389,8 @@ static void transfer_complete(GObex *obex, GError *err, gpointer user_data)
 
 	if (err != NULL) {
 		error("transfer failed: %s\n", err->message);
+		if(strcmp(err->message,"Request was aborted")==0)
+			os_set_response(os, 0);
 		goto reset;
 	}
 


### PR DESCRIPTION
Incase of ongoing transfer, If the client sends Abort request, Server is not
sending any response back.

Ideally it should send OK or Success reponse code for the abort command.

This is required in PTS testing for passing below testcases -
1) OPP/SR/OPH/BV-27-I
To verify that a server can respond to an ABORT from the client during an OBEX operation.
2)FTP/SR/OTR/BV-02-C
To verify that the pushed file is aborted normally.
3)PBAP/PSE/PDF/BV-06-I
Verify that the PCE can abort a Phone Book object download from the PSE.
4)PBAP/PSE/PBF/BV-03-I
Verify that the PCE can abort a vCard-listing object download from the PSE.

---
 obexd/src/obex.c | 2 ++
 1 file changed, 2 insertions(+)