### PR TITLE
[PW_SID:954078] [BlueZ,v3,1/7] bap: Fix not setting SID for broadcast receiver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v3
+      with:
+        path: src/src
+
+    - name: CI
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: ci
+        base_folder: src
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token : ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user : ${{ secrets.PATCHWORK_USER }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+  - cron: "*/15 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+
+    - name: Sync Repo
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: sync
+        upstream_repo: 'https://git.kernel.org/pub/scm/bluetooth/bluez.git'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Sync Patchwork
+      uses: tedd-an/bzcafe@dev
+      with:
+        task: patchwork
+        space: user
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+        patchwork_user: ${{ secrets.PATCHWORK_USER }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+

--- a/emulator/btdev.c
+++ b/emulator/btdev.c
@@ -5728,6 +5728,12 @@ static int cmd_pa_create_sync(struct btdev *dev, const void *data, uint8_t len)
 	uint8_t status = BT_HCI_ERR_SUCCESS;
 	struct le_per_adv *per_adv;
 
+	if (cmd->sid > 0x0f) {
+		cmd_status(dev, BT_HCI_ERR_INVALID_PARAMETERS,
+			   BT_HCI_CMD_LE_PA_CREATE_SYNC);
+		return 0;
+	}
+
 	/* Create new train */
 	per_adv = le_per_adv_new(dev, cmd->addr_type, cmd->addr);
 	if (!per_adv)

--- a/profiles/audio/bap.c
+++ b/profiles/audio/bap.c
@@ -2813,6 +2813,7 @@ static void bap_detached(struct bt_bap *bap, void *user_data)
 static int pa_sync(struct bap_data *data)
 {
 	GError *err = NULL;
+	uint8_t sid = 0xff;
 
 	if (data->listen_io) {
 		DBG("Already probed");
@@ -2833,6 +2834,7 @@ static int pa_sync(struct bap_data *data)
 		btd_device_get_bdaddr_type(data->device),
 		BT_IO_OPT_MODE, BT_IO_MODE_ISO,
 		BT_IO_OPT_QOS, &bap_sink_pa_qos,
+		BT_IO_OPT_ISO_BC_SID, sid,
 		BT_IO_OPT_INVALID);
 	if (!data->listen_io) {
 		error("%s", err->message);

--- a/profiles/audio/bass.c
+++ b/profiles/audio/bass.c
@@ -141,8 +141,9 @@ static struct bass_data *bass_data_new(struct btd_device *device);
 static void bass_data_add(struct bass_data *data);
 static void bass_data_remove(struct bass_data *data);
 
-static void bis_probe(uint8_t bis, uint8_t sgrp, struct iovec *caps,
-	struct iovec *meta, struct bt_bap_qos *qos, void *user_data);
+static void bis_probe(uint8_t sid, uint8_t bis, uint8_t sgrp,
+			struct iovec *caps, struct iovec *meta,
+			struct bt_bap_qos *qos, void *user_data);
 static void bis_remove(struct bt_bap *bap, void *user_data);
 
 
@@ -482,8 +483,9 @@ static void bass_add_bis(struct bass_setup *setup)
 	setup_configure_stream(setup);
 }
 
-static void bis_handler(uint8_t bis, uint8_t sgrp, struct iovec *caps,
-	struct iovec *meta, struct bt_bap_qos *qos, void *user_data)
+static void bis_handler(uint8_t sid, uint8_t bis, uint8_t sgrp,
+			struct iovec *caps, struct iovec *meta,
+			struct bt_bap_qos *qos, void *user_data)
 {
 	struct bass_delegator *dg = user_data;
 	struct bt_bap_pac *lpac;
@@ -526,12 +528,14 @@ static gboolean big_info_cb(GIOChannel *io, GIOCondition cond,
 	struct bt_iso_qos qos;
 	struct iovec iov;
 	struct bt_bap_qos bap_qos = {0};
+	uint8_t sid;
 
 	dg->io_id = 0;
 
 	bt_io_get(io, &err,
 			BT_IO_OPT_BASE, &base,
 			BT_IO_OPT_QOS, &qos,
+			BT_IO_OPT_ISO_BC_SID, &sid,
 			BT_IO_OPT_INVALID);
 	if (err) {
 		error("%s", err->message);
@@ -545,7 +549,7 @@ static gboolean big_info_cb(GIOChannel *io, GIOCondition cond,
 	/* Create BAP QoS structure */
 	bt_bap_iso_qos_to_bap_qos(&qos, &bap_qos);
 
-	bt_bap_parse_base(&iov, &bap_qos, bass_debug, bis_handler, dg);
+	bt_bap_parse_base(sid, &iov, &bap_qos, bass_debug, bis_handler, dg);
 
 	util_iov_free(bap_qos.bcast.bcode, 1);
 
@@ -1107,8 +1111,9 @@ static struct bass_assistant *assistant_new(struct btd_adapter *adapter,
 	return assistant;
 }
 
-static void bis_probe(uint8_t bis, uint8_t sgrp, struct iovec *caps,
-	struct iovec *meta, struct bt_bap_qos *qos, void *user_data)
+static void bis_probe(uint8_t sid, uint8_t bis, uint8_t sgrp,
+			struct iovec *caps, struct iovec *meta,
+			struct bt_bap_qos *qos, void *user_data)
 {
 	struct btd_device *device = user_data;
 	const struct queue_entry *entry;

--- a/src/shared/bap.c
+++ b/src/shared/bap.c
@@ -5721,8 +5721,9 @@ bool bt_bap_bis_cb_unregister(struct bt_bap *bap, unsigned int id)
 	return false;
 }
 
-void bt_bap_bis_probe(struct bt_bap *bap, uint8_t bis, uint8_t sgrp,
-	struct iovec *caps, struct iovec *meta, struct bt_bap_qos *qos)
+void bt_bap_bis_probe(struct bt_bap *bap, uint8_t sid, uint8_t bis,
+		      uint8_t sgrp, struct iovec *caps, struct iovec *meta,
+		      struct bt_bap_qos *qos)
 {
 	const struct queue_entry *entry;
 
@@ -5737,7 +5738,7 @@ void bt_bap_bis_probe(struct bt_bap *bap, uint8_t bis, uint8_t sgrp,
 		entry = entry->next;
 
 		if (cb->probe)
-			cb->probe(bis, sgrp, caps, meta, qos, cb->data);
+			cb->probe(sid, bis, sgrp, caps, meta, qos, cb->data);
 	}
 
 	bt_bap_unref(bap);
@@ -7341,7 +7342,7 @@ void bt_bap_verify_bis(struct bt_bap *bap, uint8_t bis_index,
 
 }
 
-bool bt_bap_parse_base(struct iovec *iov,
+bool bt_bap_parse_base(uint8_t sid, struct iovec *iov,
 			struct bt_bap_qos *qos,
 			util_debug_func_t func,
 			bt_bap_bis_func_t handler,
@@ -7452,7 +7453,7 @@ bool bt_bap_parse_base(struct iovec *iov,
 			if (!bis_cc)
 				continue;
 
-			handler(bis_index, idx, bis_cc, &meta,
+			handler(sid, bis_index, idx, bis_cc, &meta,
 				qos, user_data);
 
 			util_iov_free(bis_cc, 1);

--- a/src/shared/bap.h
+++ b/src/shared/bap.h
@@ -40,9 +40,9 @@ typedef void (*bt_bap_stream_func_t)(struct bt_bap_stream *stream,
 					void *user_data);
 typedef void (*bt_bap_func_t)(struct bt_bap *bap, void *user_data);
 
-typedef void (*bt_bap_bis_func_t)(uint8_t bis, uint8_t sgrp,
-		struct iovec *caps, struct iovec *meta,
-		struct bt_bap_qos *qos, void *user_data);
+typedef void (*bt_bap_bis_func_t)(uint8_t sid, uint8_t bis, uint8_t sgrp,
+				struct iovec *caps, struct iovec *meta,
+				struct bt_bap_qos *qos, void *user_data);
 
 typedef void (*bt_bap_bcode_reply_t)(void *user_data, int err);
 
@@ -271,7 +271,7 @@ void bt_bap_verify_bis(struct bt_bap *bap, uint8_t bis_index,
 		struct iovec *caps,
 		struct bt_bap_pac **lpac);
 
-bool bt_bap_parse_base(struct iovec *base,
+bool bt_bap_parse_base(uint8_t sid, struct iovec *base,
 			struct bt_bap_qos *qos,
 			util_debug_func_t func,
 			bt_bap_bis_func_t handler,
@@ -284,8 +284,9 @@ unsigned int bt_bap_bis_cb_register(struct bt_bap *bap,
 				bt_bap_destroy_func_t destroy);
 bool bt_bap_bis_cb_unregister(struct bt_bap *bap, unsigned int id);
 
-void bt_bap_bis_probe(struct bt_bap *bap, uint8_t bis, uint8_t sgrp,
-	struct iovec *caps, struct iovec *meta, struct bt_bap_qos *qos);
+void bt_bap_bis_probe(struct bt_bap *bap, uint8_t sid, uint8_t bis,
+			uint8_t sgrp, struct iovec *caps, struct iovec *meta,
+			struct bt_bap_qos *qos);
 void bt_bap_bis_remove(struct bt_bap *bap);
 
 void bt_bap_req_bcode(struct bt_bap_stream *stream,

--- a/tools/iso-tester.c
+++ b/tools/iso-tester.c
@@ -495,6 +495,7 @@ struct iso_client_data {
 	uint8_t pkt_status;
 	const uint8_t *base;
 	size_t base_len;
+	uint8_t sid;
 	bool listen_bind;
 	bool pa_bind;
 	bool big;
@@ -1417,6 +1418,16 @@ static const struct iso_client_data bcast_16_2_1_recv2 = {
 	.bcast = true,
 	.server = true,
 	.big = true,
+};
+
+static const struct iso_client_data bcast_16_2_1_recv_sid = {
+	.qos = QOS_IN_16_2_1,
+	.expect_err = 0,
+	.recv = &send_16_2_1,
+	.bcast = true,
+	.server = true,
+	.big = true,
+	.sid = 0xff,
 };
 
 static const struct iso_client_data bcast_enc_16_2_1_recv = {
@@ -2843,6 +2854,7 @@ static int listen_iso_sock(struct test_data *data, uint8_t num)
 
 		bacpy(&addr->iso_bc->bc_bdaddr, (void *) dst);
 		addr->iso_bc->bc_bdaddr_type = BDADDR_LE_PUBLIC;
+		addr->iso_bc->bc_sid = isodata->sid;
 
 		if (!isodata->defer || isodata->listen_bind) {
 			addr->iso_bc->bc_num_bis = 1;
@@ -3815,6 +3827,10 @@ int main(int argc, char *argv[])
 							test_bcast);
 
 	test_iso("ISO Broadcaster Receiver - Success", &bcast_16_2_1_recv,
+							setup_powered,
+							test_bcast_recv);
+	test_iso("ISO Broadcaster Receiver SID 0xff - Success",
+							&bcast_16_2_1_recv_sid,
 							setup_powered,
 							test_bcast_recv);
 	test_iso2("ISO Broadcaster Receiver2 - Success", &bcast_16_2_1_recv2,


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

SID most be set otherwise 0x00 is assume which may not be what the
broadcast source is using over the air. but since we don't have access
to the SID of the advertisement in userspace mark de SID as invalid
(0xff) so the kernel fill it up while scanning when creating the PA
sync.
---
 profiles/audio/bap.c | 2 ++
 1 file changed, 2 insertions(+)