### PR TITLE
[PW_SID:954640] [BlueZ,v1,1/2] shared/shell: Fix build errors in fc42

### DIFF
--- a/mesh/crypto.c
+++ b/mesh/crypto.c
@@ -371,7 +371,7 @@ bool mesh_crypto_session_key(const uint8_t secret[32],
 					const uint8_t salt[16],
 					uint8_t session_key[16])
 {
-	const uint8_t prsk[4] = "prsk";
+	const uint8_t prsk[4] = { 'p', 'r', 's', 'k' };
 
 	if (!aes_cmac_one(salt, secret, 32, session_key))
 		return false;
@@ -383,7 +383,7 @@ bool mesh_crypto_nonce(const uint8_t secret[32],
 					const uint8_t salt[16],
 					uint8_t nonce[13])
 {
-	const uint8_t prsn[4] = "prsn";
+	const uint8_t prsn[4] = { 'p', 'r', 's', 'n' };
 	uint8_t tmp[16];
 	bool result;
 
@@ -421,7 +421,7 @@ bool mesh_crypto_prov_conf_key(const uint8_t secret[32],
 					const uint8_t salt[16],
 					uint8_t conf_key[16])
 {
-	const uint8_t prck[4] = "prck";
+	const uint8_t prck[4] = { 'p', 'r', 'c', 'k' };
 
 	if (!aes_cmac_one(salt, secret, 32, conf_key))
 		return false;
@@ -433,7 +433,7 @@ bool mesh_crypto_device_key(const uint8_t secret[32],
 						const uint8_t salt[16],
 						uint8_t device_key[16])
 {
-	const uint8_t prdk[4] = "prdk";
+	const uint8_t prdk[4] = { 'p', 'r', 'd', 'k' };
 
 	if (!aes_cmac_one(salt, secret, 32, device_key))
 		return false;

--- a/src/shared/shell.c
+++ b/src/shared/shell.c
@@ -1426,7 +1426,7 @@ static void rl_cleanup(void)
 	if (data.history[0] != '\0')
 		write_history(data.history);
 
-	rl_message("");
+	rl_message("%s", "");
 	rl_callback_handler_remove();
 }
 

--- a/tools/mesh-gatt/crypto.c
+++ b/tools/mesh-gatt/crypto.c
@@ -902,7 +902,7 @@ bool mesh_crypto_session_key(const uint8_t secret[32],
 					const uint8_t salt[16],
 					uint8_t session_key[16])
 {
-	const uint8_t prsk[4] = "prsk";
+	const uint8_t prsk[4] = { 'p', 'r', 's', 'k' };
 
 	if (!aes_cmac_one(salt, secret, 32, session_key))
 		return false;
@@ -914,7 +914,7 @@ bool mesh_crypto_nonce(const uint8_t secret[32],
 					const uint8_t salt[16],
 					uint8_t nonce[13])
 {
-	const uint8_t prsn[4] = "prsn";
+	const uint8_t prsn[4] = { 'p', 'r', 's', 'n' };
 	uint8_t tmp[16];
 	bool result;
 
@@ -955,7 +955,7 @@ bool mesh_crypto_prov_conf_key(const uint8_t secret[32],
 					const uint8_t salt[16],
 					uint8_t conf_key[16])
 {
-	const uint8_t prck[4] = "prck";
+	const uint8_t prck[4] = { 'p', 'r', 'c', 'k' };
 
 	if (!aes_cmac_one(salt, secret, 32, conf_key))
 		return false;
@@ -967,7 +967,7 @@ bool mesh_crypto_device_key(const uint8_t secret[32],
 						const uint8_t salt[16],
 						uint8_t device_key[16])
 {
-	const uint8_t prdk[4] = "prdk";
+	const uint8_t prdk[4] = { 'p', 'r', 'd', 'k' };
 
 	if (!aes_cmac_one(salt, secret, 32, device_key))
 		return false;


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

This fixes the following errors:

src/shared/shell.c: In function 'rl_cleanup':
src/shared/shell.c:1429:20: error: zero-length gnu_printf format string [-Werror=format-zero-length]
 1429 |         rl_message("");
      |                    ^~
---
 src/shared/shell.c | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)