### PR TITLE
[PW_SID:953925] [BlueZ,bluez] bass: remove the device of BIS source when modify operation.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/profiles/audio/bass.c
+++ b/profiles/audio/bass.c
@@ -1427,6 +1427,9 @@ static int handle_mod_src_req(struct bt_bcast_src *bcast_src,
 
 			bt_bass_set_pa_sync(dg->src,
 				BT_BASS_NOT_SYNCHRONIZED_TO_PA);
+
+			/* Remove device of BIS source*/
+			btd_adapter_remove_device(device_get_adapter(dg->device), dg->device);
 		} else {
 			bass_update_bis_sync(dg, bcast_src);
 		}


### PR DESCRIPTION
From: Yang Li <yang.li@amlogic.com>

When the Client sends a modify operation and PA Sync is
"Do not synchronize to PA", the BIS source information
needs to be cleared.

Fixes: https://github.com/bluez/bluez/issues/1145
---
Signed-off-by: Yang Li <yang.li@amlogic.com>
---
 profiles/audio/bass.c | 3 +++
 1 file changed, 3 insertions(+)


---
base-commit: f8e7bcfdfb83a6a3becabdba1e4448bf04e32db5
change-id: 20250416-bass_modify-7accebe87323

Best regards,